### PR TITLE
F-X012: validate pinned CI toolchains

### DIFF
--- a/.claude/plans/F-X012-design.md
+++ b/.claude/plans/F-X012-design.md
@@ -15,7 +15,12 @@ Binaryen 125 archive but rejects its official Linux identity string because it
 expects the shorter Homebrew spelling.
 
 The same failure set is present in the S37 and S38 merge runs. This is a
-workflow portability defect rather than an S39 product regression.
+workflow portability defect rather than an S39 product regression. The first
+hosted validation of the Poppler and Binaryen corrections then exposed two
+previously unreachable corpus-test requirements in Test and MSRV. Those jobs
+did not install the `uv` executable used by the pinned python-pptx oracles, and
+their default Rust test-thread stack is too small for the largest modelled
+corpus round trip on hosted Linux.
 
 ## Spec reference
 
@@ -44,6 +49,13 @@ installation separate. Correct the WASM identity assertion to the exact
 official Linux output `wasm-opt version 125 (version_125)` after the existing
 archive checksum verification.
 
+In Test and MSRV, install exact `uv` 0.10.2 through the official setup action
+at reviewed commit `20cfd1bf945f4377ade1205e4dbc17946fc9a30d`. Run the full
+workspace suite with an isolated runner-temporary uv cache and an 8 MiB
+`RUST_MIN_STACK`. This keeps the two concurrent pinned python-pptx oracles
+self-contained and gives the existing largest corpus round trip a declared
+hosted-Linux stack budget.
+
 Extend the existing workflow regression suite. Do not add another test binary
 or another workflow file.
 
@@ -64,6 +76,7 @@ or another workflow file.
 |---|---|---|
 | unit | `test_pinned_poppler_installer_contract` | Exact version, source checksum, tools, extraction bound, and build options |
 | regression | `test_every_poppler_consumer_uses_the_pinned_installer` | Test, MSRV, Python bindings, and Presentation fidelity install the oracle before use |
+| regression | `test_workspace_oracle_jobs_pin_uv_cache_and_stack` | Test and MSRV pin official uv 0.10.2, isolate its cache, and run with the exact 8 MiB stack budget |
 | regression | `test_wasm_pr_job_checks_both_targets_and_runs_node_tests` | Official Binaryen 125 Linux identity is accepted only after checksum verification |
 | integration | installer on macOS and disposable Ubuntu 24.04 | All three Poppler tools report exact 26.01.0 and execute |
 | integration | hosted pull-request CI run | Every job passes at the reviewed SHA |
@@ -86,6 +99,9 @@ unchanged.
 - External oracle comparison. Retain Poppler 26.01.0, verify the official
   source checksum and all three runtime identities, and run the existing exact
   pixel and fidelity gates without changing their baselines.
+- Hosted test runtime. Pin the official uv setup action and executable version,
+  isolate its cache per job, and bind the explicit stack budget to only the two
+  broad corpus-test jobs. No product runtime or published package changes.
 
 ## Hash harness
 
@@ -98,6 +114,7 @@ validation only.
 - [ ] Add the authorized Poppler installer with exact source and runtime checks.
 - [ ] Wire every Poppler consumer job to the shared installer.
 - [ ] Correct the official Binaryen 125 Linux identity assertion.
+- [ ] Pin uv and the corpus-test stack budget in Test and MSRV.
 - [ ] Add positive and mutation-sensitive workflow regressions.
 - [ ] Prove the installer on macOS and disposable Ubuntu 24.04.
 - [ ] Run full verification with all 28 hashes unchanged.

--- a/.claude/plans/F-X012-design.md
+++ b/.claude/plans/F-X012-design.md
@@ -20,7 +20,9 @@ hosted validation of the Poppler and Binaryen corrections then exposed two
 previously unreachable corpus-test requirements in Test and MSRV. Those jobs
 did not install the `uv` executable used by the pinned python-pptx oracles, and
 their default Rust test-thread stack is too small for the largest modelled
-corpus round trip on hosted Linux.
+corpus round trip on hosted Linux. The second hosted validation reached the
+three `rpptx-chart` viewer gates and exposed one final clean-runner requirement:
+Test and MSRV also need the exact LibreOffice oracle that those gates execute.
 
 ## Spec reference
 
@@ -34,7 +36,7 @@ corpus round trip on hosted Linux.
 
 ## Approach
 
-Add one authorized script, `scripts/install_pinned_poppler.py`. It downloads
+Add authorized script `scripts/install_pinned_poppler.py`. It downloads
 the official Poppler 26.01.0 source archive, verifies SHA-256
 `1cb944a4b88847f5fb6551683bc799db59f04990f5d8be07aba2acbf38601089`,
 builds only the required command-line tools into a caller-selected prefix, and
@@ -56,6 +58,18 @@ workspace suite with an isolated runner-temporary uv cache and an 8 MiB
 self-contained and gives the existing largest corpus round trip a declared
 hosted-Linux stack budget.
 
+Add the separately authorized `scripts/install_pinned_libreoffice.py` for the
+two Ubuntu 24.04 workspace jobs. It downloads the official LibreOffice 26.2.5 Linux
+x86-64 Debian archive, verifies SHA-256
+`2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e`,
+streams extraction under member and expanded-byte bounds, rejects unsafe
+members and a populated `/opt/libreoffice26.2` prefix, installs only from the
+reviewed archive, provisions the explicit Ubuntu system libraries needed by
+that build, and verifies exact runtime identity
+`LibreOffice 26.2.5.2 cd7284b4cbbfeb507e630c1aac019f4157393acb`.
+Test and MSRV invoke it before the full workspace suite. The existing macOS
+Presentation fidelity job retains its separately reviewed installation path.
+
 Extend the existing workflow regression suite. Do not add another test binary
 or another workflow file.
 
@@ -69,6 +83,10 @@ or another workflow file.
   version, checksum, build, and runtime checks one owner.
 - Skip the Poppler-dependent Rust test in Test and MSRV. The broad workspace
   commands must remain honest and self-contained.
+- Skip the three `rpptx-chart` viewer tests on Ubuntu. They are part of the
+  unconditional workspace suite and require the same reviewed oracle identity.
+- Trust a preinstalled `soffice` based on version output. The installer must
+  prove archive provenance and refuses any populated target prefix.
 
 ## Test plan
 
@@ -77,8 +95,10 @@ or another workflow file.
 | unit | `test_pinned_poppler_installer_contract` | Exact version, source checksum, tools, extraction bound, and build options |
 | regression | `test_every_poppler_consumer_uses_the_pinned_installer` | Test, MSRV, Python bindings, and Presentation fidelity install the oracle before use |
 | regression | `test_workspace_oracle_jobs_pin_uv_cache_and_stack` | Test and MSRV pin official uv 0.10.2, isolate its cache, and run with the exact 8 MiB stack budget |
+| unit | `test_pinned_libreoffice_installer_enforces_runtime_guards` | Checksum, download, member, expanded-byte, prefix, and runtime-identity guards execute |
+| regression | `test_workspace_viewer_jobs_install_pinned_libreoffice` | Test and MSRV install exact LibreOffice unconditionally before the workspace suite |
 | regression | `test_wasm_pr_job_checks_both_targets_and_runs_node_tests` | Official Binaryen 125 Linux identity is accepted only after checksum verification |
-| integration | installer on macOS and disposable Ubuntu 24.04 | All three Poppler tools report exact 26.01.0 and execute |
+| integration | installers on macOS and disposable Ubuntu 24.04 | All three Poppler tools and pinned LibreOffice report their exact identities and execute |
 | integration | hosted pull-request CI run | Every job passes at the reviewed SHA |
 
 The **test gate** is the workflow contract plus full verification and a hosted
@@ -93,15 +113,21 @@ unchanged.
 
 ## Risk routing
 
-- New file. The user explicitly authorized
-  `scripts/install_pinned_poppler.py`. It is the single owner for the shared
-  cross-platform oracle installation.
+- New files. The user explicitly authorized
+  `scripts/install_pinned_poppler.py` and
+  `scripts/install_pinned_libreoffice.py`. The first owns the shared
+  cross-platform Poppler installation. The second owns exact Ubuntu
+  LibreOffice installation for broad workspace jobs.
 - External oracle comparison. Retain Poppler 26.01.0, verify the official
   source checksum and all three runtime identities, and run the existing exact
   pixel and fidelity gates without changing their baselines.
 - Hosted test runtime. Pin the official uv setup action and executable version,
   isolate its cache per job, and bind the explicit stack budget to only the two
   broad corpus-test jobs. No product runtime or published package changes.
+- External LibreOffice oracle. Retain version 26.2.5.2 and the reviewed build
+  identity. Verify the official Linux archive checksum and resource bounds,
+  provision its explicit Ubuntu runtime libraries, then run the existing
+  viewer gates without changing their expected output.
 
 ## Hash harness
 
@@ -115,6 +141,7 @@ validation only.
 - [ ] Wire every Poppler consumer job to the shared installer.
 - [ ] Correct the official Binaryen 125 Linux identity assertion.
 - [ ] Pin uv and the corpus-test stack budget in Test and MSRV.
+- [ ] Add the authorized pinned LibreOffice installer to Test and MSRV.
 - [ ] Add positive and mutation-sensitive workflow regressions.
 - [ ] Prove the installer on macOS and disposable Ubuntu 24.04.
 - [ ] Run full verification with all 28 hashes unchanged.
@@ -123,5 +150,5 @@ validation only.
 
 ## Open questions
 
-None. The user authorized S40, F-X012, and the single new installer path. The
-reviewed Poppler and rendering baselines remain fixed.
+None. The user authorized S40, F-X012, and both new installer paths. The
+reviewed Poppler and LibreOffice rendering baselines remain fixed.

--- a/.claude/plans/F-X012-design.md
+++ b/.claude/plans/F-X012-design.md
@@ -1,0 +1,110 @@
+# F-X012, Restore pinned CI toolchains
+
+**Status**: approved
+**Sprint**: S40
+**Size**: M
+**Depends on**: none
+
+## Problem
+
+Hosted CI has five failing jobs at the S39 merge SHA. The Test and MSRV jobs
+execute the F-043 `pdftoppm` gate without installing Poppler. The two macOS
+oracle jobs call unpinned `brew install poppler`, which now supplies 26.07.0
+instead of the reviewed 26.01.0. The WASM job verifies a checksum-pinned
+Binaryen 125 archive but rejects its official Linux identity string because it
+expects the shorter Homebrew spelling.
+
+The same failure set is present in the S37 and S38 merge runs. This is a
+workflow portability defect rather than an S39 product regression.
+
+## Spec reference
+
+- `docs/hld/12-testing-strategy.md`, "The golden-PNG gate" and "The render
+  fidelity gate".
+- `docs/hld/15-build-and-toolchain.md`, "A WASM target and Node job", "A
+  pull-request Python bindings job", and "A dedicated Presentation fidelity
+  job".
+- `docs/hld/14-development-backlog.md`, "F-X012, Restore pinned CI
+  toolchains".
+
+## Approach
+
+Add one authorized script, `scripts/install_pinned_poppler.py`. It downloads
+the official Poppler 26.01.0 source archive, verifies SHA-256
+`1cb944a4b88847f5fb6551683bc799db59f04990f5d8be07aba2acbf38601089`,
+builds only the required command-line tools into a caller-selected prefix, and
+verifies exact `pdftoppm`, `pdfinfo`, and `pdftotext` version identities. It
+uses bounded extraction, an isolated build directory, explicit CMake options,
+and no published-crate dependency.
+
+Wire Test, MSRV, both Python binding matrix rows, and Presentation fidelity to
+the same installer before any Poppler-dependent test. Platform package managers
+may install build dependencies, but never Poppler itself. Keep LibreOffice
+installation separate. Correct the WASM identity assertion to the exact
+official Linux output `wasm-opt version 125 (version_125)` after the existing
+archive checksum verification.
+
+Extend the existing workflow regression suite. Do not add another test binary
+or another workflow file.
+
+## Rejected alternatives
+
+- Upgrade the rendering baseline to Poppler 26.07.0. That would turn a CI
+  packaging defect into an unrelated output change.
+- Keep using `brew install poppler`. The formula is moving and has already
+  invalidated the exact oracle contract.
+- Duplicate the source-build commands in four jobs. One installer gives the
+  version, checksum, build, and runtime checks one owner.
+- Skip the Poppler-dependent Rust test in Test and MSRV. The broad workspace
+  commands must remain honest and self-contained.
+
+## Test plan
+
+| Category | Test | Asserts |
+|---|---|---|
+| unit | `test_pinned_poppler_installer_contract` | Exact version, source checksum, tools, extraction bound, and build options |
+| regression | `test_every_poppler_consumer_uses_the_pinned_installer` | Test, MSRV, Python bindings, and Presentation fidelity install the oracle before use |
+| regression | `test_wasm_pr_job_checks_both_targets_and_runs_node_tests` | Official Binaryen 125 Linux identity is accepted only after checksum verification |
+| integration | installer on macOS and disposable Ubuntu 24.04 | All three Poppler tools report exact 26.01.0 and execute |
+| integration | hosted pull-request CI run | Every job passes at the reviewed SHA |
+
+The **test gate** is the workflow contract plus full verification and a hosted
+pull-request CI run at the reviewed SHA, all with the 28-entry hash harness
+unchanged.
+
+## HLD impact
+
+- `docs/hld/12-testing-strategy.md`
+- `docs/hld/14-development-backlog.md`
+- `docs/hld/15-build-and-toolchain.md`
+
+## Risk routing
+
+- New file. The user explicitly authorized
+  `scripts/install_pinned_poppler.py`. It is the single owner for the shared
+  cross-platform oracle installation.
+- External oracle comparison. Retain Poppler 26.01.0, verify the official
+  source checksum and all three runtime identities, and run the existing exact
+  pixel and fidelity gates without changing their baselines.
+
+## Hash harness
+
+Expected to be unchanged. The story changes CI tool installation and
+validation only.
+
+## Implementation checklist
+
+- [ ] Record the five-job hosted failure set and focused workflow-test red.
+- [ ] Add the authorized Poppler installer with exact source and runtime checks.
+- [ ] Wire every Poppler consumer job to the shared installer.
+- [ ] Correct the official Binaryen 125 Linux identity assertion.
+- [ ] Add positive and mutation-sensitive workflow regressions.
+- [ ] Prove the installer on macOS and disposable Ubuntu 24.04.
+- [ ] Run full verification with all 28 hashes unchanged.
+- [ ] Obtain a fully green hosted pull-request CI run at the reviewed SHA.
+- [ ] Obtain a clean independent microscope and sprint review.
+
+## Open questions
+
+None. The user authorized S40, F-X012, and the single new installer path. The
+reviewed Poppler and rendering baselines remain fixed.

--- a/.claude/reviews/F-X012-all-pass-1.md
+++ b/.claude/reviews/F-X012-all-pass-1.md
@@ -1,0 +1,132 @@
+# F-X012, all aspects, pass 1
+
+**Reviewed**: the complete five-file working tree delta at
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 330 additions and 16 deletions,
+including the untracked authorized installer
+**Verdict**: 4 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, the archive member bound is applied after unbounded allocation
+
+`scripts/install_pinned_poppler.py:50`
+`scripts/install_pinned_poppler.py:52`
+`.claude/plans/F-X012-design.md:37`
+
+`archive.getmembers()` reads every tar header and retains every `TarInfo` in a
+list before the code compares its length with `MAX_ARCHIVE_MEMBERS`. A small
+XZ input can expand to a very large tar stream containing zero-length members.
+That input consumes memory proportional to the entire member table before the
+2,048-member check runs, while the extracted-size sum remains zero. The stated
+member limit therefore does not bound the resource it is meant to protect.
+Iterate the archive, increment the count and total size, and reject as soon as
+either bound is crossed.
+
+### D2, a populated prefix bypasses the pinned source guarantee
+
+`scripts/install_pinned_poppler.py:118`
+`scripts/install_pinned_poppler.py:119`
+`scripts/install_pinned_poppler.py:123`
+`.claude/plans/F-X012-design.md:32`
+`.claude/plans/F-X012-design.md:86`
+
+Any non-empty caller-selected prefix takes the reuse branch. That branch checks
+only that three files report the expected version text, then returns without
+downloading or hashing the reviewed source. Three arbitrary executables that
+print `26.01.0`, or a differently sourced build of that version, are therefore
+accepted as the exact oracle. This contradicts the source-provenance boundary
+that motivated replacing the package-manager installation. Build into an
+empty owned prefix every time, or authenticate an installer-owned provenance
+record before permitting reuse.
+
+### D3, the installer regression checks declarations rather than enforcement
+
+`scripts/test_sprint_workflow.py:112`
+`scripts/test_sprint_workflow.py:125`
+`scripts/test_sprint_workflow.py:319`
+`scripts/test_sprint_workflow.py:345`
+`.claude/plans/F-X012-design.md:65`
+`.claude/plans/F-X012-design.md:101`
+
+The installer helper only searches the source text for constants, function
+names, one CMake option, and the expected-version assignment. It never calls
+the download, extraction, verification, or build behavior. Focused mutations
+changed the checksum comparison, member-count comparison, and runtime identity
+comparison to `if False` while retaining those strings. All three mutated
+installers still passed `assert_pinned_poppler_installer_contract()`. The
+declared version, checksum, and bounds can consequently remain present while
+none is enforced. Add behavioral tests with controlled responses and synthetic
+archives so bypassing each gate fails the named unit test.
+
+### D4, every installer step can be disabled without failing the consumer test
+
+`scripts/test_sprint_workflow.py:127`
+`scripts/test_sprint_workflow.py:139`
+`scripts/test_sprint_workflow.py:347`
+`scripts/test_sprint_workflow.py:362`
+`.claude/plans/F-X012-design.md:66`
+`.claude/plans/F-X012-design.md:101`
+
+The consumer helper proves that the script command text occurs in each named
+job before a use marker, but it does not inspect step conditions or failure
+policy. Adding `if: false` to any of the four installer steps leaves the step,
+command, count, and ordering unchanged, so the regression still passes while
+the consuming job runs without Poppler. `continue-on-error: true` is likewise
+accepted for the Test, MSRV, and Presentation fidelity installer steps. Extend
+the contract and negative mutations to reject conditional or failure-tolerant
+installer steps in every consumer.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Focused evidence
+
+- The workflow invokes the shared installer in Test, both Python matrix rows,
+  Presentation fidelity, and MSRV before their Poppler-dependent work
+  (`.github/workflows/ci.yml:26`, `.github/workflows/ci.yml:58`,
+  `.github/workflows/ci.yml:224`, `.github/workflows/ci.yml:368`). No workflow
+  command installs Poppler from Homebrew or `poppler-utils`. LibreOffice remains
+  a separate step (`.github/workflows/ci.yml:221`).
+- The Binaryen archive checksum still precedes extraction and the exact
+  official Linux identity assertion
+  (`.github/workflows/ci.yml:121`, `.github/workflows/ci.yml:126`). The existing
+  exact WASM job contract and its weakened-gate mutations cover that ordering
+  and identity (`scripts/test_sprint_workflow.py:704`,
+  `scripts/test_sprint_workflow.py:721`,
+  `scripts/test_sprint_workflow.py:959`,
+  `scripts/test_sprint_workflow.py:970`).
+- All 41 workflow tests pass. The installer compiles and exposes its CLI help.
+  The hash harness remains 28 of 28, prose and generated skills pass, and the
+  working diff has no whitespace error. The progress record also reports the
+  unchanged installer executing successfully on disposable Ubuntu 24.04 and
+  macOS, with the three tool identities verified
+  (`.claude/scratch/F-X012-progress.md:20`,
+  `.claude/scratch/F-X012-progress.md:24`,
+  `.claude/scratch/F-X012-progress.md:33`). These positive results do not cover
+  D1 through D4.
+- The implementation adds the one authorized installer and no crate, module,
+  trait, generic, public API, package dependency, version, publication path, or
+  rendering baseline. The exact planned HLD impact remains testing strategy,
+  development backlog, and build/toolchain
+  (`.claude/plans/F-X012-design.md:75`). Those HLD updates correctly remain for
+  completion rather than being mixed into this in-progress implementation.
+- Sprint state is consistent. F-X012 is the sole in-progress story under owner
+  `codex`, and the backlog arithmetic reports 165 done, one in progress, and
+  zero pending (`docs/sprints/CURRENT_SPRINT.md:23`,
+  `docs/sprints/BACKLOG.md:32`, `docs/sprints/BACKLOG.md:33`,
+  `docs/sprints/BACKLOG.md:299`).
+
+## Not found
+
+No additional workflow consumer, moving Poppler binary installation, wrong
+Poppler literal or source checksum, wrong Binaryen identity, checksum-order
+regression, product-code change, dependency-direction change, package or
+release mutation, rendering-baseline delta, hash delta, unapproved file,
+structural indirection, exception-swallowing path, arithmetic overflow, HLD
+scope omission, tracker mismatch, prose violation, or nitpick was found beyond
+D1 through D4.

--- a/.claude/reviews/F-X012-all-pass-2.md
+++ b/.claude/reviews/F-X012-all-pass-2.md
@@ -1,0 +1,132 @@
+# F-X012, all aspects, pass 2
+
+**Reviewed**: the complete five-file working implementation delta at
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 419 additions and 16 deletions,
+plus pass 1 and its remediation record
+**Verdict**: 2 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, the behavioral guard test still leaves two bounds and two identities unproved
+
+`scripts/test_sprint_workflow.py:359`
+`scripts/test_sprint_workflow.py:369`
+`scripts/test_sprint_workflow.py:371`
+`scripts/test_sprint_workflow.py:399`
+`scripts/install_pinned_poppler.py:39`
+`scripts/install_pinned_poppler.py:60`
+`scripts/install_pinned_poppler.py:90`
+`.claude/plans/F-X012-design.md:36`
+`.claude/plans/F-X012-design.md:65`
+
+The new behavioral test proves a bad digest, the member-count limit, and a
+wrong first tool identity. It never exceeds `MAX_DOWNLOAD_BYTES`, never exceeds
+`MAX_EXTRACTED_BYTES`, and makes all three fake tools wrong so verification
+stops at `pdftoppm`. Disabling either byte-limit comparison, or changing
+`verify_tools()` to iterate only the first tool, therefore leaves the behavioral
+test green. The lexical assertions retain the constants and all three tool
+names, so they do not close those gaps. Exercise both byte ceilings and make
+`pdfinfo` and `pdftotext` fail one at a time while the preceding tools report
+the exact version.
+
+### D2, three consumer jobs can still short-circuit the installer successfully
+
+`scripts/test_sprint_workflow.py:129`
+`scripts/test_sprint_workflow.py:145`
+`scripts/test_sprint_workflow.py:421`
+`scripts/test_sprint_workflow.py:448`
+`.claude/plans/F-X012-design.md:66`
+`.claude/plans/F-X012-design.md:101`
+
+The remediation rejects step-level `if` and `continue-on-error`, but it does
+not reject success short circuits inside the run body. A focused mutation added
+`exit 0` before the exact installer command in the Test step.
+`assert_poppler_consumers_contract()` still accepted the mutated workflow
+because the command, step fields, count, and ordering remained present. The
+separate exact Python job assertion happens to reject this mutation for the
+matrix job, but no equivalent assertion protects Test, MSRV, or Presentation
+fidelity. Apply the existing `assert_no_success_short_circuit()` helper to every
+installer run body and add the corresponding negative mutation.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Pass 1 dispositions
+
+- D1 is fixed. Extraction uses streaming XZ mode, counts each member before
+  extraction, rejects the 2,049th member immediately, and no longer calls
+  `getmembers()` (`scripts/install_pinned_poppler.py:52`,
+  `scripts/install_pinned_poppler.py:56`,
+  `scripts/test_sprint_workflow.py:371`,
+  `scripts/test_sprint_workflow.py:386`).
+- D2 is fixed. Any existing file or non-empty directory at the selected prefix
+  fails before download, so a successful invocation cannot reuse tools based
+  on version text alone (`scripts/install_pinned_poppler.py:118`,
+  `scripts/install_pinned_poppler.py:123`,
+  `scripts/test_sprint_workflow.py:401`,
+  `scripts/test_sprint_workflow.py:419`).
+- D3 is partially fixed by real checksum, member-count, and runtime probes
+  (`scripts/test_sprint_workflow.py:359`). D1 records the remaining behavioral
+  coverage gap.
+- D4's cited conditional and failure-tolerant step policies are fixed. The
+  direct step-field contract and eight negative policy mutations reject both
+  forms for all four consumers (`scripts/test_sprint_workflow.py:139`,
+  `scripts/test_sprint_workflow.py:151`,
+  `scripts/test_sprint_workflow.py:426`,
+  `scripts/test_sprint_workflow.py:448`). D2 records the remaining in-body
+  short-circuit gap.
+
+## Focused evidence
+
+- All 43 workflow tests pass, both Python files compile, and the exact focused
+  early-success mutation described in D2 is accepted by the consumer helper.
+  The hash harness remains 28 of 28. Prose, generated-skill synchronization,
+  and diff hygiene pass.
+- The workflow itself remains correctly wired. Test, both Python rows,
+  Presentation fidelity, and MSRV invoke the one installer before their
+  Poppler-dependent work (`.github/workflows/ci.yml:26`,
+  `.github/workflows/ci.yml:58`, `.github/workflows/ci.yml:224`,
+  `.github/workflows/ci.yml:368`). Each current installer step is unconditional
+  and failure-propagating. No package manager installs Poppler, and LibreOffice
+  remains separate (`.github/workflows/ci.yml:221`).
+- The source checksum and official version remain exact, extraction paths and
+  unsupported member types fail closed, work is isolated, build concurrency is
+  capped at four, and only the three requested tools are copied and verified
+  (`scripts/install_pinned_poppler.py:18`,
+  `scripts/install_pinned_poppler.py:43`,
+  `scripts/install_pinned_poppler.py:62`,
+  `scripts/install_pinned_poppler.py:70`,
+  `scripts/install_pinned_poppler.py:125`,
+  `scripts/install_pinned_poppler.py:161`,
+  `scripts/install_pinned_poppler.py:175`).
+- Binaryen still verifies the reviewed archive checksum before requiring the
+  exact official Linux identity (`.github/workflows/ci.yml:122`,
+  `.github/workflows/ci.yml:126`). The existing exact job contract and negative
+  checksum and identity mutations remain intact
+  (`scripts/test_sprint_workflow.py:790`,
+  `scripts/test_sprint_workflow.py:806`,
+  `scripts/test_sprint_workflow.py:1049`,
+  `scripts/test_sprint_workflow.py:1056`).
+- The progress record reports successful remediated macOS installation and
+  fail-closed populated-prefix behavior
+  (`.claude/scratch/F-X012-progress.md:54`,
+  `.claude/scratch/F-X012-progress.md:55`). Product code, crate metadata,
+  package versions, publication authority, and rendering baselines remain
+  unchanged. The exact planned HLD impact is still 12, 14, and 15
+  (`.claude/plans/F-X012-design.md:75`).
+
+## Not found
+
+No functional regression in streaming extraction or populated-prefix refusal,
+unsafe archive path, accepted unsupported member type, unbounded build
+parallelism, wrong source checksum or runtime literal, missing Poppler consumer,
+moving Poppler package installation, Binaryen checksum-order error, wrong
+Binaryen identity, product-code change, public API change, dependency change,
+package or release mutation, rendering-baseline delta, hash delta, unapproved
+file, HLD scope omission, sprint-state mismatch, structural indirection, prose
+violation, smell, or nitpick was found beyond D1 and D2.

--- a/.claude/reviews/F-X012-all-pass-3.md
+++ b/.claude/reviews/F-X012-all-pass-3.md
@@ -1,0 +1,123 @@
+# F-X012, all aspects, pass 3
+
+**Reviewed**: the complete five-file working implementation delta at
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 458 additions and 16 deletions,
+plus passes 1 and 2 and all remediations
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Prior finding dispositions
+
+- Pass 1 D1 remains fixed. The XZ archive is streamed one member at a time,
+  the member count is checked before extraction, and the regression forbids
+  `getmembers()` while requiring rejection of member 2,049
+  (`scripts/install_pinned_poppler.py:52`,
+  `scripts/install_pinned_poppler.py:56`,
+  `scripts/test_sprint_workflow.py:382`,
+  `scripts/test_sprint_workflow.py:397`).
+- Pass 1 D2 remains fixed. An existing file or non-empty directory at the
+  selected prefix fails before download, and a populated exact-version prefix
+  is behaviorally rejected (`scripts/install_pinned_poppler.py:118`,
+  `scripts/install_pinned_poppler.py:123`,
+  `scripts/test_sprint_workflow.py:430`,
+  `scripts/test_sprint_workflow.py:448`).
+- Pass 1 D3 and pass 2 D1 are fixed. The tests now execute a bad checksum, an
+  over-limit download, an over-limit extracted member, the streaming member
+  ceiling, and a wrong identity for each of `pdftoppm`, `pdfinfo`, and
+  `pdftotext` independently (`scripts/test_sprint_workflow.py:360`,
+  `scripts/test_sprint_workflow.py:380`,
+  `scripts/test_sprint_workflow.py:393`,
+  `scripts/test_sprint_workflow.py:406`,
+  `scripts/test_sprint_workflow.py:412`,
+  `scripts/test_sprint_workflow.py:428`). The progress record reports that
+  disabling either byte ceiling or narrowing verification to the first tool
+  made the unchanged regression fail
+  (`.claude/scratch/F-X012-progress.md:70`,
+  `.claude/scratch/F-X012-progress.md:73`).
+- Pass 1 D4 and pass 2 D2 are fixed. Every consumer requires exactly the
+  ordinary Bash run step, rejects any `continue-on-error`, applies the shared
+  successful-short-circuit check, and precedes its use marker
+  (`scripts/test_sprint_workflow.py:129`,
+  `scripts/test_sprint_workflow.py:146`,
+  `scripts/test_sprint_workflow.py:151`). All four jobs have negative mutations
+  for `if: false`, `continue-on-error: true`, and an in-body `exit 0`
+  (`scripts/test_sprint_workflow.py:450`,
+  `scripts/test_sprint_workflow.py:477`,
+  `scripts/test_sprint_workflow.py:487`).
+
+## Focused evidence
+
+- The five focused Poppler and WASM tests pass, followed by all 43 workflow
+  tests. Both Python files compile. The hash harness remains 28 of 28. Prose,
+  generated-skill synchronization, and diff hygiene pass.
+- The installer pins the official version, source URL, and SHA-256, bounds the
+  compressed download, streams and bounds extraction, rejects traversal and
+  unsupported archive entries, isolates the build, caps parallel work at four,
+  copies only the three requested utilities, verifies each exact runtime
+  identity, and exposes the verified directory only after success
+  (`scripts/install_pinned_poppler.py:18`,
+  `scripts/install_pinned_poppler.py:24`,
+  `scripts/install_pinned_poppler.py:39`,
+  `scripts/install_pinned_poppler.py:52`,
+  `scripts/install_pinned_poppler.py:66`,
+  `scripts/install_pinned_poppler.py:70`,
+  `scripts/install_pinned_poppler.py:125`,
+  `scripts/install_pinned_poppler.py:161`,
+  `scripts/install_pinned_poppler.py:175`,
+  `scripts/install_pinned_poppler.py:179`).
+- Test, both Python matrix rows, Presentation fidelity, and MSRV invoke the one
+  installer before their Poppler-dependent work
+  (`.github/workflows/ci.yml:26`, `.github/workflows/ci.yml:58`,
+  `.github/workflows/ci.yml:224`, `.github/workflows/ci.yml:368`). Package
+  managers install build dependencies only. No workflow command installs a
+  moving Poppler binary, and LibreOffice remains separate
+  (`.github/workflows/ci.yml:221`).
+- Binaryen verifies the reviewed archive checksum before testing the exact
+  official Linux identity (`.github/workflows/ci.yml:122`,
+  `.github/workflows/ci.yml:126`). Its exact contract and negative checksum and
+  identity mutations remain intact
+  (`scripts/test_sprint_workflow.py:828`,
+  `scripts/test_sprint_workflow.py:845`,
+  `scripts/test_sprint_workflow.py:1088`,
+  `scripts/test_sprint_workflow.py:1095`).
+- The positive cross-platform evidence remains current. The progress record
+  reports the finished installer executing on disposable Ubuntu 24.04 and
+  macOS, all three tools executing at 26.01.0, the former native and binding
+  failures passing, and the required 421-slide corpus gate completing without
+  missing output (`.claude/scratch/F-X012-progress.md:20`,
+  `.claude/scratch/F-X012-progress.md:23`,
+  `.claude/scratch/F-X012-progress.md:35`,
+  `.claude/scratch/F-X012-progress.md:37`).
+- Product code, public APIs, dependencies, crate metadata, package versions,
+  publication authority, and rendering baselines remain unchanged. The exact
+  planned HLD impact remains testing strategy, development backlog, and build
+  and toolchain (`.claude/plans/F-X012-design.md:75`). Those current-state HLD
+  updates correctly remain part of completion rather than this in-progress
+  implementation.
+- F-X012 is the sole in-progress story under owner `codex`. Backlog arithmetic
+  remains 165 done, one in progress, and zero pending
+  (`docs/sprints/CURRENT_SPRINT.md:23`, `docs/sprints/BACKLOG.md:32`,
+  `docs/sprints/BACKLOG.md:33`, `docs/sprints/BACKLOG.md:299`).
+
+## Not found
+
+No wrong checksum or tool identity, bypassed download or extraction ceiling,
+unbounded archive member allocation, unsafe archive path, accepted unsupported
+member, populated-prefix provenance bypass, missing consumer, conditional or
+failure-tolerant installer step, successful in-body short circuit, moving
+Poppler installation, workflow-order error, Binaryen checksum-order or identity
+error, product-code change, public API change, dependency change, package or
+release mutation, rendering-baseline delta, hash delta, unapproved file, HLD
+scope omission, sprint-state mismatch, structural indirection, panic, prose
+violation, smell, or nitpick was found.

--- a/.claude/reviews/F-X012-all-pass-4.md
+++ b/.claude/reviews/F-X012-all-pass-4.md
@@ -1,0 +1,126 @@
+# F-X012, all aspects, pass 4
+
+**Reviewed**: the six-file post-pass-3 amendment at
+`b27d067be51d54e149d38369bab530f01c3434b4`, 123 additions and 9 deletions,
+then the complete twelve-file F-X012 delta from
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 1,008 additions and 35 deletions
+**Verdict**: 2 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, the runtime regression accepts a successfully skipped workspace suite
+
+`scripts/test_sprint_workflow.py:181`
+`scripts/test_sprint_workflow.py:194`
+`scripts/test_sprint_workflow.py:196`
+`.claude/plans/F-X012-design.md:53`
+`.claude/plans/F-X012-design.md:79`
+
+The helper proves that the named step contains the Cargo command text and has
+the exact environment, but it never applies the existing successful
+short-circuit check to the run body. A focused mutation inserted `exit 0` before
+`cargo test` in Test. `assert_workspace_oracle_environment_contract()` still
+accepted the workflow, even though the step would succeed without running the
+suite under either the uv cache or stack environment. Apply
+`assert_no_success_short_circuit()` to both workspace-suite run bodies and add
+the mutation for Test and MSRV.
+
+### D2, the regression does not enforce the exclusive stack scope
+
+`scripts/test_sprint_workflow.py:157`
+`scripts/test_sprint_workflow.py:191`
+`scripts/test_sprint_workflow.py:535`
+`scripts/test_sprint_workflow.py:548`
+`.claude/plans/F-X012-design.md:102`
+`docs/hld/15-build-and-toolchain.md:363`
+
+The helper requires the two local `RUST_MIN_STACK` entries but never rejects
+the same variable outside those steps. A focused mutation added
+`RUST_MIN_STACK=8388608` to the workflow-global environment while leaving the
+two local entries intact. The new regression still passed, even though that
+widens the stack budget to every job and contradicts the plan and HLD promise
+that it is bound only to the two corpus-heavy suites. Assert exactly two
+operative occurrences, both owned by the named test steps, and add a
+scope-widening mutation.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Amendment evidence
+
+- The current workflow correctly pins official
+  `astral-sh/setup-uv` commit
+  `20cfd1bf945f4377ade1205e4dbc17946fc9a30d` in Test and MSRV, requests exact
+  uv 0.10.2, and disables the action cache
+  (`.github/workflows/ci.yml:26`, `.github/workflows/ci.yml:30`,
+  `.github/workflows/ci.yml:377`, `.github/workflows/ci.yml:381`). Independent
+  GitHub API inspection confirms that SHA is the official `v10.0.1` tag commit,
+  its `action.yml` owns the `version` and `enable-cache` inputs, and uv 0.10.2
+  is a published non-prerelease release.
+- Each current workspace-suite step uses exactly
+  `${{ runner.temp }}/uv-cache` and `RUST_MIN_STACK=8388608`, with neither
+  variable present elsewhere in the workflow
+  (`.github/workflows/ci.yml:42`, `.github/workflows/ci.yml:48`,
+  `.github/workflows/ci.yml:393`, `.github/workflows/ci.yml:399`). The action
+  setup precedes the suite in both jobs. The present implementation therefore
+  has the intended scope despite D1 and D2's regression gaps.
+- The focused amendment test, Poppler installer test, consumer-policy test, and
+  WASM contract pass. All 44 workflow tests pass, both Python files compile,
+  the hash harness remains 28 of 28, and prose, generated-skill synchronization,
+  and diff hygiene pass. The progress record also reports the full `rpptx`
+  suite passing locally under the exact cache and stack environment with 19
+  unit and 86 integration tests passing and 7 ignored
+  (`.claude/scratch/F-X012-progress.md:92`,
+  `.claude/scratch/F-X012-progress.md:97`).
+- The amendment modifies exactly the approved plan, CI workflow, existing
+  workflow regression file, and HLD12, HLD14, and HLD15. The HLD impact list is
+  unchanged and exact (`.claude/plans/F-X012-design.md:88`,
+  `.claude/plans/F-X012-design.md:92`). HLD12 owns the two job commands, HLD14
+  owns the story gate, and HLD15 owns the exact action, cache, and stack
+  mechanism (`docs/hld/12-testing-strategy.md:458`,
+  `docs/hld/12-testing-strategy.md:468`,
+  `docs/hld/14-development-backlog.md:1300`,
+  `docs/hld/14-development-backlog.md:1308`,
+  `docs/hld/15-build-and-toolchain.md:358`,
+  `docs/hld/15-build-and-toolchain.md:364`). The documents describe current
+  mechanism rather than change history and do not contradict another HLD.
+
+## Full feature evidence
+
+- Pass 3 remains clean for the Poppler source checksum, all three resource
+  bounds, streaming member handling, safe paths and types, each tool identity,
+  populated-prefix refusal, the four Poppler consumers, and the Binaryen
+  checksum and official identity
+  (`.claude/reviews/F-X012-all-pass-3.md:14`,
+  `.claude/reviews/F-X012-all-pass-3.md:48`,
+  `.claude/reviews/F-X012-all-pass-3.md:70`). The amendment does not touch the
+  installer or those workflow steps.
+- The complete feature delta contains no `crates/` file, manifest, lockfile,
+  public API, product runtime, package version, publication workflow, rendering
+  baseline, or hash-baseline change. The hosted stack variable is currently
+  step-local in Test and MSRV, so the implementation itself does not expand
+  product runtime behavior (`docs/hld/15-build-and-toolchain.md:361`,
+  `docs/hld/15-build-and-toolchain.md:364`).
+- The temporary draft PR and branch remain evidence-only. The progress record
+  identifies candidate SHA `b27d067be51d54e149d38369bab530f01c3434b4`, draft
+  PR 26, and the two newly reached hosted failures that justify the amendment
+  (`.claude/scratch/F-X012-progress.md:77`,
+  `.claude/scratch/F-X012-progress.md:86`). The plan still requires a fully
+  green hosted run at the amended reviewed SHA before completion
+  (`.claude/plans/F-X012-design.md:81`,
+  `.claude/plans/F-X012-design.md:85`).
+
+## Not found
+
+No incorrect official action SHA or tag, floating uv version, enabled action
+cache, non-temporary active uv cache, incorrect 8 MiB value, current stack-scope
+leak, wrong job ordering, missing Test or MSRV setup, product or public API
+change, crate or dependency change, package or publication change, rendering or
+hash-baseline delta, unlisted HLD edit, stale HLD mechanism, structural
+indirection, panic, prose violation, smell, or nitpick was found beyond D1 and
+D2.

--- a/.claude/reviews/F-X012-all-pass-5.md
+++ b/.claude/reviews/F-X012-all-pass-5.md
@@ -1,0 +1,136 @@
+# F-X012, all aspects, pass 5
+
+**Reviewed**: the six-file post-pass-3 amendment at
+`b27d067be51d54e149d38369bab530f01c3434b4`, 167 additions and 9 deletions,
+then the complete twelve-file F-X012 delta from
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 1,052 additions and 35 deletions
+**Verdict**: 1 defect, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, the stack-scope regression still accepts an equivalent global YAML key
+
+`scripts/test_sprint_workflow.py:198`
+`scripts/test_sprint_workflow.py:537`
+`scripts/test_sprint_workflow.py:543`
+`.claude/plans/F-X012-design.md:102`
+`.claude/plans/F-X012-design.md:104`
+`docs/hld/15-build-and-toolchain.md:363`
+
+The new workflow-wide guard counts only the literal text `RUST_MIN_STACK:`.
+YAML permits a mapping key to be quoted, so adding
+`"RUST_MIN_STACK": "8388608"` to the workflow-global `env` widens the stack
+budget to every job but does not increase that literal count. A focused
+in-memory mutation made exactly that change and
+`assert_workspace_oracle_environment_contract()` accepted it. The committed
+mutation covers only the unquoted spelling. Count parsed or normalized
+operative environment keys, then require that the only two occurrences belong
+to the two named workspace-suite steps. Add the quoted-key mutation to keep the
+exclusive scope mutation-sensitive.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Pass 4 finding dispositions
+
+- Pass 4 D1 is fixed. Both Test and MSRV apply the shared successful
+  short-circuit rejection to the full workspace step, and each job independently
+  mutates an `exit 0` before Cargo
+  (`scripts/test_sprint_workflow.py:181`,
+  `scripts/test_sprint_workflow.py:195`,
+  `scripts/test_sprint_workflow.py:544`,
+  `scripts/test_sprint_workflow.py:582`).
+- Pass 4 D2 is only partially fixed. The current unquoted global-stack mutation
+  is rejected and the positive workflow has exactly the intended two local
+  settings, but D1 shows that the raw-text count does not enforce the promised
+  YAML key scope (`scripts/test_sprint_workflow.py:198`,
+  `scripts/test_sprint_workflow.py:538`,
+  `.github/workflows/ci.yml:45`, `.github/workflows/ci.yml:396`).
+
+## Focused evidence
+
+- Test and MSRV each use the exact official setup action commit, request uv
+  0.10.2, disable the action cache, and place the runner-temporary uv cache and
+  8 MiB stack only on the named workspace-suite step
+  (`.github/workflows/ci.yml:26`, `.github/workflows/ci.yml:30`,
+  `.github/workflows/ci.yml:42`, `.github/workflows/ci.yml:48`,
+  `.github/workflows/ci.yml:377`, `.github/workflows/ci.yml:381`,
+  `.github/workflows/ci.yml:393`, `.github/workflows/ci.yml:399`). The present
+  workflow therefore has the intended runtime scope despite D1's regression
+  bypass.
+- The mutation matrix independently changes the action, uv version, cache,
+  local stack, and successful exit in both jobs, followed by the separate
+  unquoted global-stack mutation
+  (`scripts/test_sprint_workflow.py:537`,
+  `scripts/test_sprint_workflow.py:544`,
+  `scripts/test_sprint_workflow.py:549`,
+  `scripts/test_sprint_workflow.py:559`,
+  `scripts/test_sprint_workflow.py:566`,
+  `scripts/test_sprint_workflow.py:575`,
+  `scripts/test_sprint_workflow.py:582`,
+  `scripts/test_sprint_workflow.py:593`). All intended mutations are routed
+  through the same central validation helper.
+- The four focused workflow tests pass, followed by all 44 workflow tests. Both
+  Python files compile. The hash harness remains 28 of 28. Prose, generated-skill
+  synchronization, and diff hygiene pass. The progress record also reports the
+  complete `rpptx` suite under the exact environment with 19 unit and 86
+  integration tests passing and 7 ignored
+  (`.claude/scratch/F-X012-progress.md:92`,
+  `.claude/scratch/F-X012-progress.md:97`,
+  `.claude/scratch/F-X012-progress.md:103`).
+- The amendment changes exactly the approved plan, workflow, existing workflow
+  regression file, and HLD12, HLD14, and HLD15. The plan's HLD impact list is
+  exact (`.claude/plans/F-X012-design.md:88`,
+  `.claude/plans/F-X012-design.md:92`). HLD12 owns the two job commands, HLD14
+  owns the story gate, and HLD15 owns the exact runtime mechanism
+  (`docs/hld/12-testing-strategy.md:458`,
+  `docs/hld/12-testing-strategy.md:468`,
+  `docs/hld/14-development-backlog.md:1300`,
+  `docs/hld/14-development-backlog.md:1308`,
+  `docs/hld/15-build-and-toolchain.md:358`,
+  `docs/hld/15-build-and-toolchain.md:364`). Their current-state descriptions
+  agree.
+
+## Complete feature evidence
+
+- Pass 3's clean findings remain valid for the exact Poppler source and
+  checksum, bounded download and streaming extraction, safe archive handling,
+  empty-prefix provenance, three runtime identities, four unconditional
+  consumers, and Binaryen checksum and identity
+  (`.claude/reviews/F-X012-all-pass-3.md:22`,
+  `.claude/reviews/F-X012-all-pass-3.md:48`,
+  `.claude/reviews/F-X012-all-pass-3.md:64`,
+  `.claude/reviews/F-X012-all-pass-3.md:86`). The amendment does not touch the
+  installer or the pre-existing consumer and WASM corrections.
+- The installer still enforces its checksum and three resource ceilings before
+  bounded extraction and construction, rejects a populated destination, limits
+  build parallelism to four, verifies every copied tool, and exposes the path
+  only after verification (`scripts/install_pinned_poppler.py:18`,
+  `scripts/install_pinned_poppler.py:39`,
+  `scripts/install_pinned_poppler.py:52`,
+  `scripts/install_pinned_poppler.py:60`,
+  `scripts/install_pinned_poppler.py:118`,
+  `scripts/install_pinned_poppler.py:161`,
+  `scripts/install_pinned_poppler.py:175`,
+  `scripts/install_pinned_poppler.py:179`).
+- The complete delta contains no crate source, manifest, lockfile, public API,
+  dependency, package version, publication workflow, rendering baseline, or
+  hash-baseline change. F-X012 remains the sole in-progress S40 story and the
+  ledgers agree on 165 done, one in progress, and zero pending
+  (`docs/sprints/CURRENT_SPRINT.md:23`, `docs/sprints/BACKLOG.md:32`,
+  `docs/sprints/BACKLOG.md:33`, `docs/sprints/BACKLOG.md:299`).
+
+## Not found
+
+No present workflow stack leak, successful Test or MSRV short circuit, wrong uv
+action or version, enabled action cache, shared active uv cache, incorrect local
+stack value, wrong job ordering, installer correctness or resource regression,
+Poppler consumer regression, Binaryen regression, product or public API change,
+crate or dependency change, package or publication change, rendering or hash
+delta, unlisted HLD edit, HLD contradiction, sprint-state mismatch, structural
+indirection, panic, prose violation, smell, or nitpick was found beyond D1.

--- a/.claude/reviews/F-X012-all-pass-6.md
+++ b/.claude/reviews/F-X012-all-pass-6.md
@@ -1,0 +1,138 @@
+# F-X012, all aspects, pass 6
+
+**Reviewed**: the six-file post-pass-3 amendment at
+`b27d067be51d54e149d38369bab530f01c3434b4`, 183 additions and 9 deletions,
+then the complete twelve-file F-X012 delta from
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 1,068 additions and 35 deletions
+**Verdict**: 1 defect, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, normalized stack-key counting misses whitespace before the YAML colon
+
+`scripts/test_sprint_workflow.py:56`
+`scripts/test_sprint_workflow.py:62`
+`scripts/test_sprint_workflow.py:209`
+`scripts/test_sprint_workflow.py:548`
+`scripts/test_sprint_workflow.py:559`
+`.claude/plans/F-X012-design.md:102`
+`.claude/plans/F-X012-design.md:104`
+`docs/hld/15-build-and-toolchain.md:363`
+
+The new helper strips quote characters from the candidate key but does not
+strip whitespace between that key and the colon. YAML treats both
+`RUST_MIN_STACK : "8388608"` and
+`"RUST_MIN_STACK" : "8388608"` as the same `RUST_MIN_STACK` mapping key. A
+focused in-memory mutation added each form to the workflow-global `env`.
+`assert_workspace_oracle_environment_contract()` accepted both and still
+reported only two keys, even though either form widens the stack budget to
+every job. The committed mutations cover unquoted and quoted keys only when
+the colon immediately follows the key. Normalize surrounding key whitespace
+before removing optional quotes, and add at least one spaced-colon mutation to
+make the exclusive scope contract sensitive to ordinary equivalent YAML.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Pass 5 finding disposition
+
+- Pass 5 D1 is partially fixed. The helper now recognizes the exact unquoted,
+  double-quoted, and single-quoted key spellings, and the regression rejects
+  separate global unquoted and double-quoted mutations
+  (`scripts/test_sprint_workflow.py:56`,
+  `scripts/test_sprint_workflow.py:62`,
+  `scripts/test_sprint_workflow.py:549`,
+  `scripts/test_sprint_workflow.py:554`). D1 shows that the same normalization
+  does not yet cover valid whitespace before the mapping colon.
+
+## Focused evidence
+
+- Test and MSRV each retain exactly one pinned official setup action, exact uv
+  0.10.2, disabled action caching, runner-temporary uv caching, and the 8 MiB
+  stack on the named workspace-suite step
+  (`.github/workflows/ci.yml:26`, `.github/workflows/ci.yml:30`,
+  `.github/workflows/ci.yml:42`, `.github/workflows/ci.yml:48`,
+  `.github/workflows/ci.yml:377`, `.github/workflows/ci.yml:381`,
+  `.github/workflows/ci.yml:393`, `.github/workflows/ci.yml:399`). The present
+  workflow has no stack-scope leak. D1 is a regression-gate bypass.
+- The central helper requires the exact action input map, exact local
+  environment map, Cargo command, action ordering, failure propagation, and no
+  successful short circuit in both jobs
+  (`scripts/test_sprint_workflow.py:168`,
+  `scripts/test_sprint_workflow.py:182`,
+  `scripts/test_sprint_workflow.py:192`,
+  `scripts/test_sprint_workflow.py:205`,
+  `scripts/test_sprint_workflow.py:208`). The mutation matrix independently
+  changes action, version, cache, local stack, and exit behavior for Test and
+  MSRV, and routes every mutation through that helper
+  (`scripts/test_sprint_workflow.py:560`,
+  `scripts/test_sprint_workflow.py:565`,
+  `scripts/test_sprint_workflow.py:575`,
+  `scripts/test_sprint_workflow.py:582`,
+  `scripts/test_sprint_workflow.py:591`,
+  `scripts/test_sprint_workflow.py:598`,
+  `scripts/test_sprint_workflow.py:609`).
+- The four focused workflow tests pass, followed by all 44 workflow tests. Both
+  Python files compile. The hash harness remains 28 of 28. Prose, generated-skill
+  synchronization, and diff hygiene pass. The progress record reports the full
+  `rpptx` suite under the exact environment with 19 unit and 86 integration
+  tests passing and 7 ignored
+  (`.claude/scratch/F-X012-progress.md:92`,
+  `.claude/scratch/F-X012-progress.md:97`,
+  `.claude/scratch/F-X012-progress.md:106`).
+- The amendment edits exactly the approved plan, CI workflow, existing workflow
+  regression file, and HLD12, HLD14, and HLD15. The HLD impact list is exact
+  (`.claude/plans/F-X012-design.md:88`,
+  `.claude/plans/F-X012-design.md:92`). HLD12 describes both job commands,
+  HLD14 owns the story gate, and HLD15 owns the exact action, cache, and stack
+  mechanism (`docs/hld/12-testing-strategy.md:458`,
+  `docs/hld/12-testing-strategy.md:468`,
+  `docs/hld/14-development-backlog.md:1300`,
+  `docs/hld/14-development-backlog.md:1308`,
+  `docs/hld/15-build-and-toolchain.md:358`,
+  `docs/hld/15-build-and-toolchain.md:364`). The current-state documents agree.
+
+## Complete feature evidence
+
+- Pass 3's clean dispositions remain valid for the exact Poppler source and
+  checksum, bounded download and streaming extraction, safe archive handling,
+  empty-prefix provenance, all three runtime identities, all four unconditional
+  consumers, and the Binaryen checksum and identity
+  (`.claude/reviews/F-X012-all-pass-3.md:22`,
+  `.claude/reviews/F-X012-all-pass-3.md:48`,
+  `.claude/reviews/F-X012-all-pass-3.md:64`,
+  `.claude/reviews/F-X012-all-pass-3.md:86`). The pass-6 remediation touches
+  only the existing workflow regression file.
+- The installer still verifies the reviewed SHA-256, caps the compressed
+  download, member count, and expanded bytes, streams extraction, rejects
+  unsafe members and populated prefixes, bounds build parallelism to four,
+  verifies every requested tool, and exposes the path only after success
+  (`scripts/install_pinned_poppler.py:18`,
+  `scripts/install_pinned_poppler.py:39`,
+  `scripts/install_pinned_poppler.py:52`,
+  `scripts/install_pinned_poppler.py:60`,
+  `scripts/install_pinned_poppler.py:70`,
+  `scripts/install_pinned_poppler.py:118`,
+  `scripts/install_pinned_poppler.py:161`,
+  `scripts/install_pinned_poppler.py:178`).
+- The complete delta contains no crate source, manifest, lockfile, public API,
+  dependency, package version, publication workflow, rendering baseline, or
+  hash-baseline change. F-X012 remains the sole in-progress S40 story, and the
+  ledgers agree on 165 done, one in progress, and zero pending
+  (`docs/sprints/CURRENT_SPRINT.md:23`, `docs/sprints/BACKLOG.md:32`,
+  `docs/sprints/BACKLOG.md:33`, `docs/sprints/BACKLOG.md:299`).
+
+## Not found
+
+No present workflow stack leak, successful Test or MSRV short circuit, wrong uv
+action or version, enabled action cache, shared active uv cache, incorrect local
+stack value, wrong job ordering, installer correctness or resource regression,
+Poppler consumer regression, Binaryen regression, product or public API change,
+crate or dependency change, package or publication change, rendering or hash
+delta, unlisted HLD edit, HLD contradiction, sprint-state mismatch, structural
+indirection, panic, prose violation, smell, or nitpick was found beyond D1.

--- a/.claude/reviews/F-X012-all-pass-7.md
+++ b/.claude/reviews/F-X012-all-pass-7.md
@@ -1,0 +1,139 @@
+# F-X012, all aspects, pass 7
+
+**Reviewed**: the six-file post-pass-3 amendment at
+`b27d067be51d54e149d38369bab530f01c3434b4`, 193 additions and 9 deletions,
+then the complete twelve-file F-X012 delta from
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 1,078 additions and 35 deletions
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Prior finding dispositions
+
+- Pass 4 D1 remains fixed. Both full workspace steps reject successful
+  short circuits, and Test and MSRV each have an independent `exit 0` mutation
+  (`scripts/test_sprint_workflow.py:192`,
+  `scripts/test_sprint_workflow.py:206`,
+  `scripts/test_sprint_workflow.py:570`,
+  `scripts/test_sprint_workflow.py:608`).
+- Pass 4 D2 and pass 5 D1 remain fixed. The central helper requires exactly two
+  normalized `RUST_MIN_STACK` mapping keys in the workflow, while both named
+  steps require the exact local key and value
+  (`scripts/test_sprint_workflow.py:56`,
+  `scripts/test_sprint_workflow.py:62`,
+  `scripts/test_sprint_workflow.py:198`,
+  `scripts/test_sprint_workflow.py:209`). Separate unquoted and quoted global
+  mutations fail (`scripts/test_sprint_workflow.py:549`,
+  `scripts/test_sprint_workflow.py:554`).
+- Pass 6 D1 is fixed. Candidate-key whitespace is stripped before and after
+  optional quote removal, and independent spaced and quoted-spaced global
+  mutations now fail (`scripts/test_sprint_workflow.py:62`,
+  `scripts/test_sprint_workflow.py:559`,
+  `scripts/test_sprint_workflow.py:564`). An independent probe also confirmed
+  rejection of all four committed forms and a single-quoted spaced form, with
+  three normalized occurrences found in every mutated workflow.
+
+## Focused evidence
+
+- Test and MSRV each retain exactly one reviewed official setup action, exact
+  uv 0.10.2, disabled action caching, a runner-temporary uv cache, and the 8 MiB
+  stack bound only to the named workspace-suite step
+  (`.github/workflows/ci.yml:26`, `.github/workflows/ci.yml:30`,
+  `.github/workflows/ci.yml:42`, `.github/workflows/ci.yml:48`,
+  `.github/workflows/ci.yml:377`, `.github/workflows/ci.yml:381`,
+  `.github/workflows/ci.yml:393`, `.github/workflows/ci.yml:399`). The setup
+  precedes the suite in both jobs, and no other current workflow location sets
+  either runtime variable.
+- The central validation path checks the exact action and input map, exact
+  environment map, Cargo command, ordering, failure propagation, successful
+  short circuits, and workflow-wide stack scope for both jobs
+  (`scripts/test_sprint_workflow.py:168`,
+  `scripts/test_sprint_workflow.py:182`,
+  `scripts/test_sprint_workflow.py:192`,
+  `scripts/test_sprint_workflow.py:205`,
+  `scripts/test_sprint_workflow.py:208`,
+  `scripts/test_sprint_workflow.py:209`). The regression independently mutates
+  action, version, cache, local stack, and exit behavior in Test and MSRV, then
+  sends every mutation through that same path
+  (`scripts/test_sprint_workflow.py:570`,
+  `scripts/test_sprint_workflow.py:575`,
+  `scripts/test_sprint_workflow.py:585`,
+  `scripts/test_sprint_workflow.py:592`,
+  `scripts/test_sprint_workflow.py:601`,
+  `scripts/test_sprint_workflow.py:608`,
+  `scripts/test_sprint_workflow.py:619`).
+- The four focused workflow tests pass, followed by all 44 workflow tests. Both
+  Python files compile. The hash harness remains 28 of 28. Prose, generated-skill
+  synchronization, and diff hygiene pass. The progress record also reports the
+  full `rpptx` suite under the exact runtime with 19 unit and 86 integration
+  tests passing and 7 ignored
+  (`.claude/scratch/F-X012-progress.md:92`,
+  `.claude/scratch/F-X012-progress.md:97`,
+  `.claude/scratch/F-X012-progress.md:108`,
+  `.claude/scratch/F-X012-progress.md:111`).
+
+## Complete feature evidence
+
+- The approved plan requires the exact shared Poppler installer, all four
+  consumer jobs, official Binaryen identity, pinned uv runtime, unchanged
+  rendering baselines, and unchanged hashes
+  (`.claude/plans/F-X012-design.md:35`,
+  `.claude/plans/F-X012-design.md:45`,
+  `.claude/plans/F-X012-design.md:48`,
+  `.claude/plans/F-X012-design.md:52`,
+  `.claude/plans/F-X012-design.md:84`,
+  `.claude/plans/F-X012-design.md:106`). The complete implementation remains
+  within that boundary.
+- Pass 3's clean dispositions remain valid for the exact Poppler source and
+  checksum, bounded download and streaming extraction, safe archive handling,
+  empty-prefix provenance, all three runtime identities, four unconditional
+  consumers, and Binaryen checksum and identity
+  (`.claude/reviews/F-X012-all-pass-3.md:22`,
+  `.claude/reviews/F-X012-all-pass-3.md:48`,
+  `.claude/reviews/F-X012-all-pass-3.md:64`,
+  `.claude/reviews/F-X012-all-pass-3.md:86`). Passes 4 through 7 change only
+  the plan, workflow, existing regression file, and approved HLD files.
+- HLD12 describes the exact Test and MSRV commands and pinned oracle mechanism,
+  HLD14 owns the story test gate, and HLD15 owns the exact Poppler, uv, cache,
+  and stack mechanism (`docs/hld/12-testing-strategy.md:412`,
+  `docs/hld/12-testing-strategy.md:458`,
+  `docs/hld/12-testing-strategy.md:468`,
+  `docs/hld/12-testing-strategy.md:478`,
+  `docs/hld/14-development-backlog.md:1290`,
+  `docs/hld/14-development-backlog.md:1308`,
+  `docs/hld/15-build-and-toolchain.md:345`,
+  `docs/hld/15-build-and-toolchain.md:358`,
+  `docs/hld/15-build-and-toolchain.md:364`). The plan lists exactly HLD12,
+  HLD14, and HLD15 (`.claude/plans/F-X012-design.md:88`,
+  `.claude/plans/F-X012-design.md:92`). Their current-state contracts agree.
+- The complete delta contains no crate source, manifest, lockfile, public API,
+  dependency, package version, publication workflow, rendering baseline, or
+  hash-baseline change. F-X012 remains the sole in-progress S40 story, and the
+  ledgers agree on 165 done, one in progress, and zero pending
+  (`docs/sprints/CURRENT_SPRINT.md:23`, `docs/sprints/BACKLOG.md:32`,
+  `docs/sprints/BACKLOG.md:33`, `docs/sprints/BACKLOG.md:299`). The remaining
+  hosted green run is an explicit completion action, not an implementation
+  defect (`.claude/plans/F-X012-design.md:82`,
+  `.claude/scratch/F-X012-progress.md:117`).
+
+## Not found
+
+No YAML scalar-key normalization bypass among unquoted, quoted, spaced,
+quoted-spaced, or single-quoted-spaced forms, stack-scope leak, successful Test
+or MSRV short circuit, wrong uv action or version, enabled action cache, shared
+active uv cache, incorrect stack value, wrong job ordering, installer
+correctness or resource regression, Poppler consumer regression, Binaryen
+regression, product or public API change, crate or dependency change, package
+or publication change, rendering or hash delta, unlisted HLD edit, HLD
+contradiction, sprint-state mismatch, structural indirection, panic, prose
+violation, smell, or nitpick was found.

--- a/.claude/reviews/F-X012-all-pass-8.md
+++ b/.claude/reviews/F-X012-all-pass-8.md
@@ -1,0 +1,174 @@
+# F-X012, all aspects, pass 8
+
+**Reviewed**: the seven-file authorized LibreOffice amendment at
+`0f3a9243f6ad7d5a60bdf71d196c0ff4fb02a378`, 442 additions and 9 deletions,
+including the untracked authorized installer, then its interaction with the
+complete seventeen-file F-X012 delta from
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 2,055 additions and 40 deletions
+**Verdict**: 3 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, the reviewed Debian packages do not make soffice runnable on minimal Ubuntu
+
+`scripts/install_pinned_libreoffice.py:149`
+`scripts/install_pinned_libreoffice.py:155`
+`scripts/install_pinned_libreoffice.py:161`
+`.github/workflows/ci.yml:40`
+`.github/workflows/ci.yml:393`
+`.claude/plans/F-X012-design.md:61`
+`.claude/plans/F-X012-design.md:68`
+`docs/hld/15-build-and-toolchain.md:366`
+`docs/hld/15-build-and-toolchain.md:373`
+
+The installer gives `apt-get` only the reviewed local Debian packages and
+disables recommended packages. A disposable minimal Ubuntu 24.04 run completed
+that package installation, but the required `soffice --version` command exited
+127. `ldd` identified absent runtime libraries across NSS and NSPR, D-Bus,
+Cairo, GLib, X11, Xext, Xinerama, CUPS, Fontconfig, Freetype, and Kerberos.
+The installer therefore fails at its own identity check before either Test or
+MSRV can run the workspace suite. Provision the explicit reviewed system
+runtime dependency set needed by the official build, while continuing to
+install LibreOffice itself only from the checksum-pinned archive.
+
+### D2, the regression does not prove the installer invokes final identity verification
+
+`scripts/install_pinned_libreoffice.py:146`
+`scripts/install_pinned_libreoffice.py:147`
+`scripts/install_pinned_libreoffice.py:149`
+`scripts/install_pinned_libreoffice.py:161`
+`scripts/test_sprint_workflow.py:141`
+`scripts/test_sprint_workflow.py:510`
+`scripts/test_sprint_workflow.py:596`
+`scripts/test_sprint_workflow.py:612`
+`.claude/plans/F-X012-design.md:97`
+`docs/hld/14-development-backlog.md:1308`
+
+The runtime test calls download, extraction, and identity helpers separately,
+then exercises `install()` only through the populated-prefix early failure. It
+never reaches a successful mocked installation. A focused mutation removed the
+`verify_soffice()` call from `install()`. The lexical installer contract still
+passed, and the complete runtime-guard test also passed against the mutated
+module. The suite consequently permits a future installer to download and
+install packages without verifying the executable that the viewer tests will
+use. Exercise the successful orchestration path with controlled helpers and
+require download, extraction, package installation, identity verification,
+and path exposure in order.
+
+### D3, two declared archive guards can be removed without failing the tests
+
+`scripts/install_pinned_libreoffice.py:86`
+`scripts/install_pinned_libreoffice.py:87`
+`scripts/install_pinned_libreoffice.py:101`
+`scripts/install_pinned_libreoffice.py:107`
+`scripts/test_sprint_workflow.py:141`
+`scripts/test_sprint_workflow.py:553`
+`scripts/test_sprint_workflow.py:566`
+`scripts/test_sprint_workflow.py:573`
+`docs/hld/12-testing-strategy.md:214`
+`docs/hld/14-development-backlog.md:1308`
+
+The archive test covers traversal, but it never supplies a symlink or another
+unsupported non-file member. Its incomplete archive omits both required
+packages, so rejection stops at the core package and never proves that Impress
+is independently required. Focused mutations removed the non-file rejection
+and removed the Impress entry from the required-package tuple one at a time.
+Both the lexical contract and complete runtime-guard test stayed green for
+both mutations. Add an unsupported-member case and construct required-package
+cases that omit core and Impress independently. The HLD promise that behavioral
+regressions execute every source and resource guard does not currently hold.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## LibreOffice amendment evidence
+
+- The official LibreOffice checksum endpoint reports the exact configured
+  SHA-256, and the official archive response reports 218,075,885 bytes, below
+  the 224 MiB download ceiling
+  (`scripts/install_pinned_libreoffice.py:18`,
+  `scripts/install_pinned_libreoffice.py:19`,
+  `scripts/install_pinned_libreoffice.py:20`,
+  `scripts/install_pinned_libreoffice.py:31`). The URL, version, archive name,
+  and checksum are internally consistent.
+- The extraction implementation is streaming and checks member count and
+  declared expanded bytes before writing each member. It enforces one archive
+  root, resolved-path containment, regular-file or directory types, the core
+  and Impress packages, and an absent installation prefix
+  (`scripts/install_pinned_libreoffice.py:63`,
+  `scripts/install_pinned_libreoffice.py:66`,
+  `scripts/install_pinned_libreoffice.py:71`,
+  `scripts/install_pinned_libreoffice.py:74`,
+  `scripts/install_pinned_libreoffice.py:78`,
+  `scripts/install_pinned_libreoffice.py:86`,
+  `scripts/install_pinned_libreoffice.py:101`,
+  `scripts/install_pinned_libreoffice.py:135`). D2 and D3 concern the test
+  contract, not additional defects in those current guard implementations.
+- Test and MSRV each invoke the exact one-line installer step before the named
+  full workspace suite
+  (`.github/workflows/ci.yml:40`, `.github/workflows/ci.yml:44`,
+  `.github/workflows/ci.yml:393`, `.github/workflows/ci.yml:397`). The consumer
+  regression rejects missing, conditional, failure-tolerant, and successfully
+  short-circuited steps in both jobs
+  (`scripts/test_sprint_workflow.py:164`,
+  `scripts/test_sprint_workflow.py:172`,
+  `scripts/test_sprint_workflow.py:485`,
+  `scripts/test_sprint_workflow.py:508`). D1 prevents the currently invoked
+  installer from completing on its target runner.
+- The two LibreOffice tests and four prior focused workflow tests pass, followed
+  by all 46 workflow tests. All three Python files compile and the CI YAML
+  parses. The hash harness remains 28 of 28. Prose, generated-skill
+  synchronization, and diff hygiene pass. These green local results do not
+  cover D1 through D3.
+- The user-authorized new path and hosted trigger are recorded in the progress
+  note (`.claude/scratch/F-X012-progress.md:113`,
+  `.claude/scratch/F-X012-progress.md:121`,
+  `.claude/scratch/F-X012-progress.md:123`). The amendment edits only the
+  approved plan, CI workflow, existing workflow regression file, authorized
+  installer, and HLD12, HLD14, and HLD15
+  (`.claude/plans/F-X012-design.md:107`,
+  `.claude/plans/F-X012-design.md:111`). HLD12 owns the exact viewer oracle,
+  HLD14 owns the story gate, and HLD15 owns installation mechanism
+  (`docs/hld/12-testing-strategy.md:203`,
+  `docs/hld/12-testing-strategy.md:216`,
+  `docs/hld/14-development-backlog.md:1303`,
+  `docs/hld/14-development-backlog.md:1315`,
+  `docs/hld/15-build-and-toolchain.md:366`,
+  `docs/hld/15-build-and-toolchain.md:374`). The HLD files agree with the
+  intended contract, though D1 means the implementation does not yet satisfy
+  their clean-Ubuntu statement.
+
+## Complete feature evidence
+
+- Pass 7 remains clean for the pinned Poppler source and consumers, Binaryen
+  identity, exact uv setup, runner-temporary cache, 8 MiB stack scope, YAML key
+  normalization, and all earlier mutation remediations
+  (`.claude/reviews/F-X012-all-pass-7.md:21`,
+  `.claude/reviews/F-X012-all-pass-7.md:46`,
+  `.claude/reviews/F-X012-all-pass-7.md:85`). The LibreOffice amendment does
+  not alter those implementations.
+- The complete F-X012 delta still contains no crate source, manifest, lockfile,
+  public API, dependency, package version, publication workflow, rendering
+  baseline, or hash-baseline change. The existing macOS Presentation fidelity
+  setup remains separate as required (`.claude/plans/F-X012-design.md:69`,
+  `docs/hld/15-build-and-toolchain.md:373`). F-X012 remains the sole in-progress
+  S40 story, with 165 done, one in progress, and zero pending
+  (`docs/sprints/CURRENT_SPRINT.md:23`, `docs/sprints/BACKLOG.md:32`,
+  `docs/sprints/BACKLOG.md:33`, `docs/sprints/BACKLOG.md:299`).
+
+## Not found
+
+No wrong LibreOffice URL or checksum, archive larger than its declared download
+ceiling, unbounded member-table allocation, current unsafe-path acceptance,
+current unsupported-member acceptance, current missing core or Impress guard,
+populated-prefix reuse, incorrect current identity literal, missing Test or
+MSRV consumer, conditional or failure-tolerant current consumer step, product
+or public API change, crate or dependency change, package or publication
+change, rendering or hash delta, unlisted HLD edit, dependency-direction
+regression, structural indirection, panic, prose violation, smell, or nitpick
+was found beyond D1 through D3.

--- a/.claude/reviews/F-X012-all-pass-9.md
+++ b/.claude/reviews/F-X012-all-pass-9.md
@@ -1,0 +1,144 @@
+# F-X012, all aspects, pass 9
+
+**Reviewed**: the seven-file authorized LibreOffice amendment at
+`0f3a9243f6ad7d5a60bdf71d196c0ff4fb02a378`, 565 additions and 12 deletions,
+including the untracked authorized installer, then its interaction with the
+complete seventeen-file F-X012 delta from
+`a75e2b906eb632d8543ebde9db6922bfda653d44`, 2,178 additions and 43 deletions
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Pass 8 finding dispositions
+
+- D1 is fixed. Test and MSRV are bound to Ubuntu 24.04, and the installer
+  declares all thirteen runtime packages established by the minimal-container
+  failure analysis (`.github/workflows/ci.yml:21`,
+  `.github/workflows/ci.yml:372`,
+  `scripts/install_pinned_libreoffice.py:34`,
+  `scripts/install_pinned_libreoffice.py:48`). It passes those system packages
+  and every checksum-bound local Debian package to one checked `apt-get`
+  invocation before testing the installed executable
+  (`scripts/install_pinned_libreoffice.py:163`,
+  `scripts/install_pinned_libreoffice.py:177`). The progress record accounts
+  for the original exit-127 failure and records that the revised installer ran
+  unchanged in fresh minimal Ubuntu 24.04 and returned the exact build identity
+  (`.claude/scratch/F-X012-progress.md:140`,
+  `.claude/scratch/F-X012-progress.md:148`,
+  `.claude/scratch/F-X012-progress.md:150`).
+- D2 is fixed. The success-path regression controls the archive download,
+  streaming extraction, checked package installation, runtime verification,
+  and GitHub PATH exposure, then requires that exact order
+  (`scripts/test_sprint_workflow.py:680`,
+  `scripts/test_sprint_workflow.py:705`,
+  `scripts/test_sprint_workflow.py:717`,
+  `scripts/test_sprint_workflow.py:720`). Independent focused mutations that
+  removed either the verification call or PATH exposure were rejected.
+- D3 is fixed. Extraction rejects every member that is neither a directory nor
+  a regular file and independently requires the core and Impress Debian
+  packages (`scripts/install_pinned_libreoffice.py:98`,
+  `scripts/install_pinned_libreoffice.py:102`,
+  `scripts/install_pinned_libreoffice.py:116`,
+  `scripts/install_pinned_libreoffice.py:122`). The regression now supplies a
+  symlink and separate archives missing each required package
+  (`scripts/test_sprint_workflow.py:585`,
+  `scripts/test_sprint_workflow.py:607`,
+  `scripts/test_sprint_workflow.py:624`). Independent mutations removing the
+  unsupported-member guard, core requirement, or Impress requirement all
+  failed.
+
+## Focused evidence
+
+- The installer retains the reviewed URL, SHA-256, exact runtime identity,
+  224 MiB download ceiling, 256-member streaming bound, 256 MiB expanded-byte
+  ceiling, safe-root check, and absent-prefix provenance rule
+  (`scripts/install_pinned_libreoffice.py:18`,
+  `scripts/install_pinned_libreoffice.py:33`,
+  `scripts/install_pinned_libreoffice.py:51`,
+  `scripts/install_pinned_libreoffice.py:78`,
+  `scripts/install_pinned_libreoffice.py:89`,
+  `scripts/install_pinned_libreoffice.py:150`). The Test and MSRV consumers
+  invoke only that installer before the full workspace suite
+  (`.github/workflows/ci.yml:40`, `.github/workflows/ci.yml:44`,
+  `.github/workflows/ci.yml:393`, `.github/workflows/ci.yml:397`).
+- The regression pins the exact thirteen-package Ubuntu set and checks that the
+  success-path apt command contains every runtime package and both local core
+  packages (`scripts/test_sprint_workflow.py:155`,
+  `scripts/test_sprint_workflow.py:172`,
+  `scripts/test_sprint_workflow.py:683`,
+  `scripts/test_sprint_workflow.py:690`). A focused mutation removing one
+  runtime package was rejected by the central installer contract. Consumer
+  mutations continue to reject a missing, conditional, failure-tolerant, or
+  successfully short-circuited step in each job
+  (`scripts/test_sprint_workflow.py:182`,
+  `scripts/test_sprint_workflow.py:195`,
+  `scripts/test_sprint_workflow.py:504`,
+  `scripts/test_sprint_workflow.py:527`).
+- The six focused workflow tests pass, followed by all 46 workflow tests. All
+  three installer and workflow Python files compile, and the CI YAML parses.
+  Cargo formatting, prose, generated-skill synchronization, and diff hygiene
+  pass. The hash harness remains 28 of 28. The recorded hosted run remains a
+  required completion action after this amendment is committed, rather than a
+  defect in the reviewed implementation
+  (`.claude/plans/F-X012-design.md:101`,
+  `.claude/plans/F-X012-design.md:105`,
+  `.claude/scratch/F-X012-progress.md:163`,
+  `.claude/scratch/F-X012-progress.md:164`).
+
+## Contract and scope evidence
+
+- The plan requires the exact Ubuntu 24.04 LibreOffice archive, checksum,
+  bounded extraction, explicit runtime libraries, runtime identity, and both
+  unconditional consumers. The implementation satisfies that boundary
+  (`.claude/plans/F-X012-design.md:61`,
+  `.claude/plans/F-X012-design.md:71`,
+  `.claude/plans/F-X012-design.md:98`,
+  `.claude/plans/F-X012-design.md:101`).
+- The plan lists exactly HLD12, HLD14, and HLD15
+  (`.claude/plans/F-X012-design.md:108`,
+  `.claude/plans/F-X012-design.md:112`). HLD12 owns the exact rendering oracle,
+  HLD14 owns its behavioral and hosted gate, and HLD15 owns the Ubuntu install
+  mechanism. All three now agree on Ubuntu 24.04, the reviewed archive and
+  identity, explicit runtime libraries, bounded extraction, and unchanged
+  baselines (`docs/hld/12-testing-strategy.md:211`,
+  `docs/hld/12-testing-strategy.md:218`,
+  `docs/hld/14-development-backlog.md:1303`,
+  `docs/hld/14-development-backlog.md:1317`,
+  `docs/hld/15-build-and-toolchain.md:366`,
+  `docs/hld/15-build-and-toolchain.md:376`).
+- Pass 7 remains clean for the exact Poppler source and consumers, Binaryen
+  identity, pinned uv action, runner-temporary cache, scoped stack budget, and
+  YAML mutation handling (`.claude/reviews/F-X012-all-pass-7.md:21`,
+  `.claude/reviews/F-X012-all-pass-7.md:46`,
+  `.claude/reviews/F-X012-all-pass-7.md:85`). The LibreOffice amendment does
+  not modify those installer implementations or expand product runtime.
+- The complete F-X012 delta still contains no crate source, manifest, lockfile,
+  public API, dependency, package version, publication workflow, rendering
+  baseline, or hash-baseline change. F-X012 remains the sole in-progress S40
+  story, and workflow state remains in implementation
+  (`docs/sprints/CURRENT_SPRINT.md:23`, `docs/sprints/BACKLOG.md:32`,
+  `docs/sprints/BACKLOG.md:33`, `docs/sprints/BACKLOG.md:299`).
+
+## Not found
+
+No missing Ubuntu runtime prerequisite, minimal-container identity failure in
+the revised evidence, wrong runner image, missing package-install check,
+successful orchestration gap, missing final identity verification, missing PATH
+exposure, unsupported archive member acceptance, missing core or Impress guard,
+unbounded archive operation, populated-prefix reuse, unsafe path acceptance,
+wrong LibreOffice source or identity, conditional or failure-tolerant consumer,
+successful consumer short circuit, Poppler or Binaryen regression, product or
+public API change, crate or dependency change, package or publication change,
+rendering or hash delta, unlisted HLD edit, HLD contradiction, sprint-state
+mismatch, structural indirection, panic, prose violation, smell, or nitpick was
+found.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -37,6 +37,8 @@ jobs:
             libfontconfig1-dev libfreetype-dev libjpeg-turbo8-dev \
             libpng-dev libtiff-dev libopenjp2-7-dev liblcms2-dev zlib1g-dev
           python3 scripts/install_pinned_poppler.py
+      - name: Install pinned LibreOffice 26.2.5.2
+        run: python3 scripts/install_pinned_libreoffice.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
       - name: Run full workspace suite
@@ -367,7 +369,7 @@ jobs:
 
   msrv:
     name: MSRV (1.93)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -388,6 +390,8 @@ jobs:
             libfontconfig1-dev libfreetype-dev libjpeg-turbo8-dev \
             libpng-dev libtiff-dev libopenjp2-7-dev liblcms2-dev zlib1g-dev
           python3 scripts/install_pinned_poppler.py
+      - name: Install pinned LibreOffice 26.2.5.2
+        run: python3 scripts/install_pinned_libreoffice.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
       - name: Run full workspace suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Set up uv 0.10.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.2"
+          enable-cache: false
       - name: Install pinned Poppler 26.01.0
         shell: bash
         run: |
@@ -34,7 +39,11 @@ jobs:
           python3 scripts/install_pinned_poppler.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
-      - run: >-
+      - name: Run full workspace suite
+        env:
+          UV_CACHE_DIR: "${{ runner.temp }}/uv-cache"
+          RUST_MIN_STACK: "8388608"
+        run: >-
           cargo test --workspace --all-features
           --exclude rdocx-py --exclude rpptx-py
 
@@ -365,6 +374,11 @@ jobs:
         with:
           toolchain: "1.93"
       - uses: Swatinem/rust-cache@v2
+      - name: Set up uv 0.10.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.2"
+          enable-cache: false
       - name: Install pinned Poppler 26.01.0
         shell: bash
         run: |
@@ -376,7 +390,11 @@ jobs:
           python3 scripts/install_pinned_poppler.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
-      - run: >-
+      - name: Run full workspace suite
+        env:
+          UV_CACHE_DIR: "${{ runner.temp }}/uv-cache"
+          RUST_MIN_STACK: "8388608"
+        run: >-
           cargo test --workspace --all-features
           --exclude rdocx-py --exclude rpptx-py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install pinned Poppler 26.01.0
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            cmake g++ ninja-build pkg-config \
+            libfontconfig1-dev libfreetype-dev libjpeg-turbo8-dev \
+            libpng-dev libtiff-dev libopenjp2-7-dev liblcms2-dev zlib1g-dev
+          python3 scripts/install_pinned_poppler.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
       - run: >-
@@ -46,10 +55,13 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12.9"
-      - name: Install pinned Poppler
+      - name: Install pinned Poppler 26.01.0
         shell: bash
         run: |
-          brew install poppler
+          brew install \
+            cmake ninja pkg-config fontconfig freetype jpeg-turbo \
+            libpng libtiff little-cms2 openjpeg
+          python3 scripts/install_pinned_poppler.py
       - name: Create isolated binding environment
         shell: bash
         run: |
@@ -111,7 +123,7 @@ jobs:
           mkdir -p "$binaryen_root"
           tar --extract --gzip --file "$binaryen_archive" --directory "$binaryen_root" --strip-components=1
           echo "$binaryen_root/bin" >> "$GITHUB_PATH"
-          "$binaryen_root/bin/wasm-opt" --version | grep --fixed-strings --line-regexp "wasm-opt version 125"
+          test "$("$binaryen_root/bin/wasm-opt" --version)" = "wasm-opt version 125 (version_125)"
       - name: Check WASM targets
         shell: bash
         run: |
@@ -206,10 +218,16 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.97.1
       - uses: Swatinem/rust-cache@v2
-      - name: Install pinned render oracle
+      - name: Install pinned LibreOffice
         run: |
           brew install --cask libreoffice
-          brew install poppler
+      - name: Install pinned Poppler 26.01.0
+        shell: bash
+        run: |
+          brew install \
+            cmake ninja pkg-config fontconfig freetype jpeg-turbo \
+            libpng libtiff little-cms2 openjpeg
+          python3 scripts/install_pinned_poppler.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
       - name: Run all-slide SSIM trend and completeness gate
@@ -347,6 +365,15 @@ jobs:
         with:
           toolchain: "1.93"
       - uses: Swatinem/rust-cache@v2
+      - name: Install pinned Poppler 26.01.0
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            cmake g++ ninja-build pkg-config \
+            libfontconfig1-dev libfreetype-dev libjpeg-turbo8-dev \
+            libpng-dev libtiff-dev libopenjp2-7-dev liblcms2-dev zlib1g-dev
+          python3 scripts/install_pinned_poppler.py
       - name: Fetch pinned presentation corpus
         run: python3 scripts/fetch_pptx_corpus.py
       - run: >-

--- a/docs/hld/12-testing-strategy.md
+++ b/docs/hld/12-testing-strategy.md
@@ -409,8 +409,11 @@ The `rpptx` CLI integration gate corrupts a relationship and requires
 `validate` to exit nonzero. It then requires all 50 manifest decks to validate
 with a zero exit and never skips a missing corpus. The primary workspace-test
 job and the MSRV job fetch and verify the pinned corpus before running Cargo
-tests. Command regressions also prove bounded DPI, bounded diff work,
-zero-slide PNG failure without output, and one-slide-at-a-time PNG conversion.
+tests. Both jobs install exact uv 0.10.2 through the reviewed official setup
+action, isolate its cache under the runner temporary directory, and give Rust
+test threads an explicit 8 MiB stack for the largest corpus round trip. Command
+regressions also prove bounded DPI, bounded diff work, zero-slide PNG failure
+without output, and one-slide-at-a-time PNG conversion.
 The thumbnail and outline gate requires an exactly 320-pixel-wide proportional
 slide-one PNG and recursive paragraph output with stable level indentation.
 Regressions cover nonstandard aspect ratios, shared output defaulting, grouped
@@ -452,7 +455,7 @@ returns non-empty rendered HTML after publication.
 
 | Job | Command |
 |---|---|
-| test | Fetch the pinned corpus, then run `cargo test --workspace --all-features --exclude rdocx-py --exclude rpptx-py` |
+| test | Install exact uv 0.10.2, fetch the pinned corpus, then run `cargo test --workspace --all-features --exclude rdocx-py --exclude rpptx-py` with an isolated uv cache and 8 MiB Rust test-thread stack |
 | no-default-features | `cargo test -p oxml-layout --no-default-features` |
 | wasm | Locked `wasm32-unknown-unknown` checks, `wasm-pack test --node`, and local bundler pack and fresh-install gates for `rdocx-wasm` and `rpptx-wasm` |
 | prose | `python3 scripts/prose_check.py` and `python3 scripts/sync_agent_skills.py --check` |
@@ -462,7 +465,7 @@ returns non-empty rendered HTML after publication.
 | fmt | `cargo fmt --all -- --check` |
 | doc | `cargo doc --workspace --no-deps --all-features --exclude rdocx-py --exclude rpptx-py` with `RUSTDOCFLAGS=-D warnings`, then `python3 scripts/readme_doctests.py` |
 | package-oxml-layout | Verify the exact font and legal-file inventory, then build and size-check the verified archive |
-| msrv | Fetch the pinned corpus, then run `cargo test --workspace --all-features --exclude rdocx-py --exclude rpptx-py` under Rust 1.93 |
+| msrv | Install exact uv 0.10.2, fetch the pinned corpus, then run `cargo test --workspace --all-features --exclude rdocx-py --exclude rpptx-py` under Rust 1.93 with an isolated uv cache and 8 MiB Rust test-thread stack |
 | python-bindings | On pull requests, build each Python package with `maturin develop --locked` in its own Python 3.12.9 environment, then run its complete pytest directory |
 | supply-chain | `cargo-deny check` |
 | python-wheels | On manual dispatch or a `py-v*` tag, build six cp39-abi3 wheels for each Python package and one source distribution per package, then install and test every compatible artifact in a fresh environment |

--- a/docs/hld/12-testing-strategy.md
+++ b/docs/hld/12-testing-strategy.md
@@ -472,6 +472,17 @@ The `--exclude` pair on every all-feature command is required, not cosmetic:
 interpreter, which is false for a test binary, and on Linux this is an
 unresolved-symbol link failure that is easy to misdiagnose.
 
+Every Poppler-dependent CI job builds the reviewed 26.01.0 command-line oracle
+from the official source archive. `scripts/install_pinned_poppler.py` enforces
+the exact source SHA-256, an 8 MiB download ceiling, streaming extraction with
+2,048-member and 64 MiB expanded-size ceilings, safe member paths and types,
+and exact runtime identities for `pdftoppm`, `pdfinfo`, and `pdftotext`. A
+successful run always starts with an empty prefix and rebuilds the reviewed
+source. Test, MSRV, both Python binding rows, and Presentation fidelity invoke
+the same unconditional failure-propagating installer before use. Platform
+package managers provide build dependencies only, never a moving Poppler
+binary package.
+
 The wheel workflow runs the installed `rdocx` suites except the
 Poppler-versioned rendering gate, which belongs to its pinned render job. It
 runs the installed `rpptx` documented-example and differential suite. Native
@@ -502,8 +513,9 @@ exact and cannot be satisfied by comments.
 The pull-request WASM job uses exact Node 24.11.1 and wasm-pack 0.15.0. It
 installs the official Binaryen version 125 Linux archive only after verifying
 its pinned SHA-256, places that optimizer on `PATH`, and requires the exact
-version string. It target-checks both WASM packages with `--locked`, then runs
-both inline suites through `wasm-pack test --node`.
+official identity `wasm-opt version 125 (version_125)`. It target-checks both
+WASM packages with `--locked`, then runs both inline suites through
+`wasm-pack test --node`.
 
 Both manifests bind release optimization to `-Oz`,
 `--enable-bulk-memory`, and `--enable-nontrapping-float-to-int`. The last flag

--- a/docs/hld/12-testing-strategy.md
+++ b/docs/hld/12-testing-strategy.md
@@ -208,6 +208,15 @@ LibreOffice 26.2.5.2 with build
 part of the asserted command because a default PDF export omits five corpus
 slides.
 
+Clean Ubuntu 24.04 workspace jobs install that exact LibreOffice build from the
+official Linux x86-64 Debian archive with reviewed SHA-256
+`2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e`.
+The installer bounds the download, archive member count, and expanded bytes,
+rejects unsafe members and populated prefixes, and checks the exact runtime
+identity before the `rpptx-chart` viewer gates execute. The installer supplies
+the explicit NSS, NSPR, D-Bus, Cairo, GLib, X11, CUPS, font, and Kerberos
+runtime libraries required by the official build.
+
 The harness decodes both PNGs through the existing strict decoder and computes
 global luminance SSIM after compositing RGBA over white. It uses population
 variance and covariance with the standard 8-bit constants `K1=0.01`,

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -1289,12 +1289,16 @@ SHA used by the successful GitHub release workflow.
 
 ### F-X012, Restore pinned CI toolchains (M)
 Hosted CI installs the reviewed Poppler 26.01.0 rendering oracle from its exact
-source archive rather than a moving package-manager version. Every job that
-executes a Poppler-dependent gate uses that installation. The WASM job verifies
-the official Binaryen 125 Linux archive and its exact release identity without
-assuming the shorter Homebrew version string. Product code, package versions,
-published artifacts, and rendering baselines remain unchanged.
-**Test gate**: the workflow contract rejects missing Poppler jobs, version or
-checksum drift, and a weakened Binaryen identity check. Full verification and
-a hosted pull-request CI run at the reviewed SHA pass with all 28 hashes
-unchanged.
+source archive and SHA-256 rather than a moving package-manager version. The
+shared installer bounds download and streaming extraction resources, rejects
+unsafe archive members and populated prefixes, builds only the three required
+tools, and verifies each runtime identity. Test, MSRV, both Python binding rows,
+and Presentation fidelity invoke it unconditionally before use. The WASM job
+verifies the official Binaryen 125 Linux archive and exact
+`wasm-opt version 125 (version_125)` release identity. Product code, package
+versions, published artifacts, and rendering baselines remain unchanged.
+**Test gate**: behavioral regressions execute every source, resource, runtime,
+and prefix guard. Workflow mutations reject missing, conditional,
+failure-tolerant, or successfully short-circuited installer steps and reject a
+weakened Binaryen checksum or identity gate. Full verification and a hosted
+pull-request CI run at the reviewed SHA pass with all 28 hashes unchanged.

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -1297,8 +1297,12 @@ and Presentation fidelity invoke it unconditionally before use. The WASM job
 verifies the official Binaryen 125 Linux archive and exact
 `wasm-opt version 125 (version_125)` release identity. Product code, package
 versions, published artifacts, and rendering baselines remain unchanged.
+Test and MSRV also install exact uv 0.10.2 through the reviewed official setup
+action, isolate its cache, and run their corpus tests with an explicit 8 MiB
+Rust test-thread stack.
 **Test gate**: behavioral regressions execute every source, resource, runtime,
 and prefix guard. Workflow mutations reject missing, conditional,
 failure-tolerant, or successfully short-circuited installer steps and reject a
-weakened Binaryen checksum or identity gate. Full verification and a hosted
-pull-request CI run at the reviewed SHA pass with all 28 hashes unchanged.
+weakened Binaryen checksum or identity gate. They also reject uv action,
+version, cache, or stack drift. Full verification and a hosted pull-request CI
+run at the reviewed SHA pass with all 28 hashes unchanged.

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -1300,9 +1300,18 @@ versions, published artifacts, and rendering baselines remain unchanged.
 Test and MSRV also install exact uv 0.10.2 through the reviewed official setup
 action, isolate its cache, and run their corpus tests with an explicit 8 MiB
 Rust test-thread stack.
+They run on Ubuntu 24.04 and install LibreOffice 26.2.5.2 from the reviewed official Linux x86-64
+archive before the full workspace suite. The shared installer verifies SHA-256
+`2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e`,
+uses bounded streaming extraction, refuses populated prefixes, and checks the
+exact reviewed build identity before the three `rpptx-chart` viewer gates run.
+The installer also declares the exact Ubuntu runtime-library package set needed
+to execute that official build.
 **Test gate**: behavioral regressions execute every source, resource, runtime,
 and prefix guard. Workflow mutations reject missing, conditional,
 failure-tolerant, or successfully short-circuited installer steps and reject a
 weakened Binaryen checksum or identity gate. They also reject uv action,
-version, cache, or stack drift. Full verification and a hosted pull-request CI
-run at the reviewed SHA pass with all 28 hashes unchanged.
+version, cache, or stack drift. The same contract rejects LibreOffice version,
+checksum, bound, runtime, ordering, or consumer-step drift. Full verification
+and a hosted pull-request CI run at the reviewed SHA pass with all 28 hashes
+unchanged.

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -1286,3 +1286,15 @@ archive inventory, 28-entry hash harness, WASM package gate, and supply-chain
 gate pass. All fourteen crates resolve at 0.2.0 under owner `mantissaman`, each
 crates.io README is present, and the annotated tag targets the reviewed sprint
 SHA used by the successful GitHub release workflow.
+
+### F-X012, Restore pinned CI toolchains (M)
+Hosted CI installs the reviewed Poppler 26.01.0 rendering oracle from its exact
+source archive rather than a moving package-manager version. Every job that
+executes a Poppler-dependent gate uses that installation. The WASM job verifies
+the official Binaryen 125 Linux archive and its exact release identity without
+assuming the shorter Homebrew version string. Product code, package versions,
+published artifacts, and rendering baselines remain unchanged.
+**Test gate**: the workflow contract rejects missing Poppler jobs, version or
+checksum drift, and a weakened Binaryen identity check. Full verification and
+a hosted pull-request CI run at the reviewed SHA pass with all 28 hashes
+unchanged.

--- a/docs/hld/15-build-and-toolchain.md
+++ b/docs/hld/15-build-and-toolchain.md
@@ -304,7 +304,8 @@ crates with the locked workspace graph. It then runs both packages' inline Node
 regressions. It installs the official Binaryen version 125 Linux archive after
 checking exact SHA-256
 `7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4`,
-places its `wasm-opt` on `PATH`, and verifies the exact version.
+places its `wasm-opt` on `PATH`, and verifies the exact official identity
+`wasm-opt version 125 (version_125)`.
 
 Both WASM manifests use release optimization arguments `-Oz`,
 `--enable-bulk-memory`, and `--enable-nontrapping-float-to-int`. The job builds
@@ -340,6 +341,19 @@ condition. Workflow permissions are exactly repository content read, with no
 OIDC token grant. Checkout v6.0.2, setup-python v6.2.0, rust-cache v2.9.1, and
 the selected stable rust-toolchain revision use reviewed full commit SHAs and
 exact input maps.
+
+**One checksum-pinned Poppler installer.**
+`scripts/install_pinned_poppler.py` downloads the official 26.01.0 source
+archive, verifies SHA-256
+`1cb944a4b88847f5fb6551683bc799db59f04990f5d8be07aba2acbf38601089`,
+and builds only `pdftoppm`, `pdfinfo`, and `pdftotext` in an isolated directory.
+It caps the download at 8 MiB and streams at most 2,048 safe archive members
+with at most 64 MiB of expanded content. A populated prefix fails closed, so a
+successful invocation cannot substitute unrelated binaries that print the
+right version. All three finished tools must report exact 26.01.0 identities.
+Test, MSRV, both Python binding rows, and Presentation fidelity use this single
+unconditional step before any oracle-dependent command. Package managers may
+install build prerequisites but do not install Poppler itself.
 
 **A prose and generated-skill job.** It runs `scripts/prose_check.py` and
 `scripts/sync_agent_skills.py --check` as separate steps, so voice-rule or

--- a/docs/hld/15-build-and-toolchain.md
+++ b/docs/hld/15-build-and-toolchain.md
@@ -355,6 +355,14 @@ Test, MSRV, both Python binding rows, and Presentation fidelity use this single
 unconditional step before any oracle-dependent command. Package managers may
 install build prerequisites but do not install Poppler itself.
 
+**Pinned corpus-test runtime.** Test and MSRV install uv 0.10.2 with official
+`astral-sh/setup-uv` commit
+`20cfd1bf945f4377ade1205e4dbc17946fc9a30d`. Each job disables the action cache,
+uses only its runner-temporary uv cache, and runs the broad workspace suite with
+`RUST_MIN_STACK=8388608`. The pin makes the python-pptx oracle executable
+available on a clean Ubuntu host. The stack budget is scoped to these two
+corpus-heavy jobs and does not alter product runtime behavior.
+
 **A prose and generated-skill job.** It runs `scripts/prose_check.py` and
 `scripts/sync_agent_skills.py --check` as separate steps, so voice-rule or
 adapter drift fails before integration.

--- a/docs/hld/15-build-and-toolchain.md
+++ b/docs/hld/15-build-and-toolchain.md
@@ -363,6 +363,18 @@ uses only its runner-temporary uv cache, and runs the broad workspace suite with
 available on a clean Ubuntu host. The stack budget is scoped to these two
 corpus-heavy jobs and does not alter product runtime behavior.
 
+The same two clean Ubuntu 24.04 jobs install LibreOffice 26.2.5.2 from the official
+Linux x86-64 Debian archive before the workspace suite. The archive SHA-256 is
+`2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e`.
+The installer streams under fixed download, member, and expanded-byte bounds,
+rejects unsafe entries and any populated `/opt/libreoffice26.2` prefix, then
+requires exact identity
+`LibreOffice 26.2.5.2 cd7284b4cbbfeb507e630c1aac019f4157393acb`.
+It installs the explicit Ubuntu NSS, NSPR, D-Bus, Cairo, GLib, X11, CUPS,
+font, and Kerberos runtime-library set needed by that official build. This
+makes the unconditional `rpptx-chart` viewer tests self-contained without
+changing the separate macOS Presentation fidelity setup.
+
 **A prose and generated-skill job.** It runs `scripts/prose_check.py` and
 `scripts/sync_agent_skills.py --check` as separate steps, so voice-rule or
 adapter drift fails before integration.

--- a/docs/sprints/BACKLOG.md
+++ b/docs/sprints/BACKLOG.md
@@ -29,8 +29,8 @@ regenerated, never hand-edited.
 | M11, Write API                              | 12 | 12 | 0 | 0  |
 | M12, Charts                                 | 12 | 12 | 0 | 0  |
 | M13, Bindings and tooling                   | 18 | 18 | 0 | 0  |
-| X, Cross-cutting (opportunistic)            | 12 | 11 | 0 | 1  |
-| **Total** | **166** | **165** | **0** | **1** |
+| X, Cross-cutting (opportunistic)            | 12 | 11 | 1 | 0  |
+| **Total** | **166** | **165** | **1** | **0** |
 <!-- AUTOGEN:backlog-summary END -->
 
 ## All F-IDs
@@ -296,5 +296,5 @@ regenerated, never hand-edited.
 | F-X009 | README coverage for every workspace crate   | S39 | L | done |
 | F-X010 | Tag v0.6.0                                  | S39 | S | done |
 | F-X011 | Tag rpptx-v0.2.0                            | S39 | S | done |
-| F-X012 | Restore pinned CI toolchains                | S40 | M | pending |
+| F-X012 | Restore pinned CI toolchains                | S40 | M | in-progress |
 <!-- AUTOGEN:backlog-MX END -->

--- a/docs/sprints/BACKLOG.md
+++ b/docs/sprints/BACKLOG.md
@@ -29,8 +29,8 @@ regenerated, never hand-edited.
 | M11, Write API                              | 12 | 12 | 0 | 0  |
 | M12, Charts                                 | 12 | 12 | 0 | 0  |
 | M13, Bindings and tooling                   | 18 | 18 | 0 | 0  |
-| X, Cross-cutting (opportunistic)            | 11 | 11 | 0 | 0  |
-| **Total** | **165** | **165** | **0** | **0** |
+| X, Cross-cutting (opportunistic)            | 12 | 11 | 0 | 1  |
+| **Total** | **166** | **165** | **0** | **1** |
 <!-- AUTOGEN:backlog-summary END -->
 
 ## All F-IDs
@@ -296,4 +296,5 @@ regenerated, never hand-edited.
 | F-X009 | README coverage for every workspace crate   | S39 | L | done |
 | F-X010 | Tag v0.6.0                                  | S39 | S | done |
 | F-X011 | Tag rpptx-v0.2.0                            | S39 | S | done |
+| F-X012 | Restore pinned CI toolchains                | S40 | M | pending |
 <!-- AUTOGEN:backlog-MX END -->

--- a/docs/sprints/CURRENT_SPRINT.md
+++ b/docs/sprints/CURRENT_SPRINT.md
@@ -20,7 +20,7 @@ without changing product output or recorded rendering baselines.
 
 | F-ID | Title | Size | Status | Owner |
 |------|-------|------|--------|-------|
-| F-X012 | Restore pinned CI toolchains | M | pending | - |
+| F-X012 | Restore pinned CI toolchains | M | in-progress | codex |
 
 ## Sequencing note
 

--- a/docs/sprints/CURRENT_SPRINT.md
+++ b/docs/sprints/CURRENT_SPRINT.md
@@ -1,47 +1,42 @@
-# Current Sprint, S39
+# Current Sprint, S40
 
 **Milestone**: X Cross-cutting.
 
-**Goal**: every Cargo workspace package has documentation at its package
-boundary, and every crates.io-eligible package publishes that documentation at
-the next minor version through its exact release family.
+**Goal**: restore a green hosted CI baseline after runner and package-manager
+updates exposed unpinned or incorrectly validated external tools. Preserve the
+reviewed Poppler 26.01.0 rendering oracle and Binaryen 125 optimizer boundary
+without changing product output or recorded rendering baselines.
 
 ## Spec references
 
-- `docs/hld/12-testing-strategy.md`, for README compilation and package
-  inventory gates.
-- `docs/hld/11-migration-plan.md`, for the stable family release boundary.
-- `docs/hld/03-architecture.md`, for the incubating family version boundary.
-- `docs/hld/14-development-backlog.md`, for the exact F-X009, F-X010, and
-  F-X011 acceptance gates.
-- `docs/hld/15-build-and-toolchain.md`, for package metadata and publication
-  boundaries.
+- `docs/hld/12-testing-strategy.md`, for the exact Poppler rendering oracle and
+  output-stability gates.
+- `docs/hld/14-development-backlog.md`, for the F-X012 scope and hosted CI
+  acceptance gate.
+- `docs/hld/15-build-and-toolchain.md`, for deterministic external-tool
+  installation and CI job ownership.
 
 ## The wave
 
 | F-ID | Title | Size | Status | Owner |
 |------|-------|------|--------|-------|
-| F-X009 | README coverage for every workspace crate | L | done | |
-| F-X010 | Tag v0.6.0 | S | done | |
-| F-X011 | Tag rpptx-v0.2.0 | S | done | |
+| F-X012 | Restore pinned CI toolchains | M | pending | - |
 
 ## Sequencing note
 
-The documentation story completes first. The stable train then moves to 0.6.0
-and publishes seven crates. After that release is verified, the incubating
-train moves to 0.2.0 and publishes fourteen crates. The five `publish = false`
-packages move with their local train but are not published.
+There is one CI restoration story. It first pins and validates the shared
+external tools, then runs the complete hosted workflow so platform-specific
+failures are covered before sprint closure.
 
 ## Definition of done for this sprint
 
-- All 26 workspace packages declare a README.
-- Every README states purpose, audience, package relationships, and a concrete
-  usage example.
-- Rust examples compile where applicable, and CLI, Python, and JavaScript
-  examples pass exact syntax and package-name contracts.
-- Every publishable archive contains exactly one intended README.
+- Every CI job that executes a Poppler-dependent gate installs and verifies
+  Poppler 26.01.0 from the checksum-pinned source.
+- The WASM job accepts only the exact official Binaryen 125 Linux version
+  identity after verifying the reviewed archive checksum.
+- The workflow contract rejects missing pins, omitted jobs, weakened version
+  checks, and package-manager drift.
 - `/verify --full` passes with all 28 deterministic hashes unchanged.
-- All seven stable crates publish at 0.6.0 and render their README on crates.io.
-- All fourteen incubating crates publish at 0.2.0 and render their README on
-  crates.io.
-- Python, WASM, npm, and PyPI publication authority remains unchanged.
+- A hosted pull-request CI run at the reviewed SHA completes every job
+  successfully.
+- No crate, release version, package publication, or rendering baseline changes.

--- a/docs/sprints/SPRINT_PLAN.md
+++ b/docs/sprints/SPRINT_PLAN.md
@@ -5,7 +5,7 @@ are dependency and review boundaries, not fixed two-week containers. Sprint
 clocks start at the first `/start-feature` of that sprint, not at a fixed
 calendar date.
 
-39 numbered sprints plus two deferred cutover sprints across 13 milestones,
+40 numbered sprints plus two deferred cutover sprints across 13 milestones,
 roughly 390 developer-days. The sizing rationale and compression options are in
 `docs/hld/14-development-backlog.md`.
 
@@ -613,6 +613,23 @@ WASM packages receive accurate local usage examples without gaining any new
 publication authority. F-X010 publishes the seven stable crates first. F-X011
 then publishes the fourteen incubating crates. Each tag has its own full
 verification, clean review, and immediate release approval boundary.
+
+#### Sprint S40, Restore pinned CI toolchains
+
+**Goal**: restore a green hosted CI baseline after runner and package-manager
+updates exposed unpinned or incorrectly validated external tools. Keep the
+reviewed Poppler 26.01.0 rendering oracle and Binaryen 125 optimizer boundary
+without changing product output or recorded rendering baselines.
+
+| F-ID | Title | Size |
+|------|-------|------|
+| F-X012 | Restore pinned CI toolchains | M |
+
+The story installs checksum-pinned Poppler 26.01.0 for every job that executes
+its oracle-dependent tests, validates the official Binaryen 125 Linux version
+string, and proves the complete pull-request workflow on a hosted runner. It
+does not change a crate, release version, published package, or rendering
+baseline.
 
 ## Cross-cutting
 

--- a/scripts/install_pinned_libreoffice.py
+++ b/scripts/install_pinned_libreoffice.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Install the exact LibreOffice Linux viewer oracle used by CI."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import platform
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+
+
+LIBREOFFICE_VERSION = "26.2.5.2"
+LIBREOFFICE_SHA256 = "2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e"
+LIBREOFFICE_ARCHIVE = "LibreOffice_26.2.5_Linux_x86-64_deb.tar.gz"
+LIBREOFFICE_URL = (
+    "https://download.documentfoundation.org/libreoffice/stable/26.2.5/"
+    f"deb/x86_64/{LIBREOFFICE_ARCHIVE}"
+)
+ARCHIVE_ROOT = f"LibreOffice_{LIBREOFFICE_VERSION}_Linux_x86-64_deb"
+INSTALL_ROOT = Path("/opt/libreoffice26.2")
+SOFFICE = INSTALL_ROOT / "program/soffice"
+EXPECTED_IDENTITY = (
+    "LibreOffice 26.2.5.2 cd7284b4cbbfeb507e630c1aac019f4157393acb"
+)
+MAX_DOWNLOAD_BYTES = 224 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 256
+MAX_EXTRACTED_BYTES = 256 * 1024 * 1024
+SYSTEM_RUNTIME_PACKAGES = (
+    "libcairo2",
+    "libcups2t64",
+    "libdbus-1-3",
+    "libfontconfig1",
+    "libfreetype6",
+    "libglib2.0-0t64",
+    "libgssapi-krb5-2",
+    "libnspr4",
+    "libnss3",
+    "libx11-6",
+    "libx11-xcb1",
+    "libxext6",
+    "libxinerama1",
+)
+
+
+def download_archive(destination: Path) -> None:
+    digest = hashlib.sha256()
+    written = 0
+    request = urllib.request.Request(
+        LIBREOFFICE_URL,
+        headers={"User-Agent": "rdocx-ci-libreoffice-installer/1"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response, destination.open(
+        "wb"
+    ) as output:
+        while chunk := response.read(1024 * 1024):
+            written += len(chunk)
+            if written > MAX_DOWNLOAD_BYTES:
+                raise RuntimeError("LibreOffice archive exceeds the download bound")
+            digest.update(chunk)
+            output.write(chunk)
+    if digest.hexdigest() != LIBREOFFICE_SHA256:
+        raise RuntimeError(
+            "LibreOffice archive SHA-256 does not match the reviewed source"
+        )
+
+
+def safe_extract(archive_path: Path, destination: Path) -> Path:
+    destination = destination.resolve()
+    destination.mkdir(parents=True)
+    member_count = 0
+    extracted_bytes = 0
+    with tarfile.open(archive_path, mode="r|gz") as archive:
+        for member in archive:
+            member_count += 1
+            if member_count > MAX_ARCHIVE_MEMBERS:
+                raise RuntimeError("LibreOffice archive exceeds the member-count bound")
+            if member.size < 0:
+                raise RuntimeError("LibreOffice archive contains a negative member size")
+            extracted_bytes += member.size
+            if extracted_bytes > MAX_EXTRACTED_BYTES:
+                raise RuntimeError("LibreOffice archive exceeds the extracted-size bound")
+            member_path = Path(member.name)
+            if not member_path.parts or member_path.parts[0] != ARCHIVE_ROOT:
+                raise RuntimeError("LibreOffice archive has an unexpected root layout")
+            target = (destination / member_path).resolve()
+            try:
+                target.relative_to(destination)
+            except ValueError as error:
+                raise RuntimeError(
+                    "LibreOffice archive contains an unsafe path"
+                ) from error
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise RuntimeError("LibreOffice archive contains a non-file entry")
+            source = archive.extractfile(member)
+            if source is None:
+                raise RuntimeError("LibreOffice archive member could not be read")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            target.chmod(stat.S_IMODE(member.mode))
+
+    source_root = destination / ARCHIVE_ROOT
+    deb_root = source_root / "DEBS"
+    packages = tuple(sorted(deb_root.glob("*.deb")))
+    if not packages:
+        raise RuntimeError("LibreOffice archive contains no Debian packages")
+    required = (
+        f"libobasis26.2-core_{LIBREOFFICE_VERSION}-2_amd64.deb",
+        f"libreoffice26.2-impress_{LIBREOFFICE_VERSION}-2_amd64.deb",
+    )
+    for package in required:
+        if not (deb_root / package).is_file():
+            raise RuntimeError(f"LibreOffice archive is missing {package}")
+    return deb_root
+
+
+def verify_soffice(executable: Path = SOFFICE) -> None:
+    if not executable.is_file():
+        raise RuntimeError(f"missing LibreOffice executable: {executable}")
+    result = subprocess.run(
+        [str(executable), "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    actual = result.stdout.strip() or result.stderr.strip()
+    if actual.splitlines()[:1] != [EXPECTED_IDENTITY]:
+        raise RuntimeError(f"unexpected LibreOffice identity: {actual!r}")
+
+
+def expose_soffice(executable: Path = SOFFICE) -> None:
+    github_path = os.environ.get("GITHUB_PATH")
+    if github_path:
+        with Path(github_path).open("a", encoding="utf-8") as path_file:
+            path_file.write(f"{executable.parent}\n")
+
+
+def install() -> None:
+    if platform.system() != "Linux" or platform.machine() != "x86_64":
+        raise RuntimeError("the pinned LibreOffice installer requires Linux x86_64")
+    if INSTALL_ROOT.exists():
+        raise RuntimeError(
+            f"LibreOffice prefix must be absent before installation: {INSTALL_ROOT}"
+        )
+
+    runner_temp = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir()))
+    with tempfile.TemporaryDirectory(
+        prefix="rdocx-libreoffice-", dir=runner_temp
+    ) as work:
+        work_root = Path(work)
+        archive_path = work_root / LIBREOFFICE_ARCHIVE
+        download_archive(archive_path)
+        deb_root = safe_extract(archive_path, work_root / "source")
+        packages = tuple(str(package) for package in sorted(deb_root.glob("*.deb")))
+        subprocess.run(
+            [
+                "sudo",
+                "apt-get",
+                "install",
+                "--yes",
+                "--no-install-recommends",
+                *SYSTEM_RUNTIME_PACKAGES,
+                *packages,
+            ],
+            check=True,
+        )
+
+    verify_soffice()
+    expose_soffice()
+    print(f"Installed LibreOffice {LIBREOFFICE_VERSION} from reviewed packages")
+
+
+if __name__ == "__main__":
+    install()

--- a/scripts/install_pinned_poppler.py
+++ b/scripts/install_pinned_poppler.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Build the exact Poppler command-line oracle used by CI."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+
+
+POPLER_VERSION = "26.01.0"
+POPLER_SHA256 = "1cb944a4b88847f5fb6551683bc799db59f04990f5d8be07aba2acbf38601089"
+POPLER_URL = f"https://poppler.freedesktop.org/poppler-{POPLER_VERSION}.tar.xz"
+TOOLS = ("pdftoppm", "pdfinfo", "pdftotext")
+MAX_DOWNLOAD_BYTES = 8 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 2_048
+MAX_EXTRACTED_BYTES = 64 * 1024 * 1024
+
+
+def download_archive(destination: Path) -> None:
+    digest = hashlib.sha256()
+    written = 0
+    request = urllib.request.Request(
+        POPLER_URL,
+        headers={"User-Agent": "rdocx-ci-poppler-installer/1"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response, destination.open(
+        "wb"
+    ) as output:
+        while chunk := response.read(1024 * 1024):
+            written += len(chunk)
+            if written > MAX_DOWNLOAD_BYTES:
+                raise RuntimeError("Poppler archive exceeds the download bound")
+            digest.update(chunk)
+            output.write(chunk)
+    if digest.hexdigest() != POPLER_SHA256:
+        raise RuntimeError("Poppler archive SHA-256 does not match the reviewed source")
+
+
+def safe_extract(archive_path: Path, destination: Path) -> Path:
+    destination = destination.resolve()
+    destination.mkdir(parents=True)
+    member_count = 0
+    extracted_bytes = 0
+    with tarfile.open(archive_path, mode="r|xz") as archive:
+        for member in archive:
+            member_count += 1
+            if member_count > MAX_ARCHIVE_MEMBERS:
+                raise RuntimeError("Poppler archive exceeds the member-count bound")
+            if member.size < 0:
+                raise RuntimeError("Poppler archive contains a negative member size")
+            extracted_bytes += member.size
+            if extracted_bytes > MAX_EXTRACTED_BYTES:
+                raise RuntimeError("Poppler archive exceeds the extracted-size bound")
+            target = (destination / member.name).resolve()
+            try:
+                target.relative_to(destination)
+            except ValueError as error:
+                raise RuntimeError("Poppler archive contains an unsafe path") from error
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise RuntimeError("Poppler archive contains a non-file entry")
+            source = archive.extractfile(member)
+            if source is None:
+                raise RuntimeError("Poppler archive member could not be read")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            target.chmod(stat.S_IMODE(member.mode))
+
+    source_root = destination / f"poppler-{POPLER_VERSION}"
+    if not (source_root / "CMakeLists.txt").is_file():
+        raise RuntimeError("Poppler archive has an unexpected root layout")
+    return source_root
+
+
+def run(command: list[str]) -> None:
+    subprocess.run(command, check=True)
+
+
+def verify_tools(prefix: Path) -> None:
+    for tool in TOOLS:
+        executable = prefix / "bin" / tool
+        if not executable.is_file():
+            raise RuntimeError(f"missing Poppler tool: {executable}")
+        result = subprocess.run(
+            [str(executable), "-v"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        lines = tuple(
+            line.strip()
+            for line in (result.stdout + result.stderr).splitlines()
+            if line.strip()
+        )
+        expected = f"{tool} version {POPLER_VERSION}"
+        if not lines or lines[0] != expected:
+            raise RuntimeError(f"unexpected {tool} identity: {lines[:1]}")
+
+
+def expose_tools(prefix: Path) -> None:
+    github_path = os.environ.get("GITHUB_PATH")
+    if github_path:
+        with Path(github_path).open("a", encoding="utf-8") as path_file:
+            path_file.write(f"{prefix / 'bin'}\n")
+
+
+def build(prefix: Path) -> None:
+    prefix = prefix.resolve()
+    if prefix.exists() and (not prefix.is_dir() or any(prefix.iterdir())):
+        raise RuntimeError(
+            f"Poppler prefix must be empty so the reviewed source is rebuilt: {prefix}"
+        )
+
+    runner_temp = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir()))
+    with tempfile.TemporaryDirectory(prefix="rdocx-poppler-", dir=runner_temp) as work:
+        work_root = Path(work)
+        archive_path = work_root / f"poppler-{POPLER_VERSION}.tar.xz"
+        download_archive(archive_path)
+        source_root = safe_extract(archive_path, work_root / "source")
+        build_root = work_root / "build"
+        configure = [
+            "cmake",
+            "-S",
+            str(source_root),
+            "-B",
+            str(build_root),
+            "-G",
+            "Ninja",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DENABLE_UTILS=ON",
+            "-DENABLE_CPP=OFF",
+            "-DENABLE_GLIB=OFF",
+            "-DENABLE_GOBJECT_INTROSPECTION=OFF",
+            "-DENABLE_QT5=OFF",
+            "-DENABLE_QT6=OFF",
+            "-DENABLE_BOOST=OFF",
+            "-DENABLE_LIBCURL=OFF",
+            "-DENABLE_NSS3=OFF",
+            "-DENABLE_GPGME=OFF",
+            "-DBUILD_GTK_TESTS=OFF",
+            "-DBUILD_QT5_TESTS=OFF",
+            "-DBUILD_QT6_TESTS=OFF",
+            "-DBUILD_CPP_TESTS=OFF",
+            "-DBUILD_MANUAL_TESTS=OFF",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DENABLE_UNSTABLE_API_ABI_HEADERS=OFF",
+            "-DRUN_GPERF_IF_PRESENT=OFF",
+        ]
+        run(configure)
+        jobs = max(1, min(os.cpu_count() or 1, 4))
+        run(
+            [
+                "cmake",
+                "--build",
+                str(build_root),
+                "--parallel",
+                str(jobs),
+                "--target",
+                *TOOLS,
+            ]
+        )
+        binary_root = prefix / "bin"
+        binary_root.mkdir(parents=True, exist_ok=True)
+        for tool in TOOLS:
+            shutil.copy2(build_root / "utils" / tool, binary_root / tool)
+
+    verify_tools(prefix)
+    expose_tools(prefix)
+    print(f"Installed Poppler {POPLER_VERSION} at {prefix}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_prefix = Path(
+        os.environ.get("RUNNER_TEMP", tempfile.gettempdir())
+    ) / f"poppler-{POPLER_VERSION}"
+    parser.add_argument("--prefix", type=Path, default=default_prefix)
+    arguments = parser.parse_args()
+    build(arguments.prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_sprint_workflow.py
+++ b/scripts/test_sprint_workflow.py
@@ -53,6 +53,17 @@ class SprintWorkflowTests(unittest.TestCase):
             if line.strip() and not line.lstrip().startswith("#")
         )
 
+    def yaml_mapping_key_count(self, source: str, key: str) -> int:
+        count = 0
+        for line in source.splitlines():
+            stripped = line.strip().split(" #", 1)[0].rstrip()
+            if not stripped or stripped.startswith("#") or ":" not in stripped:
+                continue
+            candidate = stripped.split(":", 1)[0].strip().strip("'\"").strip()
+            if candidate == key:
+                count += 1
+        return count
+
     def yaml_steps(self, job: str) -> tuple[str, ...]:
         steps = self.yaml_block(job, "    steps:")
         lines = steps.splitlines()[1:]
@@ -153,6 +164,49 @@ class SprintWorkflowTests(unittest.TestCase):
         self.assertEqual(ci.count("python3 scripts/install_pinned_poppler.py"), 4)
         self.assertNotIn("brew install poppler", ci)
         self.assertNotIn("apt-get install poppler-utils", ci)
+
+    def assert_workspace_oracle_environment_contract(self, ci: str) -> None:
+        setup_action = (
+            "astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d"
+        )
+        for job_name in ("test", "msrv"):
+            job = self.yaml_block(ci, f"  {job_name}:")
+            steps = self.yaml_steps(job)
+            setup_steps = tuple(
+                step
+                for step in steps
+                if self.yaml_step_actions(step) == (setup_action,)
+            )
+            self.assertEqual(len(setup_steps), 1, job_name)
+            setup = setup_steps[0]
+            self.assertEqual(
+                self.yaml_direct_lines(setup, 8),
+                (f"uses: {setup_action}", "with:"),
+            )
+            setup_with = self.yaml_block(setup, "        with:")
+            self.assertEqual(
+                self.yaml_direct_lines(setup_with, 10),
+                ('version: "0.10.2"', "enable-cache: false"),
+            )
+
+            test_step = self.yaml_step(job, "Run full workspace suite")
+            self.assertEqual(
+                self.yaml_direct_lines(test_step, 8),
+                ("env:", "run: >-"),
+            )
+            environment = self.yaml_block(test_step, "        env:")
+            self.assertEqual(
+                self.yaml_direct_lines(environment, 10),
+                (
+                    'UV_CACHE_DIR: "${{ runner.temp }}/uv-cache"',
+                    'RUST_MIN_STACK: "8388608"',
+                ),
+            )
+            self.assertIn("cargo test --workspace", test_step)
+            self.assert_no_success_short_circuit(self.operative_lines(test_step))
+            self.assertLess(job.index(setup), job.index(test_step))
+            self.assertNotIn("continue-on-error", setup + test_step)
+        self.assertEqual(self.yaml_mapping_key_count(ci, "RUST_MIN_STACK"), 2)
 
     def assert_python_pr_job_contract(self, ci: str) -> None:
         triggers = self.yaml_block(ci, "on:")
@@ -485,6 +539,86 @@ class SprintWorkflowTests(unittest.TestCase):
                 AssertionError
             ):
                 self.assert_poppler_consumers_contract(short_circuited)
+
+    def test_workspace_oracle_jobs_pin_uv_cache_and_stack(self) -> None:
+        ci = (workflow.REPO / ".github/workflows/ci.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assert_workspace_oracle_environment_contract(ci)
+        mutations = {
+            "global-stack": ci.replace(
+                "  CARGO_TERM_COLOR: always\n",
+                "  CARGO_TERM_COLOR: always\n  RUST_MIN_STACK: \"8388608\"\n",
+                1,
+            ),
+            "global-quoted-stack": ci.replace(
+                "  CARGO_TERM_COLOR: always\n",
+                "  CARGO_TERM_COLOR: always\n  \"RUST_MIN_STACK\": \"8388608\"\n",
+                1,
+            ),
+            "global-spaced-stack": ci.replace(
+                "  CARGO_TERM_COLOR: always\n",
+                "  CARGO_TERM_COLOR: always\n  RUST_MIN_STACK : \"8388608\"\n",
+                1,
+            ),
+            "global-quoted-spaced-stack": ci.replace(
+                "  CARGO_TERM_COLOR: always\n",
+                "  CARGO_TERM_COLOR: always\n  \"RUST_MIN_STACK\" : \"8388608\"\n",
+                1,
+            ),
+        }
+        for job_name in ("test", "msrv"):
+            job = self.yaml_block(ci, f"  {job_name}:")
+            test_step = self.yaml_step(job, "Run full workspace suite")
+            mutations.update(
+                {
+                    f"{job_name}-wrong-action": ci.replace(
+                        job,
+                        job.replace(
+                            "astral-sh/setup-uv@"
+                            "20cfd1bf945f4377ade1205e4dbc17946fc9a30d",
+                            "astral-sh/setup-uv@main",
+                            1,
+                        ),
+                        1,
+                    ),
+                    f"{job_name}-wrong-uv-version": ci.replace(
+                        job,
+                        job.replace(
+                            'version: "0.10.2"', 'version: "latest"', 1
+                        ),
+                        1,
+                    ),
+                    f"{job_name}-shared-home-cache": ci.replace(
+                        job,
+                        job.replace(
+                            'UV_CACHE_DIR: "${{ runner.temp }}/uv-cache"',
+                            'UV_CACHE_DIR: "~/.cache/uv"',
+                            1,
+                        ),
+                        1,
+                    ),
+                    f"{job_name}-default-stack": ci.replace(
+                        job,
+                        job.replace(
+                            '          RUST_MIN_STACK: "8388608"\n', "", 1
+                        ),
+                        1,
+                    ),
+                    f"{job_name}-exit-zero": ci.replace(
+                        test_step,
+                        test_step.replace(
+                            "        run: >-\n",
+                            "        run: >-\n          exit 0\n",
+                            1,
+                        ),
+                        1,
+                    ),
+                }
+            )
+        for label, mutated in mutations.items():
+            with self.subTest(mutation=label), self.assertRaises(AssertionError):
+                self.assert_workspace_oracle_environment_contract(mutated)
 
     def test_wasm_job_accepts_the_official_binaryen_125_identity(self) -> None:
         ci = (workflow.REPO / ".github/workflows/ci.yml").read_text(

--- a/scripts/test_sprint_workflow.py
+++ b/scripts/test_sprint_workflow.py
@@ -7,6 +7,7 @@ import io
 import json
 import os
 import subprocess
+import tarfile
 import tempfile
 import tomllib
 import unittest
@@ -14,6 +15,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts import readme_doctests
+from scripts import install_pinned_poppler
 from scripts import sprint_workflow as workflow
 
 
@@ -109,6 +111,49 @@ class SprintWorkflowTests(unittest.TestCase):
                     line,
                 )
 
+    def assert_pinned_poppler_installer_contract(self, installer: str) -> None:
+        self.assertIn('POPLER_VERSION = "26.01.0"', installer)
+        self.assertIn(
+            'POPLER_SHA256 = "1cb944a4b88847f5fb6551683bc799db59f04990f5d8be07aba2acbf38601089"',
+            installer,
+        )
+        self.assertIn("MAX_DOWNLOAD_BYTES = 8 * 1024 * 1024", installer)
+        self.assertIn("MAX_ARCHIVE_MEMBERS = 2_048", installer)
+        self.assertIn("MAX_EXTRACTED_BYTES = 64 * 1024 * 1024", installer)
+        for tool in ("pdftoppm", "pdfinfo", "pdftotext"):
+            self.assertIn(tool, installer)
+        self.assertIn("safe_extract", installer)
+        self.assertIn("-DENABLE_UTILS=ON", installer)
+        self.assertIn('expected = f"{tool} version {POPLER_VERSION}"', installer)
+
+    def assert_poppler_consumers_contract(self, ci: str) -> None:
+        consumers = {
+            "test": "cargo test --workspace",
+            "python-bindings": "Run full Python binding suite",
+            "presentation-fidelity": "Run all-slide SSIM trend and completeness gate",
+            "msrv": "cargo test --workspace",
+        }
+        for job_name, use_marker in consumers.items():
+            job = self.yaml_block(ci, f"  {job_name}:")
+            step = self.yaml_step(job, "Install pinned Poppler 26.01.0")
+            self.assertEqual(
+                self.yaml_direct_lines(step, 8),
+                ("shell: bash", "run: |"),
+            )
+            lines = self.yaml_run_lines(step)
+            self.assertIn("python3 scripts/install_pinned_poppler.py", lines)
+            self.assert_no_success_short_circuit(lines)
+            self.assertLess(job.index(step), job.index(use_marker))
+            self.assertFalse(
+                any(
+                    "continue-on-error:" in line
+                    for line in self.operative_lines(job)
+                )
+            )
+        self.assertEqual(ci.count("python3 scripts/install_pinned_poppler.py"), 4)
+        self.assertNotIn("brew install poppler", ci)
+        self.assertNotIn("apt-get install poppler-utils", ci)
+
     def assert_python_pr_job_contract(self, ci: str) -> None:
         triggers = self.yaml_block(ci, "on:")
         trigger_keys = tuple(
@@ -172,7 +217,7 @@ class SprintWorkflowTests(unittest.TestCase):
             "step:1",
             "step:2",
             "Set up Python 3.12",
-            "Install pinned Poppler",
+            "Install pinned Poppler 26.01.0",
             "Create isolated binding environment",
             "Build Python extension",
             "Run full Python binding suite",
@@ -216,8 +261,16 @@ class SprintWorkflowTests(unittest.TestCase):
             ('python-version: "3.12.9"',),
         )
 
-        poppler = self.yaml_step(job, "Install pinned Poppler")
-        self.assertEqual(self.yaml_run_lines(poppler), ("brew install poppler",))
+        poppler = self.yaml_step(job, "Install pinned Poppler 26.01.0")
+        self.assertEqual(
+            self.yaml_run_lines(poppler),
+            (
+                "brew install \\",
+                "cmake ninja pkg-config fontconfig freetype jpeg-turbo \\",
+                "libpng libtiff little-cms2 openjpeg",
+                "python3 scripts/install_pinned_poppler.py",
+            ),
+        )
 
         environment = self.yaml_step(job, "Create isolated binding environment")
         self.assertEqual(
@@ -275,6 +328,174 @@ class SprintWorkflowTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assert_python_pr_job_contract(ci)
+
+    def test_pinned_poppler_installer_contract(self) -> None:
+        installer_path = workflow.REPO / "scripts/install_pinned_poppler.py"
+        self.assertTrue(
+            installer_path.is_file(),
+            "F-X012 requires one shared pinned Poppler installer",
+        )
+        installer = installer_path.read_text(encoding="utf-8")
+        self.assert_pinned_poppler_installer_contract(installer)
+
+        mutations = {
+            "wrong-version": installer.replace("26.01.0", "26.02.0"),
+            "wrong-checksum": installer.replace(
+                "1cb944a4b88847f5fb6551683bc799db59f04990f5d8be07aba2acbf38601089",
+                "0" * 64,
+            ),
+            "missing-member-bound": installer.replace(
+                "MAX_ARCHIVE_MEMBERS = 2_048",
+                "MAX_ARCHIVE_MEMBERS = len(members)",
+            ),
+            "missing-runtime-identity": installer.replace(
+                'expected = f"{tool} version {POPLER_VERSION}"',
+                'expected = tool',
+            ),
+        }
+        for label, mutated in mutations.items():
+            with self.subTest(mutation=label), self.assertRaises(AssertionError):
+                self.assert_pinned_poppler_installer_contract(mutated)
+
+    def test_pinned_poppler_installer_enforces_its_runtime_guards(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+
+            with patch.object(
+                install_pinned_poppler.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(b"not the reviewed Poppler source"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "SHA-256"):
+                    install_pinned_poppler.download_archive(root / "poppler.tar.xz")
+
+            with patch.object(
+                install_pinned_poppler.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(
+                    b"x" * (install_pinned_poppler.MAX_DOWNLOAD_BYTES + 1)
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "download bound"):
+                    install_pinned_poppler.download_archive(root / "too-large.tar.xz")
+
+            archive_path = root / "too-many-members.tar.xz"
+            with tarfile.open(archive_path, mode="w:xz") as archive:
+                for index in range(install_pinned_poppler.MAX_ARCHIVE_MEMBERS + 1):
+                    member = tarfile.TarInfo(f"poppler-26.01.0/member-{index}")
+                    member.size = 0
+                    archive.addfile(member, io.BytesIO())
+            with patch.object(
+                tarfile.TarFile,
+                "getmembers",
+                side_effect=AssertionError("unbounded member-table allocation"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "member-count"):
+                    install_pinned_poppler.safe_extract(
+                        archive_path,
+                        root / "extract",
+                    )
+
+            oversized_member = tarfile.TarInfo("poppler-26.01.0/oversized")
+            oversized_member.size = install_pinned_poppler.MAX_EXTRACTED_BYTES + 1
+            with patch.object(
+                install_pinned_poppler.tarfile,
+                "open",
+                return_value=contextlib.nullcontext((oversized_member,)),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "extracted-size"):
+                    install_pinned_poppler.safe_extract(
+                        root / "unused.tar.xz",
+                        root / "oversized-extract",
+                    )
+
+            for wrong_tool in install_pinned_poppler.TOOLS:
+                prefix = root / f"wrong-{wrong_tool}"
+                binary_root = prefix / "bin"
+                binary_root.mkdir(parents=True)
+                for tool in install_pinned_poppler.TOOLS:
+                    version = "99.0.0" if tool == wrong_tool else "26.01.0"
+                    executable = binary_root / tool
+                    executable.write_text(
+                        f"#!/bin/sh\necho '{tool} version {version}' >&2\n",
+                        encoding="utf-8",
+                    )
+                    executable.chmod(0o755)
+                with self.subTest(wrong_tool=wrong_tool), self.assertRaisesRegex(
+                    RuntimeError,
+                    f"unexpected {wrong_tool} identity",
+                ):
+                    install_pinned_poppler.verify_tools(prefix)
+
+    def test_pinned_poppler_installer_rejects_a_populated_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            prefix = Path(temp) / "populated"
+            binary_root = prefix / "bin"
+            binary_root.mkdir(parents=True)
+            for tool in install_pinned_poppler.TOOLS:
+                executable = binary_root / tool
+                executable.write_text(
+                    f"#!/bin/sh\necho '{tool} version 26.01.0' >&2\n",
+                    encoding="utf-8",
+                )
+                executable.chmod(0o755)
+            with patch.object(
+                install_pinned_poppler,
+                "download_archive",
+                side_effect=AssertionError("download must not be bypassed"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "prefix must be empty"):
+                    install_pinned_poppler.build(prefix)
+
+    def test_every_poppler_consumer_uses_the_pinned_installer(self) -> None:
+        ci = (workflow.REPO / ".github/workflows/ci.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assert_poppler_consumers_contract(ci)
+        for job_name in ("test", "python-bindings", "presentation-fidelity", "msrv"):
+            marker = f"  {job_name}:"
+            job = self.yaml_block(ci, marker)
+            step = self.yaml_step(job, "Install pinned Poppler 26.01.0")
+            mutated_job = job.replace(
+                "          python3 scripts/install_pinned_poppler.py\n", "", 1
+            )
+            mutated = ci.replace(job, mutated_job, 1)
+            with self.subTest(missing_consumer=job_name), self.assertRaises(
+                AssertionError
+            ):
+                self.assert_poppler_consumers_contract(mutated)
+            for policy in ("if: false", "continue-on-error: true"):
+                weakened_step = step.replace(
+                    "        shell: bash\n",
+                    f"        {policy}\n        shell: bash\n",
+                    1,
+                )
+                weakened = ci.replace(step, weakened_step, 1)
+                with self.subTest(job=job_name, policy=policy), self.assertRaises(
+                    AssertionError
+                ):
+                    self.assert_poppler_consumers_contract(weakened)
+            short_circuited_step = step.replace(
+                "        run: |\n",
+                "        run: |\n          exit 0\n",
+                1,
+            )
+            short_circuited = ci.replace(step, short_circuited_step, 1)
+            with self.subTest(job=job_name, policy="exit 0"), self.assertRaises(
+                AssertionError
+            ):
+                self.assert_poppler_consumers_contract(short_circuited)
+
+    def test_wasm_job_accepts_the_official_binaryen_125_identity(self) -> None:
+        ci = (workflow.REPO / ".github/workflows/ci.yml").read_text(
+            encoding="utf-8"
+        )
+        job = self.yaml_block(ci, "  wasm:")
+        install = self.yaml_step(job, "Install wasm-opt 125")
+        self.assertIn(
+            'wasm-opt version 125 (version_125)',
+            "\n".join(self.yaml_run_lines(install)),
+        )
 
     def test_workspace_test_jobs_fetch_the_pinned_presentation_corpus(self) -> None:
         ci = (workflow.REPO / ".github/workflows/ci.yml").read_text(
@@ -619,8 +840,8 @@ class SprintWorkflowTests(unittest.TestCase):
                 'tar --extract --gzip --file "$binaryen_archive" --directory '
                 '"$binaryen_root" --strip-components=1',
                 'echo "$binaryen_root/bin" >> "$GITHUB_PATH"',
-                '"$binaryen_root/bin/wasm-opt" --version | grep --fixed-strings '
-                '--line-regexp "wasm-opt version 125"',
+                'test "$("$binaryen_root/bin/wasm-opt" --version)" = '
+                '"wasm-opt version 125 (version_125)"',
             ),
         )
         self.assertEqual(
@@ -869,8 +1090,8 @@ class SprintWorkflowTests(unittest.TestCase):
                 "0000000000000000000000000000000000000000000000000000000000000000",
             ),
             "missing-wasm-opt-version-check": mutate_job(
-                "          \"$binaryen_root/bin/wasm-opt\" --version | grep "
-                "--fixed-strings --line-regexp \"wasm-opt version 125\"\n",
+                '          test "$("$binaryen_root/bin/wasm-opt" --version)" = '
+                '"wasm-opt version 125 (version_125)"\n',
                 "",
             ),
             "unlocked-target-check": mutate_job(

--- a/scripts/test_sprint_workflow.py
+++ b/scripts/test_sprint_workflow.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts import readme_doctests
+from scripts import install_pinned_libreoffice
 from scripts import install_pinned_poppler
 from scripts import sprint_workflow as workflow
 
@@ -136,6 +137,62 @@ class SprintWorkflowTests(unittest.TestCase):
         self.assertIn("safe_extract", installer)
         self.assertIn("-DENABLE_UTILS=ON", installer)
         self.assertIn('expected = f"{tool} version {POPLER_VERSION}"', installer)
+
+    def assert_pinned_libreoffice_installer_contract(self, installer: str) -> None:
+        self.assertIn('LIBREOFFICE_VERSION = "26.2.5.2"', installer)
+        self.assertIn(
+            'LIBREOFFICE_SHA256 = "2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e"',
+            installer,
+        )
+        self.assertIn(
+            '"https://download.documentfoundation.org/libreoffice/stable/26.2.5/"',
+            installer,
+        )
+        self.assertIn("MAX_DOWNLOAD_BYTES = 224 * 1024 * 1024", installer)
+        self.assertIn("MAX_ARCHIVE_MEMBERS = 256", installer)
+        self.assertIn("MAX_EXTRACTED_BYTES = 256 * 1024 * 1024", installer)
+        self.assertIn('INSTALL_ROOT = Path("/opt/libreoffice26.2")', installer)
+        self.assertEqual(
+            install_pinned_libreoffice.SYSTEM_RUNTIME_PACKAGES,
+            (
+                "libcairo2",
+                "libcups2t64",
+                "libdbus-1-3",
+                "libfontconfig1",
+                "libfreetype6",
+                "libglib2.0-0t64",
+                "libgssapi-krb5-2",
+                "libnspr4",
+                "libnss3",
+                "libx11-6",
+                "libx11-xcb1",
+                "libxext6",
+                "libxinerama1",
+            ),
+        )
+        self.assertIn("safe_extract", installer)
+        self.assertIn("apt-get", installer)
+        self.assertIn("--no-install-recommends", installer)
+        self.assertIn(
+            '"LibreOffice 26.2.5.2 cd7284b4cbbfeb507e630c1aac019f4157393acb"',
+            installer,
+        )
+        self.assertIn('os.environ.get("GITHUB_PATH")', installer)
+
+    def assert_libreoffice_consumers_contract(self, ci: str) -> None:
+        for job_name in ("test", "msrv"):
+            job = self.yaml_block(ci, f"  {job_name}:")
+            self.assertIn("runs-on: ubuntu-24.04", job)
+            install = self.yaml_step(job, "Install pinned LibreOffice 26.2.5.2")
+            self.assertEqual(
+                self.yaml_direct_lines(install, 8),
+                ("run: python3 scripts/install_pinned_libreoffice.py",),
+            )
+            test_step = self.yaml_step(job, "Run full workspace suite")
+            self.assertLess(job.index(install), job.index(test_step))
+            self.assertNotIn("continue-on-error", install)
+            self.assert_no_success_short_circuit(self.operative_lines(install))
+        self.assertEqual(ci.count("python3 scripts/install_pinned_libreoffice.py"), 2)
 
     def assert_poppler_consumers_contract(self, ci: str) -> None:
         consumers = {
@@ -410,6 +467,258 @@ class SprintWorkflowTests(unittest.TestCase):
         for label, mutated in mutations.items():
             with self.subTest(mutation=label), self.assertRaises(AssertionError):
                 self.assert_pinned_poppler_installer_contract(mutated)
+
+    def test_workspace_viewer_jobs_install_pinned_libreoffice(self) -> None:
+        installer_path = workflow.REPO / "scripts/install_pinned_libreoffice.py"
+        self.assertTrue(
+            installer_path.is_file(),
+            "F-X012 requires one pinned Linux LibreOffice installer",
+        )
+        installer = installer_path.read_text(encoding="utf-8")
+        self.assert_pinned_libreoffice_installer_contract(installer)
+
+        mutations = {
+            "wrong-version": installer.replace("26.2.5.2", "26.2.6.0"),
+            "wrong-checksum": installer.replace(
+                "2f03bfb2ac9f33ea7c77331b4b7a23300fb0ed7443566046bf8b5bc51c1bed1e",
+                "0" * 64,
+            ),
+            "missing-member-bound": installer.replace(
+                "MAX_ARCHIVE_MEMBERS = 256",
+                "MAX_ARCHIVE_MEMBERS = len(members)",
+            ),
+            "recommended-packages": installer.replace(
+                '"--no-install-recommends",', '"--install-recommends",'
+            ),
+        }
+        for label, mutated in mutations.items():
+            with self.subTest(installer_mutation=label), self.assertRaises(
+                AssertionError
+            ):
+                self.assert_pinned_libreoffice_installer_contract(mutated)
+
+        ci = (workflow.REPO / ".github/workflows/ci.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assert_libreoffice_consumers_contract(ci)
+        for job_name in ("test", "msrv"):
+            job = self.yaml_block(ci, f"  {job_name}:")
+            install = self.yaml_step(job, "Install pinned LibreOffice 26.2.5.2")
+            for label, mutated_install in {
+                "missing": "",
+                "if-false": install.replace(
+                    "        run:", "        if: false\n        run:", 1
+                ),
+                "continue-on-error": install.replace(
+                    "        run:",
+                    "        continue-on-error: true\n        run:",
+                    1,
+                ),
+                "exit-zero": install.replace(
+                    "        run: python3",
+                    "        run: exit 0\n          python3",
+                    1,
+                ),
+            }.items():
+                mutated = ci.replace(install, mutated_install, 1)
+                with self.subTest(job=job_name, mutation=label), self.assertRaises(
+                    AssertionError
+                ):
+                    self.assert_libreoffice_consumers_contract(mutated)
+
+    def test_pinned_libreoffice_installer_enforces_runtime_guards(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with patch.object(
+                install_pinned_libreoffice.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(b"not the reviewed LibreOffice source"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "SHA-256"):
+                    install_pinned_libreoffice.download_archive(root / "wrong.tar.gz")
+
+            with (
+                patch.object(install_pinned_libreoffice, "MAX_DOWNLOAD_BYTES", 8),
+                patch.object(
+                    install_pinned_libreoffice.urllib.request,
+                    "urlopen",
+                    return_value=io.BytesIO(b"x" * 9),
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "download bound"):
+                    install_pinned_libreoffice.download_archive(root / "large.tar.gz")
+
+            archive_path = root / "too-many.tar.gz"
+            with tarfile.open(archive_path, mode="w:gz") as archive:
+                for index in range(
+                    install_pinned_libreoffice.MAX_ARCHIVE_MEMBERS + 1
+                ):
+                    member = tarfile.TarInfo(
+                        f"{install_pinned_libreoffice.ARCHIVE_ROOT}/member-{index}"
+                    )
+                    member.size = 0
+                    archive.addfile(member, io.BytesIO())
+            with patch.object(
+                tarfile.TarFile,
+                "getmembers",
+                side_effect=AssertionError("unbounded member-table allocation"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "member-count"):
+                    install_pinned_libreoffice.safe_extract(
+                        archive_path,
+                        root / "extract",
+                    )
+
+            unsafe_archive = root / "unsafe.tar.gz"
+            with tarfile.open(unsafe_archive, mode="w:gz") as archive:
+                member = tarfile.TarInfo(
+                    f"{install_pinned_libreoffice.ARCHIVE_ROOT}/../../escape"
+                )
+                member.size = 0
+                archive.addfile(member, io.BytesIO())
+            with self.assertRaisesRegex(RuntimeError, "unsafe path"):
+                install_pinned_libreoffice.safe_extract(
+                    unsafe_archive,
+                    root / "unsafe-extract",
+                )
+
+            unsupported_archive = root / "unsupported.tar.gz"
+            with tarfile.open(unsupported_archive, mode="w:gz") as archive:
+                member = tarfile.TarInfo(
+                    f"{install_pinned_libreoffice.ARCHIVE_ROOT}/unsupported"
+                )
+                member.type = tarfile.SYMTYPE
+                member.linkname = "target"
+                archive.addfile(member)
+            with self.assertRaisesRegex(RuntimeError, "non-file entry"):
+                install_pinned_libreoffice.safe_extract(
+                    unsupported_archive,
+                    root / "unsupported-extract",
+                )
+
+            core_package = (
+                f"libobasis26.2-core_{install_pinned_libreoffice.LIBREOFFICE_VERSION}"
+                "-2_amd64.deb"
+            )
+            impress_package = (
+                f"libreoffice26.2-impress_{install_pinned_libreoffice.LIBREOFFICE_VERSION}"
+                "-2_amd64.deb"
+            )
+            for missing, present in (
+                ("libobasis26.2-core", impress_package),
+                ("libreoffice26.2-impress", core_package),
+            ):
+                incomplete_archive = root / f"missing-{missing}.tar.gz"
+                with tarfile.open(incomplete_archive, mode="w:gz") as archive:
+                    member = tarfile.TarInfo(
+                        f"{install_pinned_libreoffice.ARCHIVE_ROOT}/DEBS/{present}"
+                    )
+                    member.size = 0
+                    archive.addfile(member, io.BytesIO())
+                with self.subTest(missing=missing), self.assertRaisesRegex(
+                    RuntimeError, f"missing {missing}"
+                ):
+                    install_pinned_libreoffice.safe_extract(
+                        incomplete_archive,
+                        root / f"missing-{missing}-extract",
+                    )
+
+            oversized_member = tarfile.TarInfo(
+                f"{install_pinned_libreoffice.ARCHIVE_ROOT}/oversized"
+            )
+            oversized_member.size = (
+                install_pinned_libreoffice.MAX_EXTRACTED_BYTES + 1
+            )
+            with patch.object(
+                install_pinned_libreoffice.tarfile,
+                "open",
+                return_value=contextlib.nullcontext((oversized_member,)),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "extracted-size"):
+                    install_pinned_libreoffice.safe_extract(
+                        root / "unused.tar.gz",
+                        root / "oversized-extract",
+                    )
+
+            fake_soffice = root / "soffice"
+            fake_soffice.write_text("not used", encoding="utf-8")
+            wrong_identity = subprocess.CompletedProcess(
+                [str(fake_soffice), "--version"],
+                0,
+                stdout="LibreOffice 99.0.0\n",
+                stderr="",
+            )
+            with patch.object(
+                install_pinned_libreoffice.subprocess,
+                "run",
+                return_value=wrong_identity,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "unexpected LibreOffice"):
+                    install_pinned_libreoffice.verify_soffice(fake_soffice)
+
+            populated = root / "populated-prefix"
+            populated.mkdir()
+            with (
+                patch.object(install_pinned_libreoffice, "INSTALL_ROOT", populated),
+                patch.object(install_pinned_libreoffice.platform, "system", return_value="Linux"),
+                patch.object(install_pinned_libreoffice.platform, "machine", return_value="x86_64"),
+                patch.object(
+                    install_pinned_libreoffice,
+                    "download_archive",
+                    side_effect=AssertionError("populated prefix must fail first"),
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "prefix must be absent"):
+                    install_pinned_libreoffice.install()
+
+            deb_root = root / "complete" / "DEBS"
+            deb_root.mkdir(parents=True)
+            for package in (core_package, impress_package):
+                (deb_root / package).write_bytes(b"package")
+            events: list[str] = []
+
+            def record_download(_destination: Path) -> None:
+                events.append("download")
+
+            def record_install(command: list[str], *, check: bool) -> None:
+                self.assertTrue(check)
+                self.assertEqual(command[:5], ["sudo", "apt-get", "install", "--yes", "--no-install-recommends"])
+                for package in install_pinned_libreoffice.SYSTEM_RUNTIME_PACKAGES:
+                    self.assertIn(package, command)
+                self.assertIn(str(deb_root / core_package), command)
+                self.assertIn(str(deb_root / impress_package), command)
+                events.append("install")
+
+            with (
+                patch.object(install_pinned_libreoffice, "INSTALL_ROOT", root / "absent"),
+                patch.object(install_pinned_libreoffice.platform, "system", return_value="Linux"),
+                patch.object(install_pinned_libreoffice.platform, "machine", return_value="x86_64"),
+                patch.dict(os.environ, {"RUNNER_TEMP": str(root)}),
+                patch.object(install_pinned_libreoffice, "download_archive", side_effect=record_download),
+                patch.object(
+                    install_pinned_libreoffice,
+                    "safe_extract",
+                    side_effect=lambda _archive, _destination: (
+                        events.append("extract") or deb_root
+                    ),
+                ),
+                patch.object(install_pinned_libreoffice.subprocess, "run", side_effect=record_install),
+                patch.object(
+                    install_pinned_libreoffice,
+                    "verify_soffice",
+                    side_effect=lambda: events.append("verify"),
+                ),
+                patch.object(
+                    install_pinned_libreoffice,
+                    "expose_soffice",
+                    side_effect=lambda: events.append("expose"),
+                ),
+            ):
+                install_pinned_libreoffice.install()
+            self.assertEqual(
+                events,
+                ["download", "extract", "install", "verify", "expose"],
+            )
 
     def test_pinned_poppler_installer_enforces_its_runtime_guards(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
Temporary hosted-CI validation PR for F-X012.\n\nThis fixes the five recurring merge-CI failures by building checksum-pinned Poppler 26.01.0 for every consumer and accepting the official Binaryen 125 Linux identity. The installer uses streaming resource bounds, refuses populated prefixes, and verifies all three runtime tools.\n\nLocal evidence: full verification passed, hash harness 28/28 unchanged, and microscope pass 3 reported 0 defects, 0 smells, 0 nitpicks.\n\nDo not merge this draft PR. It exists only to obtain hosted CI evidence before S40 finalization.