### PR TITLE
Render shapes held in mc:AlternateContent

### DIFF
--- a/crates/rdocx-layout/src/block.rs
+++ b/crates/rdocx-layout/src/block.rs
@@ -30,8 +30,50 @@ pub struct AnchoredDrawing {
     pub width: f64,
     /// Height in points.
     pub height: f64,
-    /// Relationship ID of the image part.
-    pub embed_id: String,
+    /// What the drawing actually holds.
+    pub content: AnchoredContent,
+}
+
+/// The drawable content of an anchored drawing.
+#[derive(Debug, Clone)]
+pub enum AnchoredContent {
+    /// A picture, identified by its relationship ID.
+    Image { embed_id: String },
+    /// A shape: preset geometry, an optional fill, and optional text.
+    ///
+    /// The text arrives already laid out, because breaking it into lines needs
+    /// a font manager and that only exists in the engine.
+    Shape {
+        /// Preset geometry we recognise.
+        preset: ShapePreset,
+        /// Fill colour, or `None` for `a:noFill` and for fills we cannot
+        /// resolve. An unfilled shape draws no body, only its text.
+        fill: Option<Color>,
+        /// Laid-out paragraphs of the shape's text box.
+        text: Vec<ParagraphBlock>,
+    },
+}
+
+/// The preset geometries we can draw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShapePreset {
+    /// A rectangle, drawn as a filled box.
+    Rect,
+    /// A straight line, drawn along the top edge of the extent.
+    Line,
+    /// Anything else. The body is not drawn, but text still is.
+    Unsupported,
+}
+
+impl ShapePreset {
+    /// Map an `a:prstGeom@prst` value onto what we can draw.
+    pub fn from_prst(prst: Option<&str>) -> Self {
+        match prst {
+            Some("rect") => ShapePreset::Rect,
+            Some("line") | Some("straightConnector1") => ShapePreset::Line,
+            _ => ShapePreset::Unsupported,
+        }
+    }
 }
 
 /// A laid-out block element (paragraph or table).
@@ -237,5 +279,23 @@ mod tests {
         };
         assert!((block.content_height() - 26.0).abs() < 0.01);
         assert!((block.total_height() - 40.0).abs() < 0.01);
+    }
+
+    /// Only the presets we can actually draw map to a drawable body. Anything
+    /// else still renders its text, so it must not be treated as a rectangle.
+    #[test]
+    fn shape_presets_map_to_what_we_can_draw() {
+        assert_eq!(ShapePreset::from_prst(Some("rect")), ShapePreset::Rect);
+        assert_eq!(ShapePreset::from_prst(Some("line")), ShapePreset::Line);
+        assert_eq!(
+            ShapePreset::from_prst(Some("straightConnector1")),
+            ShapePreset::Line
+        );
+        assert_eq!(
+            ShapePreset::from_prst(Some("roundRect")),
+            ShapePreset::Unsupported,
+            "an unhandled preset must not silently draw as a plain rectangle"
+        );
+        assert_eq!(ShapePreset::from_prst(None), ShapePreset::Unsupported);
     }
 }

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -838,7 +838,7 @@ pub fn layout_paragraph(
         page_break_before,
         widow_control,
     );
-    result.anchored = collect_anchored_drawings(para);
+    result.anchored = collect_anchored_drawings(para, styles, input, fm, num_state)?;
     Ok(result)
 }
 
@@ -847,27 +847,77 @@ pub fn layout_paragraph(
 /// The offsets stay paired with the frame they are measured from. Resolving
 /// them here is not possible: a paragraph-relative offset needs the laid-out
 /// position of the paragraph, which only the paginator knows.
-fn collect_anchored_drawings(para: &CT_P) -> Vec<block::AnchoredDrawing> {
+///
+/// A shape's text box is laid out here rather than later, because breaking it
+/// into lines needs the font manager.
+fn collect_anchored_drawings(
+    para: &CT_P,
+    styles: &CT_Styles,
+    input: &LayoutInput,
+    fm: &mut FontManager,
+    num_state: &mut NumberingState,
+) -> Result<Vec<block::AnchoredDrawing>> {
     let mut out = Vec::new();
+
+    // Drawings written plainly, and drawings recovered from an
+    // mc:AlternateContent block, are both anchored the same way.
     for run in &para.runs {
-        for rc in &run.content {
-            if let RunContent::Drawing(drawing) = rc
-                && let Some(ref anchor) = drawing.anchor
-            {
-                out.push(block::AnchoredDrawing {
-                    behind_doc: anchor.behind_doc,
-                    rel_h: anchor.pos_h_relative_from,
-                    off_h: anchor.pos_h_offset.to_pt(),
-                    rel_v: anchor.pos_v_relative_from,
-                    off_v: anchor.pos_v_offset.to_pt(),
-                    width: anchor.extent_cx.to_pt(),
-                    height: anchor.extent_cy.to_pt(),
+        let plain = run.content.iter().filter_map(|rc| match rc {
+            RunContent::Drawing(d) => Some(d),
+            _ => None,
+        });
+        for drawing in plain.chain(run.alt_drawings.iter()) {
+            let Some(anchor) = drawing.anchor.as_ref() else {
+                continue;
+            };
+
+            // A picture also carries a pic:spPr, so a parsed shape alone does
+            // not mean this is a shape. An embed id is what makes it a
+            // picture, and that takes precedence.
+            let shape = if anchor.embed_id.is_empty() {
+                anchor.shape.as_ref()
+            } else {
+                None
+            };
+
+            let content = match shape {
+                Some(shape) => {
+                    // A shape's text box wraps at the shape width.
+                    let mut text = Vec::new();
+                    for p in &shape.text {
+                        text.push(layout_paragraph(
+                            p,
+                            anchor.extent_cx.to_pt(),
+                            styles,
+                            input,
+                            fm,
+                            num_state,
+                        )?);
+                    }
+                    block::AnchoredContent::Shape {
+                        preset: block::ShapePreset::from_prst(shape.preset.as_deref()),
+                        fill: shape.solid_fill.as_deref().map(Color::from_hex),
+                        text,
+                    }
+                }
+                None => block::AnchoredContent::Image {
                     embed_id: anchor.embed_id.clone(),
-                });
-            }
+                },
+            };
+
+            out.push(block::AnchoredDrawing {
+                behind_doc: anchor.behind_doc,
+                rel_h: anchor.pos_h_relative_from,
+                off_h: anchor.pos_h_offset.to_pt(),
+                rel_v: anchor.pos_v_relative_from,
+                off_v: anchor.pos_v_offset.to_pt(),
+                width: anchor.extent_cx.to_pt(),
+                height: anchor.extent_cy.to_pt(),
+                content,
+            });
         }
     }
-    out
+    Ok(out)
 }
 
 /// Merge direct paragraph properties (only fields explicitly set in the XML).

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -3,7 +3,7 @@
 //! Handles page breaks, widow/orphan control, keep-with-next,
 //! keep-lines-together, and header/footer placement.
 
-use crate::block::{AnchoredDrawing, LayoutBlock, ParagraphBlock};
+use crate::block::{AnchoredContent, AnchoredDrawing, LayoutBlock, ParagraphBlock, ShapePreset};
 use crate::font::FontManager;
 use crate::line::{LayoutLine, LineItem};
 use crate::output::{Color, GlyphRun, OutlineEntry, PageFrame, Point, PositionedElement, Rect};
@@ -269,27 +269,64 @@ impl<'a> Pager<'a> {
     /// measured from the top of the content area.
     fn place_anchored(&mut self, anchored: &[AnchoredDrawing], para_top: f64, indent_left: f64) {
         for a in anchored {
-            if a.embed_id.is_empty() {
-                continue;
-            }
             let x = resolve_anchor_h(a.rel_h, a.off_h, &self.geometry, indent_left);
             let y = resolve_anchor_v(a.rel_v, a.off_v, &self.geometry, para_top);
-            let element = PositionedElement::Image {
-                rect: Rect {
-                    x,
-                    y,
-                    width: a.width,
-                    height: a.height,
-                },
-                // The inline image pass fills these in from the embed id.
-                data: Vec::new(),
-                content_type: String::new(),
-                embed_id: Some(a.embed_id.clone()),
+            let rect = Rect {
+                x,
+                y,
+                width: a.width,
+                height: a.height,
             };
+
+            let mut produced: Vec<PositionedElement> = Vec::new();
+
+            match &a.content {
+                AnchoredContent::Image { embed_id } => {
+                    if embed_id.is_empty() {
+                        continue;
+                    }
+                    produced.push(PositionedElement::Image {
+                        rect,
+                        // The inline image pass fills these in from the embed id.
+                        data: Vec::new(),
+                        content_type: String::new(),
+                        embed_id: Some(embed_id.clone()),
+                    });
+                }
+                AnchoredContent::Shape { preset, fill, text } => {
+                    // A shape with no fill draws no body. That is not a gap:
+                    // Word uses unfilled rectangles as plain text boxes.
+                    match (preset, fill) {
+                        (ShapePreset::Rect, Some(color)) => {
+                            produced.push(PositionedElement::FilledRect {
+                                rect,
+                                color: *color,
+                            });
+                        }
+                        (ShapePreset::Line, Some(color)) => {
+                            // A line shape's extent describes its bounding box,
+                            // so the stroke runs corner to corner.
+                            produced.push(PositionedElement::Line {
+                                start: Point { x, y },
+                                end: Point {
+                                    x: x + a.width,
+                                    y: y + a.height,
+                                },
+                                width: 1.0,
+                                color: *color,
+                                dash_pattern: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                    produced.extend(render_shape_text(text, &self.geometry, rect));
+                }
+            }
+
             if a.behind_doc {
-                self.behind_elements.push(element);
+                self.behind_elements.append(&mut produced);
             } else {
-                self.elements.push(element);
+                self.elements.append(&mut produced);
             }
         }
     }
@@ -352,6 +389,62 @@ impl<'a> Pager<'a> {
 }
 
 /// Paginate a single paragraph, handling splitting across pages.
+/// Shift a positioned element by a fixed offset.
+///
+/// Paragraph rendering always lays out against the page margins, so a text box
+/// is rendered at the margin first and then moved to where the shape sits.
+fn translate_element(element: &mut PositionedElement, dx: f64, dy: f64) {
+    match element {
+        PositionedElement::Text(run) => {
+            run.origin.x += dx;
+            run.origin.y += dy;
+        }
+        PositionedElement::Line { start, end, .. } => {
+            start.x += dx;
+            start.y += dy;
+            end.x += dx;
+            end.y += dy;
+        }
+        PositionedElement::FilledRect { rect, .. }
+        | PositionedElement::Image { rect, .. }
+        | PositionedElement::LinkAnnotation { rect, .. } => {
+            rect.x += dx;
+            rect.y += dy;
+        }
+    }
+}
+
+/// Render a shape's text box inside `rect`.
+///
+/// The paragraphs arrive already laid out at the shape's width. They are
+/// rendered as if they sat at the left margin and then translated onto the
+/// shape, which keeps all the justification and indent handling in one place.
+fn render_shape_text(
+    text: &[ParagraphBlock],
+    geometry: &PageGeometry,
+    rect: Rect,
+) -> Vec<PositionedElement> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let mut local = Vec::new();
+    let mut y = 0.0;
+    for para in text {
+        render_paragraph_lines(&para.lines, para, geometry, y, &mut local);
+        y += para.content_height();
+    }
+
+    // render_paragraph_lines works in content-area coordinates, so undo the
+    // margin it applied and then move onto the shape.
+    let dx = rect.x - geometry.margin_left;
+    let dy = rect.y - geometry.margin_top;
+    for element in &mut local {
+        translate_element(element, dx, dy);
+    }
+    local
+}
+
 /// Resolve a horizontal anchor offset against the frame it is measured from.
 ///
 /// An offset says nothing on its own. The same number lands somewhere

--- a/crates/rdocx-oxml/src/drawing.rs
+++ b/crates/rdocx-oxml/src/drawing.rs
@@ -136,6 +136,147 @@ pub struct CT_Anchor {
     /// Raw XML bytes for the entire wp:anchor element (used for round-trip preservation).
     /// When present, to_xml uses this instead of structured serialization.
     pub raw_xml: Option<Vec<u8>>,
+    /// Shape content, when the anchor holds a `wps:wsp` rather than a picture.
+    pub shape: Option<CT_Shape>,
+}
+
+/// A `wps:wsp` shape: preset geometry, an optional fill, and optional text.
+///
+/// Word writes these inside `mc:AlternateContent`, with a VML fallback beside
+/// them. Only what we can actually draw is modelled here.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CT_Shape {
+    /// Preset geometry name from `a:prstGeom@prst`, e.g. "rect" or "line".
+    pub preset: Option<String>,
+    /// Solid fill colour as RRGGBB, from the shape's own fill rather than its
+    /// outline. `None` covers both `a:noFill` and a fill we cannot resolve,
+    /// such as a theme colour.
+    pub solid_fill: Option<String>,
+    /// Paragraphs of the shape's text box, from `wps:txbx/w:txbxContent`.
+    pub text: Vec<crate::text::CT_P>,
+}
+
+/// Parse the DrawingML held inside a captured `mc:AlternateContent` block.
+///
+/// Word writes a shape as a compatibility block: the modern DrawingML sits in
+/// `mc:Choice` and a VML fallback in `mc:Fallback`. We read the Choice and
+/// ignore the Fallback.
+///
+/// The caller keeps the raw bytes for write back, so whatever comes out of
+/// here must not be serialised again or the element ends up duplicated.
+pub fn parse_alternate_content(raw: &[u8]) -> Option<CT_Drawing> {
+    let mut reader = Reader::from_reader(raw);
+    reader.config_mut().trim_text(true);
+    let mut buf = Vec::new();
+    let mut in_choice = false;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let name = e.name();
+                let local = name.as_ref();
+                if matches_local_name(local, b"Choice") {
+                    in_choice = true;
+                } else if in_choice && matches_local_name(local, b"drawing") {
+                    return CT_Drawing::from_xml(&mut reader).ok();
+                }
+            }
+            Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"Choice") => {
+                in_choice = false;
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    None
+}
+
+/// Pull the preset geometry and solid fill out of a captured `wps:spPr`.
+///
+/// The fill has to be told apart from the outline colour. Both are written as
+/// `a:srgbClr`, and the outline sits inside `a:ln`, so anything at or below an
+/// `a:ln` is skipped.
+fn parse_shape_props(raw: &[u8]) -> (Option<String>, Option<String>) {
+    let mut reader = Reader::from_reader(raw);
+    reader.config_mut().trim_text(true);
+    let mut buf = Vec::new();
+    let mut preset = None;
+    let mut fill = None;
+    let mut ln_depth = 0usize;
+    let mut in_solid_fill = false;
+
+    // Only a Start can open a scope. A self-closing a:ln or a:solidFill has no
+    // children, so it must not change the depth or the fill flag.
+    loop {
+        let event = reader.read_event_into(&mut buf);
+        match event {
+            Ok(Event::Start(ref e)) => {
+                let name = e.name();
+                let local = name.as_ref();
+                if matches_local_name(local, b"ln") {
+                    ln_depth += 1;
+                } else if matches_local_name(local, b"solidFill") {
+                    in_solid_fill = true;
+                } else if matches_local_name(local, b"prstGeom") {
+                    for attr in e.attributes().flatten() {
+                        if attr.key.as_ref() == b"prst" {
+                            preset = std::str::from_utf8(&attr.value).ok().map(str::to_string);
+                        }
+                    }
+                } else if matches_local_name(local, b"srgbClr")
+                    && in_solid_fill
+                    && ln_depth == 0
+                    && fill.is_none()
+                {
+                    // srgbClr can carry children such as a:alpha, so it turns
+                    // up as a Start as well as an Empty.
+                    for attr in e.attributes().flatten() {
+                        if attr.key.as_ref() == b"val" {
+                            fill = std::str::from_utf8(&attr.value).ok().map(str::to_string);
+                        }
+                    }
+                }
+            }
+            Ok(Event::Empty(ref e)) => {
+                let name = e.name();
+                let local = name.as_ref();
+                if matches_local_name(local, b"prstGeom") {
+                    for attr in e.attributes().flatten() {
+                        if attr.key.as_ref() == b"prst" {
+                            preset = std::str::from_utf8(&attr.value).ok().map(str::to_string);
+                        }
+                    }
+                } else if matches_local_name(local, b"srgbClr")
+                    && in_solid_fill
+                    && ln_depth == 0
+                    && fill.is_none()
+                {
+                    for attr in e.attributes().flatten() {
+                        if attr.key.as_ref() == b"val" {
+                            fill = std::str::from_utf8(&attr.value).ok().map(str::to_string);
+                        }
+                    }
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let name = e.name();
+                let local = name.as_ref();
+                if matches_local_name(local, b"ln") {
+                    ln_depth = ln_depth.saturating_sub(1);
+                } else if matches_local_name(local, b"solidFill") {
+                    in_solid_fill = false;
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    (preset, fill)
 }
 
 impl CT_Anchor {
@@ -155,6 +296,7 @@ impl CT_Anchor {
             description: Some("Background".to_string()),
             name: Some("Background".to_string()),
             raw_xml: None,
+            shape: None,
         }
     }
 
@@ -181,6 +323,7 @@ impl CT_Anchor {
         let mut extent_cx = Emu(0);
         let mut extent_cy = Emu(0);
         let mut embed_id = String::new();
+        let mut shape: Option<CT_Shape> = None;
         let mut description = None;
         let mut name = None;
         let mut buf = Vec::new();
@@ -291,6 +434,38 @@ impl CT_Anchor {
                             }
                             inner_buf.clear();
                         }
+                    } else if matches_local_name(ename.as_ref(), b"spPr") {
+                        // Capture the shape properties and read geometry and
+                        // fill out of them separately, so the fill colour is
+                        // not confused with the outline colour.
+                        let raw = capture_element(reader, e)?;
+                        let (preset, solid_fill) = parse_shape_props(&raw);
+                        let s = shape.get_or_insert_with(CT_Shape::default);
+                        s.preset = preset;
+                        s.solid_fill = solid_fill;
+                    } else if matches_local_name(ename.as_ref(), b"txbxContent") {
+                        // A shape's text box holds ordinary w:p paragraphs.
+                        let mut inner_buf = Vec::new();
+                        let mut paragraphs = Vec::new();
+                        loop {
+                            match reader.read_event_into(&mut inner_buf) {
+                                Ok(Event::Start(ref ie))
+                                    if matches_local_name(ie.name().as_ref(), b"p") =>
+                                {
+                                    paragraphs.push(crate::text::CT_P::from_xml(reader)?);
+                                }
+                                Ok(Event::End(ref ie))
+                                    if matches_local_name(ie.name().as_ref(), b"txbxContent") =>
+                                {
+                                    break;
+                                }
+                                Ok(Event::Eof) => break,
+                                Err(e) => return Err(e.into()),
+                                _ => {}
+                            }
+                            inner_buf.clear();
+                        }
+                        shape.get_or_insert_with(CT_Shape::default).text = paragraphs;
                     } else if matches_local_name(ename.as_ref(), b"blip") {
                         for attr in e.attributes() {
                             let attr = attr?;
@@ -341,6 +516,7 @@ impl CT_Anchor {
             description,
             name,
             raw_xml: None, // Will be set by CT_Drawing::from_xml
+            shape,
         })
     }
 

--- a/crates/rdocx-oxml/src/text.rs
+++ b/crates/rdocx-oxml/src/text.rs
@@ -73,6 +73,11 @@ pub struct CT_R {
     pub content: Vec<RunContent>,
     /// Unknown child elements captured as raw XML.
     pub extra_xml: Vec<Vec<u8>>,
+    /// Drawings read out of an `mc:AlternateContent` block, for layout only.
+    ///
+    /// Never serialised. The verbatim copy in `extra_xml` is what gets
+    /// written, so emitting these as well would duplicate the element.
+    pub alt_drawings: Vec<CT_Drawing>,
 }
 
 #[allow(non_snake_case)]
@@ -82,6 +87,7 @@ impl CT_R {
             properties: None,
             content: vec![RunContent::Text(CT_Text::new(text))],
             extra_xml: Vec::new(),
+            alt_drawings: Vec::new(),
         }
     }
 
@@ -105,6 +111,7 @@ impl CT_R {
         let mut properties = None;
         let mut content = Vec::new();
         let mut extra_xml = Vec::new();
+        let mut alt_drawings = Vec::new();
         let mut buf = Vec::new();
 
         loop {
@@ -134,6 +141,16 @@ impl CT_R {
                         }));
                     } else if matches_local_name(name.as_ref(), b"drawing") {
                         content.push(RunContent::Drawing(CT_Drawing::from_xml(reader)?));
+                    } else if matches_local_name(name.as_ref(), b"AlternateContent") {
+                        // Keep the block verbatim so the VML fallback survives
+                        // a write, and separately read the DrawingML out of it
+                        // so layout can see the shape. alt_drawings is never
+                        // serialised, the raw copy below is what gets written.
+                        let raw = capture_element(reader, e)?;
+                        if let Some(drawing) = crate::drawing::parse_alternate_content(&raw) {
+                            alt_drawings.push(drawing);
+                        }
+                        extra_xml.push(raw);
                     } else {
                         // Capture unknown child elements as raw XML
                         extra_xml.push(capture_element(reader, e)?);
@@ -199,6 +216,7 @@ impl CT_R {
             properties,
             content,
             extra_xml,
+            alt_drawings,
         })
     }
 
@@ -395,6 +413,7 @@ impl CT_P {
                             properties: None,
                             content: vec![RunContent::Field { field_type }],
                             extra_xml: Vec::new(),
+                            alt_drawings: Vec::new(),
                         });
                     } else {
                         // Capture unknown elements (bookmarks, comments, etc.) as raw XML
@@ -683,6 +702,69 @@ mod tests {
     }
 
     #[test]
+    fn alternate_content_is_preserved_once_and_parsed_for_layout() {
+        // A shape as Word writes it: DrawingML in mc:Choice, VML in the
+        // fallback. The block has to come back out verbatim, exactly once,
+        // while still being visible to layout.
+        let src = concat!(
+            r#"<w:r><mc:AlternateContent><mc:Choice Requires="wps">"#,
+            r#"<w:drawing><wp:anchor behindDoc="0">"#,
+            r#"<wp:positionH relativeFrom="column"><wp:posOffset>914400</wp:posOffset></wp:positionH>"#,
+            r#"<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>"#,
+            r#"<wp:extent cx="914400" cy="457200"/>"#,
+            r#"<a:graphic><a:graphicData><wps:wsp><wps:spPr>"#,
+            r#"<a:prstGeom prst="rect"/><a:solidFill><a:srgbClr val="729FCF"/></a:solidFill>"#,
+            r#"<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:ln>"#,
+            r#"</wps:spPr><wps:txbx><w:txbxContent>"#,
+            r#"<w:p><w:r><w:t>boxed</w:t></w:r></w:p>"#,
+            r#"</w:txbxContent></wps:txbx></wps:wsp></a:graphicData></a:graphic>"#,
+            r#"</wp:anchor></w:drawing></mc:Choice>"#,
+            r#"<mc:Fallback><w:pict><v:rect/></w:pict></mc:Fallback>"#,
+            r#"</mc:AlternateContent></w:r>"#,
+        );
+        let p = parse_paragraph(src);
+        assert_eq!(p.runs.len(), 1);
+        let run = &p.runs[0];
+
+        // Visible to layout.
+        assert_eq!(
+            run.alt_drawings.len(),
+            1,
+            "the drawing must reach the model"
+        );
+        let anchor = run.alt_drawings[0]
+            .anchor
+            .as_ref()
+            .expect("should be an anchored drawing");
+        let shape = anchor.shape.as_ref().expect("should carry shape content");
+        assert_eq!(shape.preset.as_deref(), Some("rect"));
+        assert_eq!(
+            shape.solid_fill.as_deref(),
+            Some("729FCF"),
+            "the fill colour must win over the outline colour"
+        );
+        assert_eq!(shape.text.len(), 1);
+        assert_eq!(shape.text[0].text(), "boxed");
+
+        // Preserved verbatim, exactly once.
+        let mut output = Vec::new();
+        let mut writer = Writer::new(&mut output);
+        p.to_xml(&mut writer).unwrap();
+        let xml = String::from_utf8(output).unwrap();
+        assert_eq!(
+            xml.matches("<mc:AlternateContent").count(),
+            1,
+            "the block must not be duplicated: {xml}"
+        );
+        assert_eq!(
+            xml.matches("<mc:Fallback").count(),
+            1,
+            "the VML fallback must survive"
+        );
+        assert!(xml.contains(r#"<a:prstGeom prst="rect"/>"#));
+    }
+
+    #[test]
     fn empty_run_properties_are_not_moved_after_content() {
         // extra_xml is written after the run content, and CT_R requires
         // w:rPr first, so a self-closing <w:rPr/> must not be captured.
@@ -764,6 +846,7 @@ mod tests {
                 field_type: FieldType::Page,
             }],
             extra_xml: Vec::new(),
+            alt_drawings: Vec::new(),
         });
 
         let mut output = Vec::new();
@@ -844,6 +927,7 @@ mod tests {
             properties: None,
             content: vec![RunContent::FootnoteRef { id: 2 }],
             extra_xml: Vec::new(),
+            alt_drawings: Vec::new(),
         });
         p.add_run(" text after");
 

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -492,6 +492,7 @@ impl Document {
 
         let drawing = CT_Drawing::inline(inline);
         let run = CT_R {
+            alt_drawings: Vec::new(),
             properties: None,
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
@@ -541,6 +542,7 @@ impl Document {
         let anchor = CT_Anchor::background(&rel_id, page_width_emu, page_height_emu);
         let drawing = CT_Drawing::anchor(anchor);
         let run = CT_R {
+            alt_drawings: Vec::new(),
             properties: None,
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
@@ -574,6 +576,7 @@ impl Document {
 
         let drawing = CT_Drawing::anchor(anchor);
         let run = CT_R {
+            alt_drawings: Vec::new(),
             properties: None,
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
@@ -1018,6 +1021,7 @@ impl Document {
 
         let inline = CT_Inline::new(&img_rel_id, width.to_emu(), height.to_emu());
         let run = CT_R {
+            alt_drawings: Vec::new(),
             properties: None,
             content: vec![RunContent::Drawing(CT_Drawing::inline(inline))],
             extra_xml: Vec::new(),
@@ -1612,6 +1616,7 @@ impl Document {
 
             // Tab run (separates text from page number)
             p.runs.push(CT_R {
+                alt_drawings: Vec::new(),
                 properties: None,
                 content: vec![rdocx_oxml::text::RunContent::Tab],
                 extra_xml: Vec::new(),

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -262,6 +262,7 @@ impl<'a> Cell<'a> {
         let inline = CT_Inline::new(rel_id, width.to_emu(), height.to_emu());
         let drawing = CT_Drawing::inline(inline);
         let run = CT_R {
+            alt_drawings: Vec::new(),
             properties: None,
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),


### PR DESCRIPTION
Closes #11. With this, every symptom reported in #3 is addressed.

## The bug

Word writes a shape as a compatibility block, the modern DrawingML in `mc:Choice` and a VML fallback beside it:

```xml
<mc:AlternateContent>
  <mc:Choice Requires="wps"><w:drawing><wp:anchor>...<wps:wsp>...</mc:Choice>
  <mc:Fallback><w:pict><v:shape .../></w:pict></mc:Fallback>
</mc:AlternateContent>
```

The run parser did not know `mc:AlternateContent`, so the block fell into the unknown-element branch and was kept as raw XML. It survived a write, but layout never saw it, so nothing was drawn and no space was reserved.

## Keeping fidelity while making it visible

The block is still captured verbatim. The DrawingML is read out of it separately into an `alt_drawings` field that is never serialised, so the raw copy remains the single source for output and the `mc:Fallback` is not lost.

That is the main risk in this change, so there is a test asserting the block comes back exactly once and the fallback survives. Checked against the real file from #3 as well: `mc:AlternateContent` 5 in and 5 out, `w:drawing` 6 and 6, `w:pict` 5 and 5, `wps:wsp` 5 and 5, `a:blip` 1 and 1.

## Two things that are easy to get wrong

**Fill against outline.** Both are written as `a:srgbClr`. The outline sits inside `a:ln`, so the fill is read from a captured `spPr` with anything at or below an `a:ln` skipped. Without that, a shape picks up its border colour as its fill.

**A picture also has an spPr.** `pic:pic` carries `pic:spPr`, so parsed shape properties do not make a drawing a shape. An embed id is what makes it a picture and that takes precedence. I caught this because the anchored image from #3 stopped rendering once shapes were wired up.

## What renders

Only what the layout output can already express, so no new primitives.

- `rect` with a fill becomes a `FilledRect`
- `line` and `straightConnector1` become a `Line`
- `a:noFill` draws no body. That is correct rather than a gap. Word uses unfilled rectangles as plain text boxes, and two of the five shapes in the #3 file are exactly that
- an unrecognised preset draws no body but still draws its text

Text boxes are laid out in the engine, because breaking them into lines needs the font manager. The paginator renders them at the left margin and translates them onto the shape, which keeps justification and indent handling in one place rather than duplicating it.

## Result on the file from #3

All five shapes now appear: the two blue boxes with their labels inside them, and the connector. The anchored image still renders in the right place alongside them, and the list fixes from #16 are unaffected.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` and the full suite all pass. 354 tests, up from 347.

`python3 scripts/hash_harness.py --check` passes with 28 entries matching. As with #19, worth being explicit about why: none of the harness fixtures contains a shape, so the baselines are genuinely untouched. This does change output for any document that has one.

## One thing to decide

This adds a public field to `CT_R`, a public field to `CT_Anchor`, and two new public types in `rdocx-layout`. `AnchoredDrawing::embed_id` also becomes `AnchoredDrawing::content`. So it is a breaking change and wants a 0.4.0 rather than a 0.3.x.
