### PR TITLE
Add custom list definitions with per-level formatting

### DIFF
--- a/crates/rdocx-oxml/src/numbering.rs
+++ b/crates/rdocx-oxml/src/numbering.rs
@@ -432,37 +432,44 @@ impl CT_Numbering {
 
     /// Create a bullet list definition and return its numId.
     pub fn add_bullet_list(&mut self) -> u32 {
+        self.add_list(&[(ST_NumberFormat::Bullet, Some(1))])
+    }
+
+    /// Create a numbered (decimal) list definition and return its numId.
+    pub fn add_numbered_list(&mut self) -> u32 {
+        self.add_list(&[(ST_NumberFormat::Decimal, Some(1))])
+    }
+
+    /// Create a list definition with explicit per-level formats and return
+    /// its numId.
+    ///
+    /// `levels[i]` specifies level `i` as `(format, start)`; a `start` of
+    /// `None` defaults to 1 (`start` has no meaning for bullet levels). All
+    /// nine levels are always defined so a paragraph referencing a deeper
+    /// level than was specified still renders: unspecified levels continue
+    /// from the last specified format's family — the bullet-glyph rotation
+    /// for bullets, the decimal/letter/roman rotation otherwise — matching
+    /// the [`Self::add_bullet_list`] / [`Self::add_numbered_list`] templates.
+    ///
+    /// An empty `levels` behaves like [`Self::add_numbered_list`].
+    pub fn add_list(&mut self, levels: &[(ST_NumberFormat, Option<u32>)]) -> u32 {
         let abs_id = self.next_abstract_num_id();
         let num_id = self.next_num_id();
-
-        let bullet_chars = [
-            "\u{2022}", // bullet •
-            "\u{25E6}", // white bullet ◦
-            "\u{25AA}", // black small square ▪
-            "\u{2022}", // repeat pattern
-            "\u{25E6}", "\u{25AA}", "\u{2022}", "\u{25E6}", "\u{25AA}",
-        ];
 
         let mut abs = CT_AbstractNum::new(abs_id);
         abs.multi_level_type = Some("hybridMultilevel".to_string());
 
+        let mut last_specified = ST_NumberFormat::Decimal;
         for i in 0..9u32 {
-            let mut lvl = CT_Lvl::new(i);
-            lvl.start = Some(1);
-            lvl.num_fmt = Some(ST_NumberFormat::Bullet);
-            lvl.lvl_text = Some(bullet_chars[i as usize].to_string());
-            lvl.lvl_jc = Some(ST_Jc::Left);
-
-            // Standard indentation: 720tw per level
-            let indent = (i + 1) as i32 * 720;
-            let ppr = CT_PPr {
-                ind_left: Some(crate::units::Twips(indent)),
-                ind_hanging: Some(crate::units::Twips(360)),
-                ..Default::default()
+            let (num_fmt, start) = match levels.get(i as usize) {
+                Some((fmt, start)) => {
+                    last_specified = *fmt;
+                    (*fmt, start.unwrap_or(1))
+                }
+                None => (level_fill_format(last_specified, i), 1),
             };
-            lvl.ppr = Some(ppr);
 
-            abs.levels.push(lvl);
+            abs.levels.push(build_level(i, num_fmt, start));
         }
 
         self.abstract_nums.push(abs);
@@ -474,51 +481,44 @@ impl CT_Numbering {
         num_id
     }
 
-    /// Create a numbered (decimal) list definition and return its numId.
-    pub fn add_numbered_list(&mut self) -> u32 {
-        let abs_id = self.next_abstract_num_id();
-        let num_id = self.next_num_id();
-
-        let formats = [
-            (ST_NumberFormat::Decimal, "%1."),
-            (ST_NumberFormat::LowerLetter, "%2."),
-            (ST_NumberFormat::LowerRoman, "%3."),
-            (ST_NumberFormat::Decimal, "%4."),
-            (ST_NumberFormat::LowerLetter, "%5."),
-            (ST_NumberFormat::LowerRoman, "%6."),
-            (ST_NumberFormat::Decimal, "%7."),
-            (ST_NumberFormat::LowerLetter, "%8."),
-            (ST_NumberFormat::LowerRoman, "%9."),
-        ];
-
-        let mut abs = CT_AbstractNum::new(abs_id);
-        abs.multi_level_type = Some("hybridMultilevel".to_string());
-
-        for (i, (fmt, text)) in formats.iter().enumerate() {
-            let mut lvl = CT_Lvl::new(i as u32);
-            lvl.start = Some(1);
-            lvl.num_fmt = Some(*fmt);
-            lvl.lvl_text = Some(text.to_string());
-            lvl.lvl_jc = Some(ST_Jc::Left);
-
-            let indent = (i as i32 + 1) * 720;
-            let ppr = CT_PPr {
-                ind_left: Some(crate::units::Twips(indent)),
-                ind_hanging: Some(crate::units::Twips(360)),
-                ..Default::default()
-            };
-            lvl.ppr = Some(ppr);
-
-            abs.levels.push(lvl);
+    /// Redefine one level of an existing list definition, for callers that
+    /// only learn a deeper level's format when content first reaches it.
+    ///
+    /// Returns `false` when `num_id` is unknown or `ilvl` is out of range
+    /// (levels are 0–8).
+    pub fn set_list_level(
+        &mut self,
+        num_id: u32,
+        ilvl: u32,
+        num_fmt: ST_NumberFormat,
+        start: Option<u32>,
+    ) -> bool {
+        if ilvl > 8 {
+            return false;
         }
 
-        self.abstract_nums.push(abs);
-        self.nums.push(CT_Num {
-            num_id,
-            abstract_num_id: abs_id,
-        });
+        let Some(num) = self.nums.iter().find(|n| n.num_id == num_id) else {
+            return false;
+        };
+        let abstract_num_id = num.abstract_num_id;
+        let Some(abs) = self
+            .abstract_nums
+            .iter_mut()
+            .find(|a| a.abstract_num_id == abstract_num_id)
+        else {
+            return false;
+        };
 
-        num_id
+        let level = build_level(ilvl, num_fmt, start.unwrap_or(1));
+        match abs.levels.iter_mut().find(|l| l.ilvl == ilvl) {
+            Some(existing) => *existing = level,
+            None => {
+                abs.levels.push(level);
+                abs.levels.sort_by_key(|l| l.ilvl);
+            }
+        }
+
+        true
     }
 
     /// Look up the abstract numbering definition for a given numId.
@@ -534,6 +534,62 @@ impl Default for CT_Numbering {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Bullet glyph rotation shared by the list templates: • ◦ ▪ repeating.
+const BULLET_CHARS: [&str; 9] = [
+    "\u{2022}", // bullet •
+    "\u{25E6}", // white bullet ◦
+    "\u{25AA}", // black small square ▪
+    "\u{2022}", // repeat pattern
+    "\u{25E6}", "\u{25AA}", "\u{2022}", "\u{25E6}", "\u{25AA}",
+];
+
+/// Numeric format rotation shared by the list templates:
+/// decimal, lowerLetter, lowerRoman repeating.
+const NUMBERED_FORMATS: [ST_NumberFormat; 9] = [
+    ST_NumberFormat::Decimal,
+    ST_NumberFormat::LowerLetter,
+    ST_NumberFormat::LowerRoman,
+    ST_NumberFormat::Decimal,
+    ST_NumberFormat::LowerLetter,
+    ST_NumberFormat::LowerRoman,
+    ST_NumberFormat::Decimal,
+    ST_NumberFormat::LowerLetter,
+    ST_NumberFormat::LowerRoman,
+];
+
+/// Template format for an unspecified level, keyed on the last format the
+/// caller did specify: bullets stay bullets; anything numeric continues the
+/// numbered rotation.
+fn level_fill_format(last_specified: ST_NumberFormat, ilvl: u32) -> ST_NumberFormat {
+    match last_specified {
+        ST_NumberFormat::Bullet => ST_NumberFormat::Bullet,
+        _ => NUMBERED_FORMATS[ilvl as usize % NUMBERED_FORMATS.len()],
+    }
+}
+
+/// One level in the shared template shape: bullet glyph or `%N.` text,
+/// left-justified, indented 720tw per depth with a 360tw hanging indent.
+fn build_level(ilvl: u32, num_fmt: ST_NumberFormat, start: u32) -> CT_Lvl {
+    let mut lvl = CT_Lvl::new(ilvl);
+    lvl.start = Some(start);
+    lvl.num_fmt = Some(num_fmt);
+    lvl.lvl_text = Some(match num_fmt {
+        ST_NumberFormat::Bullet => BULLET_CHARS[ilvl as usize % BULLET_CHARS.len()].to_string(),
+        _ => format!("%{}.", ilvl + 1),
+    });
+    lvl.lvl_jc = Some(ST_Jc::Left);
+
+    // Standard indentation: 720tw per level
+    let indent = (ilvl + 1) as i32 * 720;
+    lvl.ppr = Some(CT_PPr {
+        ind_left: Some(crate::units::Twips(indent)),
+        ind_hanging: Some(crate::units::Twips(360)),
+        ..Default::default()
+    });
+
+    lvl
 }
 
 #[cfg(test)]
@@ -673,5 +729,79 @@ mod tests {
         assert_eq!(abs.levels[0].num_fmt, Some(ST_NumberFormat::Decimal));
 
         assert!(numbering.get_abstract_num_for(99).is_none());
+    }
+
+    #[test]
+    fn add_list_mixed_levels_round_trip() {
+        let mut numbering = CT_Numbering::new();
+        let num_id = numbering.add_list(&[
+            (ST_NumberFormat::Bullet, None),
+            (ST_NumberFormat::Decimal, Some(3)),
+        ]);
+        assert_eq!(num_id, 1);
+
+        let xml = numbering.to_xml().unwrap();
+        let parsed = CT_Numbering::from_xml(&xml).unwrap();
+
+        let abs = parsed.get_abstract_num_for(num_id).unwrap();
+        assert_eq!(abs.levels.len(), 9);
+        assert_eq!(abs.levels[0].num_fmt, Some(ST_NumberFormat::Bullet));
+        assert_eq!(abs.levels[0].lvl_text, Some("\u{2022}".to_string()));
+        assert_eq!(abs.levels[1].num_fmt, Some(ST_NumberFormat::Decimal));
+        assert_eq!(abs.levels[1].lvl_text, Some("%2.".to_string()));
+        assert_eq!(abs.levels[1].start, Some(3));
+        // Unspecified levels continue the last specified family (numeric).
+        assert_eq!(abs.levels[2].num_fmt, Some(ST_NumberFormat::LowerRoman));
+        assert_eq!(abs.levels[2].start, Some(1));
+    }
+
+    #[test]
+    fn add_list_fill_keeps_bullets_for_bullet_lists() {
+        let mut numbering = CT_Numbering::new();
+        let num_id = numbering.add_list(&[(ST_NumberFormat::Bullet, None)]);
+
+        let abs = numbering.get_abstract_num_for(num_id).unwrap();
+        for level in &abs.levels {
+            assert_eq!(level.num_fmt, Some(ST_NumberFormat::Bullet));
+        }
+    }
+
+    #[test]
+    fn add_list_delegation_matches_legacy_templates() {
+        let mut via_helpers = CT_Numbering::new();
+        via_helpers.add_bullet_list();
+        via_helpers.add_numbered_list();
+
+        let mut via_add_list = CT_Numbering::new();
+        via_add_list.add_list(&[(ST_NumberFormat::Bullet, Some(1))]);
+        via_add_list.add_list(&[(ST_NumberFormat::Decimal, Some(1))]);
+
+        assert_eq!(via_helpers.abstract_nums, via_add_list.abstract_nums);
+        assert_eq!(via_helpers.nums, via_add_list.nums);
+    }
+
+    #[test]
+    fn set_list_level_redefines_one_level() {
+        let mut numbering = CT_Numbering::new();
+        let num_id = numbering.add_list(&[(ST_NumberFormat::Bullet, None)]);
+
+        assert!(numbering.set_list_level(num_id, 1, ST_NumberFormat::Decimal, Some(3)));
+
+        let abs = numbering.get_abstract_num_for(num_id).unwrap();
+        assert_eq!(abs.levels[1].num_fmt, Some(ST_NumberFormat::Decimal));
+        assert_eq!(abs.levels[1].lvl_text, Some("%2.".to_string()));
+        assert_eq!(abs.levels[1].start, Some(3));
+        // Neighbors untouched.
+        assert_eq!(abs.levels[0].num_fmt, Some(ST_NumberFormat::Bullet));
+        assert_eq!(abs.levels[2].num_fmt, Some(ST_NumberFormat::Bullet));
+    }
+
+    #[test]
+    fn set_list_level_rejects_unknown_targets() {
+        let mut numbering = CT_Numbering::new();
+        let num_id = numbering.add_list(&[(ST_NumberFormat::Bullet, None)]);
+
+        assert!(!numbering.set_list_level(99, 0, ST_NumberFormat::Decimal, None));
+        assert!(!numbering.set_list_level(num_id, 9, ST_NumberFormat::Decimal, None));
     }
 }

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -12,7 +12,7 @@ use oxml_opc::relationship::rel_types;
 use rdocx_oxml::document::{BodyContent, CT_Columns, CT_Document, CT_SectPr};
 use rdocx_oxml::drawing::{CT_Anchor, CT_Drawing, CT_Inline};
 use rdocx_oxml::header_footer::{CT_HdrFtr, HdrFtrRef, HdrFtrType};
-use rdocx_oxml::numbering::CT_Numbering;
+use rdocx_oxml::numbering::{CT_Numbering, ST_NumberFormat};
 use rdocx_oxml::properties::{CT_PPr, CT_RPr};
 use rdocx_oxml::shared::{ST_PageOrientation, ST_SectionType};
 use rdocx_oxml::styles::CT_Styles;
@@ -1342,6 +1342,50 @@ impl Document {
             BodyContent::Paragraph(p) => Paragraph { inner: p },
             _ => unreachable!(),
         }
+    }
+
+    /// Create a list definition with explicit per-level formats and return
+    /// its numId.
+    ///
+    /// Unlike [`Self::add_bullet_list_item`] / [`Self::add_numbered_list_item`],
+    /// which share one bullet and one numbered definition per document, every
+    /// call creates a fresh definition — so separate lists restart their
+    /// numbering, and one definition can mix formats across levels (e.g. a
+    /// bullet list whose nested level is decimal). Attach paragraphs with
+    /// [`crate::Paragraph::set_numbering`].
+    ///
+    /// `levels[i]` configures level `i`; deeper unspecified levels fall back
+    /// to the standard template rotation for the last specified format's
+    /// family. An empty slice produces the standard numbered template.
+    ///
+    /// ```no_run
+    /// use rdocx::{Document, ListLevel};
+    ///
+    /// let mut doc = Document::new();
+    /// let num_id = doc.add_list_definition(&[
+    ///     ListLevel::bullet(),
+    ///     ListLevel::decimal().start(3),
+    /// ]);
+    /// doc.add_paragraph("first bullet").set_numbering(num_id, 0);
+    /// doc.add_paragraph("third decimal").set_numbering(num_id, 1);
+    /// ```
+    pub fn add_list_definition(&mut self, levels: &[ListLevel]) -> u32 {
+        self.invalidate_layout();
+        let levels: Vec<(ST_NumberFormat, Option<u32>)> = levels
+            .iter()
+            .map(|level| (level.format.to_st(), level.start))
+            .collect();
+        self.ensure_numbering().add_list(&levels)
+    }
+
+    /// Redefine one level (0–8) of an existing list definition, for callers
+    /// that only learn a deeper level's format when content first reaches it.
+    ///
+    /// Returns `false` when `num_id` is unknown or `level` is out of range.
+    pub fn set_list_level(&mut self, num_id: u32, level: u32, spec: ListLevel) -> bool {
+        self.invalidate_layout();
+        self.ensure_numbering()
+            .set_list_level(num_id, level, spec.format.to_st(), spec.start)
     }
 
     // ---- Style access ----
@@ -2824,6 +2868,67 @@ fn relative_target(source_part: &str, target_part: &str) -> String {
     match target_part.strip_prefix(dir) {
         Some(rest) if !rest.contains('/') => rest.to_string(),
         _ => target_part.to_string(),
+    }
+}
+
+/// Numbering format for one level of a custom list definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListNumberFormat {
+    Bullet,
+    Decimal,
+    LowerLetter,
+    UpperLetter,
+    LowerRoman,
+    UpperRoman,
+    Ordinal,
+}
+
+impl ListNumberFormat {
+    fn to_st(self) -> ST_NumberFormat {
+        match self {
+            Self::Bullet => ST_NumberFormat::Bullet,
+            Self::Decimal => ST_NumberFormat::Decimal,
+            Self::LowerLetter => ST_NumberFormat::LowerLetter,
+            Self::UpperLetter => ST_NumberFormat::UpperLetter,
+            Self::LowerRoman => ST_NumberFormat::LowerRoman,
+            Self::UpperRoman => ST_NumberFormat::UpperRoman,
+            Self::Ordinal => ST_NumberFormat::Ordinal,
+        }
+    }
+}
+
+/// One level of a custom list definition for [`Document::add_list_definition`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListLevel {
+    /// Numbering format for this level.
+    pub format: ListNumberFormat,
+    /// Starting number (defaults to 1; ignored for bullet levels).
+    pub start: Option<u32>,
+}
+
+impl ListLevel {
+    /// A level with the given format, starting at 1.
+    pub fn new(format: ListNumberFormat) -> Self {
+        ListLevel {
+            format,
+            start: None,
+        }
+    }
+
+    /// A bullet level.
+    pub fn bullet() -> Self {
+        Self::new(ListNumberFormat::Bullet)
+    }
+
+    /// A decimal-numbered level.
+    pub fn decimal() -> Self {
+        Self::new(ListNumberFormat::Decimal)
+    }
+
+    /// Override the starting number for this level.
+    pub fn start(mut self, start: u32) -> Self {
+        self.start = Some(start);
+        self
     }
 }
 

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -818,13 +818,7 @@ impl Document {
     /// the document is empty): adds the External relationship and wraps the
     /// new run in a hyperlink span.
     pub fn append_hyperlink(&mut self, text: &str, url: &str) {
-        self.invalidate_layout();
-        use oxml_opc::relationship::rel_types;
-
-        let rel_id = {
-            let rels = self.package.get_or_create_part_rels(&self.doc_part_name);
-            rels.add_external(rel_types::HYPERLINK, url)
-        };
+        let rel_id = self.add_hyperlink_relationship(url);
 
         if !matches!(
             self.document.body.content.last(),
@@ -838,14 +832,19 @@ impl Document {
         let Some(BodyContent::Paragraph(p)) = self.document.body.content.last_mut() else {
             unreachable!();
         };
-        let run_start = p.runs.len();
-        p.add_run(text);
-        p.hyperlinks.push(rdocx_oxml::text::HyperlinkSpan {
-            rel_id: Some(rel_id),
-            anchor: None,
-            run_start,
-            run_end: run_start + 1,
-        });
+        crate::Paragraph { inner: p }.add_hyperlink(text, &rel_id);
+    }
+
+    /// Add an external hyperlink relationship and return its relationship ID.
+    ///
+    /// Use this with [`crate::Paragraph::add_hyperlink`] when the target
+    /// paragraph is not the last body paragraph, such as a paragraph inside a
+    /// table cell.
+    pub fn add_hyperlink_relationship(&mut self, url: &str) -> String {
+        self.invalidate_layout();
+        self.package
+            .get_or_create_part_rels(&self.doc_part_name)
+            .add_external(rel_types::HYPERLINK, url)
     }
 
     /// Get a builder for the last paragraph in the body, if any. Lets
@@ -4018,6 +4017,40 @@ mod tests {
         assert_eq!(end - start, 1);
         let url = doc2.hyperlink_url(rel_id.expect("rel id"));
         assert_eq!(url.as_deref(), Some("https://gnome.org"));
+    }
+
+    #[test]
+    fn paragraph_hard_break_and_table_cell_hyperlink_round_trip() {
+        let mut doc = Document::new();
+        let relationship_id = doc.add_hyperlink_relationship("https://example.com/table");
+
+        let mut paragraph = doc.add_paragraph("");
+        paragraph.add_run("before");
+        paragraph.add_line_break();
+        paragraph.add_run("after");
+
+        let mut table = doc.add_table(1, 1);
+        let mut cell = table.cell(0, 0).expect("cell");
+        cell.remove_first_empty_paragraph();
+        cell.add_paragraph("")
+            .add_hyperlink("table link", &relationship_id)
+            .bold(true);
+
+        let bytes = doc.to_bytes().unwrap();
+        let reopened = Document::from_bytes(&bytes).unwrap();
+
+        assert_eq!(reopened.paragraphs()[0].text(), "before\nafter");
+        let tables = reopened.tables();
+        let cell = tables[0].cell(0, 0).expect("cell");
+        let paragraph = cell.paragraphs().next().expect("paragraph");
+        assert_eq!(paragraph.text(), "table link");
+        assert!(paragraph.runs().next().expect("run").is_bold());
+        let spans = paragraph.hyperlink_spans();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(
+            reopened.hyperlink_url(spans[0].2.expect("relationship id")),
+            Some("https://example.com/table".to_string())
+        );
     }
 
     #[test]

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -28,7 +28,10 @@ pub mod run;
 pub mod style;
 pub mod table;
 
-pub use document::{AccessibilityIssue, Document, ImageInfo, IssueSeverity, LinkInfo, OutlineNode};
+pub use document::{
+    AccessibilityIssue, Document, ImageInfo, IssueSeverity, LinkInfo, ListLevel, ListNumberFormat,
+    OutlineNode,
+};
 pub use error::{Error, Result};
 pub use oxml_core::Length;
 pub use paragraph::{

--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -189,6 +189,31 @@ impl<'a> Paragraph<'a> {
         self.ensure_ppr().style_id = Some(style_id.to_string());
     }
 
+    /// Attach this paragraph to a list definition as a list item.
+    ///
+    /// `num_id` comes from [`crate::Document::add_list_definition`] (or the
+    /// shared definitions behind `add_bullet_list_item` /
+    /// `add_numbered_list_item`); `level` is the 0-based indentation level.
+    pub fn numbering(mut self, num_id: u32, level: u32) -> Self {
+        self.set_numbering(num_id, level);
+        self
+    }
+
+    /// Attach this paragraph to a list definition in place.
+    pub fn set_numbering(&mut self, num_id: u32, level: u32) {
+        self.set_numbering_value(Some((num_id, level)));
+    }
+
+    /// Set or clear this paragraph's list numbering.
+    pub fn set_numbering_value(&mut self, numbering: Option<(u32, u32)>) {
+        if numbering.is_none() && self.inner.properties.is_none() {
+            return;
+        }
+        let ppr = self.ensure_ppr();
+        ppr.num_id = numbering.map(|(num_id, _)| num_id);
+        ppr.num_ilvl = numbering.map(|(_, level)| level);
+    }
+
     /// Set space before the paragraph.
     pub fn space_before(mut self, length: Length) -> Self {
         self.set_space_before(length);

--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -6,7 +6,7 @@ use rdocx_oxml::properties::{CT_PPr, CT_Shd};
 use rdocx_oxml::shared::{
     ST_Border, ST_Jc, ST_PageOrientation, ST_SectionType, ST_TabJc, ST_TabLeader,
 };
-use rdocx_oxml::text::{CT_P, CT_R};
+use rdocx_oxml::text::{BreakType, CT_P, CT_R, HyperlinkSpan, RunContent};
 use rdocx_oxml::units::Twips;
 
 use crate::Length;
@@ -134,6 +134,33 @@ impl<'a> Paragraph<'a> {
     /// Add a run with the given text and return a mutable reference for chaining.
     pub fn add_run(&mut self, text: &str) -> Run<'_> {
         self.inner.runs.push(CT_R::new(text));
+        Run {
+            inner: self.inner.runs.last_mut().unwrap(),
+        }
+    }
+
+    /// Add a line break in its own run.
+    pub fn add_line_break(&mut self) {
+        let mut run = CT_R::new("");
+        run.content = vec![RunContent::Break(BreakType::Line)];
+        self.inner.runs.push(run);
+    }
+
+    /// Add a run wrapped in an external hyperlink relationship.
+    ///
+    /// Obtain `relationship_id` from
+    /// [`crate::Document::add_hyperlink_relationship`]. Returning the run
+    /// allows the hyperlink text to receive the same direct formatting as any
+    /// other run.
+    pub fn add_hyperlink(&mut self, text: &str, relationship_id: &str) -> Run<'_> {
+        let run_start = self.inner.runs.len();
+        self.inner.runs.push(CT_R::new(text));
+        self.inner.hyperlinks.push(HyperlinkSpan {
+            rel_id: Some(relationship_id.to_string()),
+            anchor: None,
+            run_start,
+            run_end: run_start + 1,
+        });
         Run {
             inner: self.inner.runs.last_mut().unwrap(),
         }

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -155,6 +155,30 @@ impl<'a> Table<'a> {
         self.ensure_tbl_pr().layout = Some("fixed".to_string());
     }
 
+    /// Set one grid column's width and apply the same width to that cell in
+    /// every row.
+    ///
+    /// Returns `false` when `column` is outside the table grid. Keeping the
+    /// grid and cell widths in sync avoids contradictory fixed-layout table
+    /// geometry.
+    pub fn set_column_width(&mut self, column: usize, width: Length) -> bool {
+        let Some(grid_column) = self
+            .inner
+            .grid
+            .as_mut()
+            .and_then(|grid| grid.columns.get_mut(column))
+        else {
+            return false;
+        };
+        grid_column.width = width.as_twips();
+        for row in &mut self.inner.rows {
+            if let Some(cell) = row.cells.get_mut(column) {
+                Cell { inner: cell }.set_width(width);
+            }
+        }
+        true
+    }
+
     /// Get the number of rows.
     pub fn row_count(&self) -> usize {
         self.inner.rows.len()

--- a/crates/rdocx/tests/integration_test.rs
+++ b/crates/rdocx/tests/integration_test.rs
@@ -636,6 +636,22 @@ fn table_basic_creation_round_trip() {
 }
 
 #[test]
+fn table_column_width_updates_grid_and_cells() {
+    let mut doc = Document::new();
+    let mut table = doc.add_table(2, 2);
+
+    assert!(table.set_column_width(0, Length::twips(2_000)));
+    assert!(table.set_column_width(1, Length::twips(3_000)));
+    assert!(!table.set_column_width(2, Length::twips(1_000)));
+
+    let xml = String::from_utf8(document_xml(&mut doc)).unwrap();
+    assert_eq!(xml.matches("<w:gridCol w:w=\"2000\"").count(), 1);
+    assert_eq!(xml.matches("<w:gridCol w:w=\"3000\"").count(), 1);
+    assert_eq!(xml.matches("<w:tcW w:w=\"2000\" w:type=\"dxa\"").count(), 2);
+    assert_eq!(xml.matches("<w:tcW w:w=\"3000\" w:type=\"dxa\"").count(), 2);
+}
+
+#[test]
 fn table_with_formatting_round_trip() {
     let mut doc = Document::new();
     doc.add_table(2, 2)

--- a/crates/rdocx/tests/integration_test.rs
+++ b/crates/rdocx/tests/integration_test.rs
@@ -6,7 +6,8 @@ use rdocx::Document;
 use rdocx::paragraph::Alignment;
 use rdocx::table::VerticalAlignment;
 use rdocx::{
-    BorderStyle, Length, SectionBreak, StyleBuilder, TabAlignment, TabLeader, UnderlineStyle,
+    BorderStyle, Length, ListLevel, SectionBreak, StyleBuilder, TabAlignment, TabLeader,
+    UnderlineStyle,
 };
 
 fn document_xml(document: &mut Document) -> Vec<u8> {
@@ -944,6 +945,85 @@ fn mixed_lists_round_trip() {
     assert_eq!(paras[1].text(), "Bullet 1");
     assert_eq!(paras[3].text(), "Transition");
     assert_eq!(paras[4].text(), "Step 1");
+}
+
+#[test]
+fn custom_list_definitions_restart_numbering_per_list() {
+    let mut doc = Document::new();
+    let first = doc.add_list_definition(&[ListLevel::decimal()]);
+    let second = doc.add_list_definition(&[ListLevel::decimal()]);
+    assert_ne!(first, second);
+
+    doc.add_paragraph("List one, item one")
+        .set_numbering(first, 0);
+    doc.add_paragraph("List two, item one")
+        .set_numbering(second, 0);
+
+    let bytes = doc.to_bytes().unwrap();
+    let doc2 = Document::from_bytes(&bytes).unwrap();
+
+    let paras = doc2.paragraphs();
+    // Distinct numId means each list numbers independently from its start.
+    assert_eq!(paras[0].numbering(), Some((first, 0)));
+    assert_eq!(paras[1].numbering(), Some((second, 0)));
+    assert_eq!(doc2.numbering_is_bullet(first), Some(false));
+    assert_eq!(doc2.numbering_is_bullet(second), Some(false));
+}
+
+#[test]
+fn custom_list_definition_mixes_formats_across_levels() {
+    let mut doc = Document::new();
+    let num_id = doc.add_list_definition(&[ListLevel::bullet(), ListLevel::decimal().start(3)]);
+
+    doc.add_paragraph("bullet item").set_numbering(num_id, 0);
+    doc.add_paragraph("third decimal item")
+        .set_numbering(num_id, 1);
+
+    let bytes = doc.to_bytes().unwrap();
+    let doc2 = Document::from_bytes(&bytes).unwrap();
+
+    let paras = doc2.paragraphs();
+    assert_eq!(paras[0].numbering(), Some((num_id, 0)));
+    assert_eq!(paras[1].numbering(), Some((num_id, 1)));
+    // Level 0 is a bullet; the definition still resolves as a bullet list.
+    assert_eq!(doc2.numbering_is_bullet(num_id), Some(true));
+
+    // The persisted numbering part survives the round trip: the reopened
+    // document still knows the definition, so a level can be redefined.
+    let mut doc3 = Document::from_bytes(&bytes).unwrap();
+    assert!(doc3.set_list_level(num_id, 2, ListLevel::decimal().start(7)));
+}
+
+#[test]
+fn set_list_level_upgrades_a_deeper_level_after_the_fact() {
+    let mut doc = Document::new();
+    let num_id = doc.add_list_definition(&[ListLevel::bullet()]);
+
+    // Level 1 starts as the bullet fill; content later needs it decimal.
+    assert!(doc.set_list_level(num_id, 1, ListLevel::decimal().start(3)));
+    assert!(!doc.set_list_level(999, 1, ListLevel::decimal()));
+
+    doc.add_paragraph("bullet").set_numbering(num_id, 0);
+    doc.add_paragraph("decimal from three")
+        .set_numbering(num_id, 1);
+
+    let bytes = doc.to_bytes().unwrap();
+    let doc2 = Document::from_bytes(&bytes).unwrap();
+    assert_eq!(doc2.paragraphs()[1].numbering(), Some((num_id, 1)));
+}
+
+#[test]
+fn paragraph_numbering_value_can_be_cleared() {
+    let mut doc = Document::new();
+    let num_id = doc.add_list_definition(&[ListLevel::bullet()]);
+
+    let mut para = doc.add_paragraph("was a list item");
+    para.set_numbering(num_id, 0);
+    para.set_numbering_value(None);
+
+    let bytes = doc.to_bytes().unwrap();
+    let doc2 = Document::from_bytes(&bytes).unwrap();
+    assert_eq!(doc2.paragraphs()[0].numbering(), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a fresh custom numbering definition API with explicit per-level formats and start values.
- Add paragraph numbering setters so callers can attach any paragraph to any definition and level.
- Add late level reconfiguration for streaming builders that discover nested list kinds incrementally.
- Add composable hard breaks, paragraph-scoped hyperlinks, and synchronized fixed-table column widths surfaced by a real DOCX emitter integration.

## Why

The existing shared bullet and numbered helpers cannot express three common document shapes:

1. Separate ordered lists that each restart at 1, because one shared numId continues numbering.
2. Mixed-format levels in one hierarchy, such as a bullet at level 0 and decimal numbering at level 1.
3. Ordered lists with a start offset, such as a nested decimal level beginning at 3.

The underlying OOXML model already supports these forms. This PR exposes that capability through the high-level writer API without requiring callers to mutate OOXML internals.

## Compatibility

The existing add_bullet_list_item and add_numbered_list_item paths delegate to the generalized definition builder. The add_list_delegation_matches_legacy_templates test pins byte-equivalent definitions for those helpers.

## Validation

- cargo test -p rdocx -p rdocx-oxml: 273 unit, integration, regression, and doc tests passed.
- The API is exercised by a projection-to-DOCX emitter against real drafts, including independent nested lists, mixed bullet-to-decimal levels, start=3, table-cell hyperlinks, hard line breaks, and fixed table grids.