### PR TITLE
Read list suffixes and table presentation properties

### DIFF
--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -6,6 +6,7 @@ use rdocx_oxml::content_control::{CT_Sdt, SdtContent};
 use rdocx_oxml::document::{BodyContent, CT_SectPr};
 use rdocx_oxml::drawing::WrapType;
 use rdocx_oxml::header_footer::HdrFtrType;
+use rdocx_oxml::numbering::ST_LvlSuffix;
 use rdocx_oxml::properties::CT_PPr;
 use rdocx_oxml::revision::{CT_Revision, RevisionContent, RevisionKind};
 use rdocx_oxml::shared::ST_HighlightColor;
@@ -684,8 +685,35 @@ pub fn layout_paragraph(
                     note: None,
                 }));
 
-                // Add a space/tab after the marker
-                inline_items.push(InlineItem::Tab);
+                match marker.suffix {
+                    ST_LvlSuffix::Tab => inline_items.push(InlineItem::Tab),
+                    ST_LvlSuffix::Space => {
+                        let shaped = fm.shape_text(font_id, " ", marker_font_size)?;
+                        inline_items.push(InlineItem::Text(TextSegment {
+                            text: " ".to_owned(),
+                            font_id,
+                            font_size: marker_font_size,
+                            glyph_ids: shaped.glyph_ids,
+                            advances: shaped.advances,
+                            width: shaped.width,
+                            ascent: metrics.ascent,
+                            descent: metrics.descent,
+                            line_gap: 0.0,
+                            color,
+                            bold: marker_bold,
+                            italic: marker_italic,
+                            underline: None,
+                            strike: false,
+                            dstrike: false,
+                            highlight: None,
+                            baseline_offset: 0.0,
+                            hyperlink_url: None,
+                            field_kind: None,
+                            note: None,
+                        }));
+                    }
+                    ST_LvlSuffix::Nothing => {}
+                }
             }
         }
     }

--- a/crates/rdocx-layout/src/style_resolver.rs
+++ b/crates/rdocx-layout/src/style_resolver.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use rdocx_oxml::numbering::{CT_Numbering, ST_NumberFormat};
+use rdocx_oxml::numbering::{CT_Numbering, ST_LvlSuffix, ST_NumberFormat};
 use rdocx_oxml::properties::{CT_PPr, CT_RPr};
 use rdocx_oxml::styles::{CT_Style, CT_Styles, StyleType};
 
@@ -36,6 +36,8 @@ pub struct ResolvedNumbering {
     pub marker_text: String,
     /// Run properties for the marker.
     pub marker_rpr: CT_RPr,
+    /// Item that follows the marker before paragraph content begins.
+    pub suffix: ST_LvlSuffix,
 }
 
 /// Tracks numbering counters across paragraphs.
@@ -205,6 +207,7 @@ pub fn generate_marker(
     Some(ResolvedNumbering {
         marker_text,
         marker_rpr,
+        suffix: lvl.suffix.unwrap_or(ST_LvlSuffix::Tab),
     })
 }
 
@@ -413,6 +416,18 @@ mod tests {
         generate_marker(num_id, 0, &numbering, &mut state);
         let sub2 = generate_marker(num_id, 1, &numbering, &mut state).unwrap();
         assert_eq!(sub2.marker_text, "a."); // reset
+    }
+
+    #[test]
+    fn numbering_marker_uses_the_level_suffix() {
+        let mut numbering = CT_Numbering::new();
+        let num_id = numbering.add_numbered_list();
+        numbering.abstract_nums[0].levels[0].suffix = Some(ST_LvlSuffix::Nothing);
+
+        let marker = generate_marker(num_id, 0, &numbering, &mut NumberingState::new())
+            .expect("numbered marker resolves");
+
+        assert_eq!(marker.suffix, ST_LvlSuffix::Nothing);
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/numbering.rs
+++ b/crates/rdocx-oxml/src/numbering.rs
@@ -2075,6 +2075,33 @@ pub enum ST_NumberFormat {
     None,
 }
 
+/// The character or layout item that follows a numbering level marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ST_LvlSuffix {
+    Tab,
+    Space,
+    Nothing,
+}
+
+impl ST_LvlSuffix {
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "tab" => Some(Self::Tab),
+            "space" => Some(Self::Space),
+            "nothing" => Some(Self::Nothing),
+            _ => None,
+        }
+    }
+
+    pub fn to_str(self) -> &'static str {
+        match self {
+            Self::Tab => "tab",
+            Self::Space => "space",
+            Self::Nothing => "nothing",
+        }
+    }
+}
+
 impl ST_NumberFormat {
     pub fn from_str(s: &str) -> Self {
         match s {
@@ -2113,6 +2140,8 @@ pub struct CT_Lvl {
     pub start: Option<u32>,
     /// Number format
     pub num_fmt: Option<ST_NumberFormat>,
+    /// Item emitted between the marker and the paragraph content.
+    pub suffix: Option<ST_LvlSuffix>,
     /// Level text (e.g., "%1.", "%1.%2.", bullet char)
     pub lvl_text: Option<String>,
     /// Level justification
@@ -2138,6 +2167,7 @@ impl CT_Lvl {
             ilvl,
             start: None,
             num_fmt: None,
+            suffix: None,
             lvl_text: None,
             lvl_jc: None,
             ppr: None,
@@ -2179,6 +2209,19 @@ impl CT_Lvl {
                         }
                         reader.read_to_end_into(name, &mut Vec::new())?;
                         boundary = 2;
+                    } else if is_word_element(name.as_ref(), b"suff", &prefixes) {
+                        if let Some(value) = word_attribute_value(e, b"val", &prefixes)?
+                            && let Some(suffix) = ST_LvlSuffix::from_str(&value)
+                        {
+                            lvl.suffix = Some(suffix);
+                        } else {
+                            let (at, next) = level_raw_boundary(name.as_ref(), boundary, &prefixes);
+                            lvl.extra_xml.push((at, capture_element(reader, e)?));
+                            boundary = next;
+                            continue;
+                        }
+                        reader.read_to_end_into(name, &mut Vec::new())?;
+                        boundary = 6;
                     } else if is_word_element(name.as_ref(), b"lvlText", &prefixes) {
                         lvl.lvl_text = word_attribute_value(e, b"val", &prefixes)?;
                         reader.read_to_end_into(name, &mut Vec::new())?;
@@ -2224,6 +2267,17 @@ impl CT_Lvl {
                             lvl.num_fmt = Some(ST_NumberFormat::from_str(&val));
                         }
                         boundary = 2;
+                    } else if is_word_element(name.as_ref(), b"suff", &prefixes) {
+                        if let Some(value) = word_attribute_value(e, b"val", &prefixes)?
+                            && let Some(suffix) = ST_LvlSuffix::from_str(&value)
+                        {
+                            lvl.suffix = Some(suffix);
+                            boundary = 6;
+                        } else {
+                            let (at, next) = level_raw_boundary(name.as_ref(), boundary, &prefixes);
+                            lvl.extra_xml.push((at, capture_empty_element(e)?));
+                            boundary = next;
+                        }
                     } else if is_word_element(name.as_ref(), b"lvlText", &prefixes) {
                         lvl.lvl_text = word_attribute_value(e, b"val", &prefixes)?;
                         boundary = 7;
@@ -2304,7 +2358,17 @@ impl CT_Lvl {
             writer.write_event(Event::Empty(e))?;
         }
 
-        for boundary in 2..=6 {
+        for boundary in 2..=4 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
+        if let Some(suffix) = self.suffix {
+            let name = qualified(word_prefix, "suff");
+            let val_name = qualified(word_prefix, "val");
+            let mut e = BytesStart::new(name.as_str());
+            e.push_attribute((val_name.as_str(), suffix.to_str()));
+            writer.write_event(Event::Empty(e))?;
+        }
+        for boundary in 5..=6 {
             write_extras_at(writer, &self.extra_xml, boundary)?;
         }
         if let Some(ref text) = self.lvl_text {
@@ -3084,6 +3148,21 @@ mod tests {
         assert_eq!(abs.levels[0].num_fmt, Some(ST_NumberFormat::Decimal));
         assert_eq!(abs.levels[0].lvl_text, Some("%1.".to_string()));
         assert_eq!(abs.levels[1].num_fmt, Some(ST_NumberFormat::LowerLetter));
+    }
+
+    #[test]
+    fn level_suffix_round_trips_in_its_schema_slot() {
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:suff w:val="space"/><w:lvlText w:val="%1."/></w:lvl></w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num></w:numbering>"#;
+        let numbering = CT_Numbering::from_xml(xml).expect("numbering parses");
+        let level = &numbering.abstract_nums[0].levels[0];
+
+        assert_eq!(level.suffix, Some(ST_LvlSuffix::Space));
+
+        let output =
+            String::from_utf8(numbering.to_xml().expect("numbering writes")).expect("XML is UTF-8");
+        let suffix = output.find("<w:suff").expect("suffix writes");
+        let text = output.find("<w:lvlText").expect("level text writes");
+        assert!(suffix < text, "suffix must precede level text: {output}");
     }
 
     #[test]
@@ -4604,6 +4683,7 @@ mod tests {
             ilvl: 0,
             start: Some(1),
             num_fmt: Some(ST_NumberFormat::Decimal),
+            suffix: None,
             lvl_text: Some("%1.".to_string()),
             lvl_jc: Some(ST_Jc::Left),
             ppr: Some(CT_PPr {

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -5,7 +5,7 @@ use quick_xml::{Reader, Writer};
 
 use crate::borders::CT_BorderEdge;
 use crate::content_control::CT_Sdt;
-use crate::error::Result;
+use crate::error::{OxmlError, Result};
 use crate::namespace::matches_local_name;
 use crate::numbering::{local_namespace_overrides, word_prefixes_at};
 use crate::properties::{
@@ -961,45 +961,14 @@ impl CT_TcPr {
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Empty(ref e)) => {
-                    let name = e.name();
-                    if matches_local_name(name.as_ref(), b"tcW") {
-                        pr.width = Some(CT_TblWidth::from_xml_attrs(e)?);
-                    } else if matches_local_name(name.as_ref(), b"gridSpan") {
-                        if let Some(val) = get_val_attr(e)? {
-                            pr.grid_span = Some(val.parse()?);
-                        }
-                    } else if matches_local_name(name.as_ref(), b"vMerge") {
-                        if let Some(val) = get_val_attr(e)? {
-                            pr.v_merge = Some(if val == "restart" {
-                                VMerge::Restart
-                            } else {
-                                VMerge::Continue
-                            });
-                        } else {
-                            // Empty vMerge means "continue"
-                            pr.v_merge = Some(VMerge::Continue);
-                        }
-                    } else if matches_local_name(name.as_ref(), b"vAlign") {
-                        if let Some(val) = get_val_attr(e)? {
-                            pr.v_align = Some(ST_VerticalJc::from_str(&val));
-                        }
-                    } else if matches_local_name(name.as_ref(), b"shd") {
-                        pr.shading = Some(CT_Shd::from_xml_attrs(e)?);
-                    } else if matches_local_name(name.as_ref(), b"cnfStyle") {
-                        pr.cnf_style = get_val_attr(e)?;
-                    } else if matches_local_name(name.as_ref(), b"noWrap") {
-                        pr.no_wrap = Some(true);
-                    } else if matches_local_name(name.as_ref(), b"textDirection")
-                        && let Some(val) = get_val_attr(e)?
-                    {
-                        pr.text_direction = Some(val);
-                    }
+                    Self::parse_property_element(e, &mut pr)?;
                 }
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
                     if matches_local_name(name.as_ref(), b"tcBorders") {
                         pr.borders = Some(CT_TblBorders::from_xml(reader)?);
                     } else {
+                        Self::parse_property_element(e, &mut pr)?;
                         reader.read_to_end_into(name, &mut Vec::new())?;
                     }
                 }
@@ -1014,6 +983,48 @@ impl CT_TcPr {
         }
 
         Ok(pr)
+    }
+
+    fn parse_property_element(e: &BytesStart<'_>, pr: &mut Self) -> Result<()> {
+        let name = e.name();
+        if matches_local_name(name.as_ref(), b"tcW") {
+            pr.width = Some(CT_TblWidth::from_xml_attrs(e)?);
+        } else if matches_local_name(name.as_ref(), b"gridSpan") {
+            if let Some(val) = get_val_attr(e)? {
+                let span: u32 = val.parse()?;
+                if span == 0 {
+                    return Err(OxmlError::InvalidValue(
+                        "w:gridSpan must be positive".to_owned(),
+                    ));
+                }
+                pr.grid_span = Some(span);
+            }
+        } else if matches_local_name(name.as_ref(), b"vMerge") {
+            pr.v_merge = Some(match get_val_attr(e)?.as_deref() {
+                Some("restart") => VMerge::Restart,
+                Some("continue") | None => VMerge::Continue,
+                Some(value) => {
+                    return Err(OxmlError::InvalidValue(format!(
+                        "invalid w:vMerge value {value}"
+                    )));
+                }
+            });
+        } else if matches_local_name(name.as_ref(), b"vAlign") {
+            if let Some(val) = get_val_attr(e)? {
+                pr.v_align = Some(ST_VerticalJc::from_str(&val));
+            }
+        } else if matches_local_name(name.as_ref(), b"shd") {
+            pr.shading = Some(CT_Shd::from_xml_attrs(e)?);
+        } else if matches_local_name(name.as_ref(), b"cnfStyle") {
+            pr.cnf_style = get_val_attr(e)?;
+        } else if matches_local_name(name.as_ref(), b"noWrap") {
+            pr.no_wrap = Some(true);
+        } else if matches_local_name(name.as_ref(), b"textDirection")
+            && let Some(val) = get_val_attr(e)?
+        {
+            pr.text_direction = Some(val);
+        }
+        Ok(())
     }
 
     pub fn to_xml<W: std::io::Write>(&self, writer: &mut Writer<W>) -> Result<()> {
@@ -1790,6 +1801,56 @@ mod tests {
             tbl.rows[2].cells[0].properties.as_ref().unwrap().v_merge,
             Some(VMerge::Continue)
         );
+    }
+
+    #[test]
+    fn expanded_presentation_cell_properties_are_read() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="100"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcW w:w="72" w:type="dxa"></w:tcW><w:shd w:val="clear" w:fill="FF0000"></w:shd><w:noWrap></w:noWrap><w:vAlign w:val="center"></w:vAlign><w:textDirection w:val="btLr"></w:textDirection><w:cnfStyle w:val="100000000000"></w:cnfStyle></w:tcPr><w:p/></w:tc></w:tr>"#,
+        );
+
+        let properties = table.rows[0].cells[0]
+            .properties
+            .as_ref()
+            .expect("cell properties parse");
+        assert_eq!(properties.width.as_ref().map(|width| width.w), Some(72));
+        assert_eq!(
+            properties
+                .shading
+                .as_ref()
+                .and_then(|shading| shading.fill.as_deref()),
+            Some("FF0000")
+        );
+        assert_eq!(properties.no_wrap, Some(true));
+        assert_eq!(properties.v_align, Some(ST_VerticalJc::Center));
+        assert_eq!(properties.text_direction.as_deref(), Some("btLr"));
+        assert_eq!(properties.cnf_style.as_deref(), Some("100000000000"));
+    }
+
+    #[test]
+    fn invalid_structural_cell_merge_values_fail_to_parse() {
+        let zero_span = r#"<w:tblGrid><w:gridCol w:w="100"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:gridSpan w:val="0"/></w:tcPr><w:p/></w:tc></w:tr>"#;
+        let bad_merge = r#"<w:tblGrid><w:gridCol w:w="100"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:vMerge w:val="sideways"/></w:tcPr><w:p/></w:tc></w:tr>"#;
+
+        for xml in [zero_span, bad_merge] {
+            let table_xml = format!("<w:tbl>{xml}</w:tbl>");
+            let mut reader = Reader::from_str(&table_xml);
+            let mut buffer = Vec::new();
+            loop {
+                match reader.read_event_into(&mut buffer) {
+                    Ok(Event::Start(element))
+                        if matches_local_name(element.name().as_ref(), b"tbl") =>
+                    {
+                        assert!(CT_Tbl::from_xml(&mut reader).is_err(), "{xml}");
+                        break;
+                    }
+                    Ok(Event::Eof) => panic!("missing table"),
+                    Ok(_) => {}
+                    Err(error) => panic!("invalid fixture: {error}"),
+                }
+                buffer.clear();
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Parse and render `w:suff` list-marker separators, preserving tab, space, and no separator behavior.
- Read expanded presentation-only table-cell properties.
- Reject zero `w:gridSpan` values and invalid `w:vMerge` values.

## Validation

- `cargo test -p rdocx-oxml`
- `cargo test -p rdocx-layout`
- `cargo clippy -p rdocx-oxml -p rdocx-layout -p rdocx --all-targets --all-features -- -D warnings`
- `python3.13 scripts/hash_harness.py --check`