### PR TITLE
Add is_page_break_before() to ParagraphRef and is_underline() to RunRef

### DIFF
--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -415,6 +415,15 @@ impl<'a> ParagraphRef<'a> {
             .map(Alignment::from_st_jc)
     }
 
+    /// Check if this paragraph has a page break before it.
+    pub fn is_page_break_before(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .and_then(|ppr| ppr.page_break_before)
+            .unwrap_or(false)
+    }
+
     /// Get an iterator over immutable run references.
     pub fn runs(&self) -> impl Iterator<Item = RunRef<'_>> {
         self.inner.runs.iter().map(|r| RunRef { inner: r })

--- a/crates/rdocx/src/run.rs
+++ b/crates/rdocx/src/run.rs
@@ -236,6 +236,15 @@ impl<'a> RunRef<'a> {
             .unwrap_or(false)
     }
 
+    /// Check if underline.
+    pub fn is_underline(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .and_then(|rpr| rpr.underline.as_ref())
+            .is_some()
+    }
+
     /// Get font size in points, if set.
     pub fn size(&self) -> Option<f64> {
         self.inner


### PR DESCRIPTION
## Summary

Adds two missing read-side methods to rdocx 0.1.2:

- **ParagraphRef::is_page_break_before()** — reads CT_PPr.page_break_before
- **RunRef::is_underline()** — reads CT_RPr.underline (returns true if any underline value is present)

These are needed by [gtk-office-suite](https://github.com/tuna-os/gtk-office-suite) (a GTK4 word processor) to import DOCX files with preserved layout and formatting.

## Changes

- `crates/rdocx/src/paragraph.rs`: Added `is_page_break_before()` to ParagraphRef
- `crates/rdocx/src/run.rs`: Added `is_underline()` to RunRef

## Testing

- `cargo check -p rdocx` passes
- Downstream consumer (gtk-office-suite) compiles successfully with these methods