### PR TITLE
Preserve reader compatibility for fields and table XML

### DIFF
--- a/.claude/plans/F-160-design.md
+++ b/.claude/plans/F-160-design.md
@@ -1,0 +1,122 @@
+# F-160, Field instruction parser
+
+**Status**: approved
+**Sprint**: S49
+**Size**: L
+**Depends on**: none
+
+## Problem
+
+`crates/rdocx-oxml/src/text.rs` parses `w:fldSimple` into the narrow
+`FieldType` projection, but complex `w:fldChar` fields have only a separate
+hyperlink-oriented parser. The latter rejects malformed, dirty, and nested
+fields from `CT_P::from_xml`, hardcodes the `w:` prefix, and does not return a
+general field name, arguments, switches, and cached result.
+
+The merged reader changes must instead preserve unsupported complex sequences
+as raw XML while reporting safe, recursively structured fields. Prefix aliases
+and the default WordprocessingML namespace must be recognized without treating
+foreign same-local-name XML as WordprocessingML.
+
+## Spec reference
+
+- `docs/hld/14-development-backlog.md`, "F-160, Field instruction parser".
+- `docs/hld/03-architecture.md`, "What stays put" and "Crate-level
+  conventions".
+- `docs/hld/04-opc-and-packaging.md`, "Facade conventions" and the Word
+  package-preservation rules.
+- `docs/hld/12-testing-strategy.md`, "Test taxonomy" and in-code fixtures.
+
+## Approach
+
+Replace the complex-field hyperlink scanner with one recursive parser in
+`rdocx-oxml::text`. The parser records field-marker ownership while each run is
+read with its in-scope WordprocessingML bindings. This keeps the original raw
+run children unchanged and allows complex-field recognition to distinguish
+WordprocessingML aliases from foreign collisions after paragraph parsing.
+
+Expose a concrete parsed field projection with the normalized field name,
+arguments, switches, cached-result run range, dirty state, and child fields.
+`CT_P` reports complete structured fields, including dirty fields, while
+unsupported, malformed, or unclosed sequences remain opaque and never make the
+paragraph or document fail to open. The original raw XML remains the
+serialization source in every case. `Document::links()` excludes dirty fields
+until F-162 defines the update policy.
+
+Use the same instruction tokenizer for `w:fldSimple` and complex fields. It
+keeps quoted arguments intact, identifies backslash-prefixed switches, and
+preserves the original instruction for compatibility with the existing
+`FieldType` writer and layout paths. The existing `Document::links()` method
+derives HYPERLINK links only from a valid parsed field and its cached result.
+
+## Rejected alternatives
+
+- Keep the hyperlink-only parser and merely make its failures non-fatal. It
+  cannot meet F-160's field-name, argument, switch, or nested-field contract.
+- Reparse preserved raw XML after paragraph parsing without namespace context.
+  Inherited aliases and default namespaces then become ambiguous, while foreign
+  collisions can be misclassified.
+- Materialize fields as synthetic runs. That would alter producer XML and lose
+  the exact run boundaries required for round-trip preservation.
+
+## Test plan
+
+| Category | Test | Asserts |
+|---|---|---|
+| unit, gate | `complex_fields_parse_nested_operands_and_split_instructions` | Nested field operands and instructions split across runs produce a recursive projection with the expected names, arguments, and switches |
+| unit | `simple_and_complex_fields_share_the_instruction_tokenizer` | Quoted arguments and switches have the same parsed representation for both OOXML field forms |
+| unit | `complex_fields_accept_aliases_and_default_word_namespaces` | Aliased and default WordprocessingML field markers are parsed |
+| regression | `foreign_field_marker_collisions_remain_opaque` | Same-local-name foreign elements do not produce a field projection or alter the raw XML |
+| round-trip | `unsupported_complex_fields_remain_raw_without_failing_document_open` | Dirty, malformed, and unclosed sequences open, preserve their bytes, and report no projection |
+| regression | `links_uses_a_valid_complex_hyperlink_cached_result` | A valid HYPERLINK reports its target and cached visible text, while an invalid field reports no link |
+
+The **test gate**, from the backlog, is unit. Every field form in the corpus
+parses, including nested fields and instructions split across runs.
+
+Fixtures are assembled in existing test modules. No new test binary or binary
+fixture is added.
+
+## HLD impact
+
+- `docs/hld/03-architecture.md`
+
+Record the recursive field projection, in-scope namespace identity, and opaque
+fallback for unsupported field sequences.
+
+## Risk routing
+
+- Any parser or serialiser. Read HLD 04 and HLD 06. Add alias,
+  default-namespace, foreign-collision, fixed-prefix, nested, and byte-preserving
+  round-trip coverage.
+- Public API of a published crate. Read HLD 10 and the structural rules. The
+  parsed-field accessor is additive and required by F-160. Run the package
+  dry-run and archive-size assertion during full verification.
+
+## Hash harness
+
+Expected unchanged. Parsed documents retain the original field XML as their
+serialization source, and the existing samples do not introduce a field
+projection mutation.
+
+## Implementation checklist
+
+- [ ] Define the additive recursive field projection and instruction token
+  types in `rdocx-oxml::text`.
+- [ ] Record namespace-aware complex-field markers while parsing runs without
+  changing preserved raw XML.
+- [ ] Parse complete complex fields recursively, retain dirty state, and
+  degrade malformed, unsupported, or unclosed sequences to opaque XML.
+- [ ] Route simple fields through the shared instruction tokenizer without
+  changing their existing writer and layout behavior.
+- [ ] Derive public HYPERLINK links from valid complex-field projections and
+  cached result ranges.
+- [ ] Add the unit, regression, and byte-preservation coverage in the test
+  plan.
+- [ ] Run the parser, facade, layout, package, and hash-harness checks.
+- [ ] Update the listed HLD architecture section at completion.
+
+## Open questions
+
+None. The parser reports complete structured fields and dirty state, retains
+original XML for every other sequence, and leaves evaluation and update policy
+to F-161 and F-162.

--- a/.claude/plans/F-203-design.md
+++ b/.claude/plans/F-203-design.md
@@ -1,0 +1,93 @@
+# F-203, Reader compatibility corrections
+
+**Status**: approved
+**Sprint**: S49
+**Size**: M
+**Depends on**: none
+
+## Problem
+
+The merged table-reader change recognizes `CT_TcPr` children by local name
+alone. A foreign `<ext:tcW>` is therefore parsed as the typed Word cell-width
+element and dropped when the table is written. The numbering writer also emits
+raw XML at boundary 5 after `w:suff`, although that boundary represents the
+slot before the suffix in the `CT_Lvl` schema sequence.
+
+Both failures violate the reader's preservation contract for producer XML.
+
+## Spec reference
+
+- `docs/hld/14-development-backlog.md`, "F-203, Reader compatibility
+  corrections".
+- `docs/hld/03-architecture.md`, "Crate-level conventions", unmodelled
+  subtree preservation.
+- `docs/hld/04-opc-and-packaging.md`, "Facade conventions" and the package
+  preservation rules.
+
+## Approach
+
+Thread the in-scope WordprocessingML namespace bindings from `CT_Tc` into
+`CT_TcPr`. Recognize table-cell property elements and their attributes only
+when both local name and WordprocessingML binding match. Preserve every other
+property child in a schema-slot sidecar, then emit it unchanged at the same
+slot during serialization.
+
+Move boundary 5 emission before the typed `w:suff` element. The level parser
+already assigns `isLgl` to that boundary, so the writer change restores the
+reader's existing model without changing public types.
+
+## Rejected alternatives
+
+- Keep local-name matching and skip only foreign `tcW`. Every property has the
+  same namespace-identity requirement, and a one-name exception would repeat
+  the bug.
+- Drop foreign properties while avoiding the typed projection. This still
+  violates verbatim preservation on save.
+- Renumber the level raw boundaries. The parser already assigns the schema
+  slots correctly. Only the writer loop is misplaced.
+
+## Test plan
+
+| Category | Test | Asserts |
+|---|---|---|
+| regression, gate | `foreign_cell_width_remains_raw_and_unmodelled` | A foreign same-local-name `tcW` child neither sets typed width nor changes its bytes or schema slot on write |
+| regression | `aliased_cell_width_uses_in_scope_word_bindings` | A WordprocessingML alias and matching alias attributes populate the typed width projection |
+| round-trip | `level_raw_is_lgl_stays_before_suffix` | A preserved raw `isLgl` child remains byte-identical and before typed `suff` after parse and write |
+
+The **test gate**, from the backlog, is regression. Foreign `tcW` XML remains
+unmodelled and byte-identical, and an `isLgl` raw child stays before `suff`
+after parse and write.
+
+Fixtures stay in the existing `table.rs` and `numbering.rs` unit modules.
+
+## HLD impact
+
+None. The architecture already requires namespace-aware readers and verbatim
+unmodelled-subtree preservation. This corrects the implementation to match it.
+
+## Risk routing
+
+- Parser or serialiser. Read HLD 04 and HLD 06. Add alias,
+  foreign-collision, schema-order, and byte-preservation coverage.
+- Public API of a published crate. `CT_TcPr` gains a hidden raw-preservation
+  sidecar that is required to retain producer XML. Run the package dry-run and
+  archive-size assertion during full verification.
+
+## Hash harness
+
+Expected unchanged. The affected XML stays the serialization source and no
+hash-harness fixture changes a typed property.
+
+## Implementation checklist
+
+- [ ] Record in-scope WordprocessingML bindings while parsing `CT_TcPr`.
+- [ ] Restrict typed cell-property and attribute parsing to those bindings.
+- [ ] Preserve non-Word and unsupported cell-property XML in schema slots.
+- [ ] Emit boundary 5 raw level XML before typed `w:suff`.
+- [ ] Add the regression and byte-preservation coverage in the test plan.
+- [ ] Run the changed-crate, package, and hash-harness checks.
+
+## Open questions
+
+None. The existing schema slots and namespace helpers specify the intended
+reader behavior.

--- a/.claude/reviews/F-160-correctness-pass-1.md
+++ b/.claude/reviews/F-160-correctness-pass-1.md
@@ -1,0 +1,28 @@
+# F-160, correctness, pass 1
+
+**Reviewed**: the uncommitted F-160 field-parser portion of the working diff:
+`crates/rdocx-oxml/src/text.rs` (365 additions, 216 deletions), constructed-run
+updates in `content_control.rs`, `comments.rs`, `document.rs`, and `table.rs`,
+the F-160 plan, and the architecture update.
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Not found
+
+Correctness, contract, panics, OOXML namespace identity, raw-XML preservation,
+tests, and structure produced no findings. The field marker capture at
+`crates/rdocx-oxml/src/text.rs:423-430` retains the serialization source while
+the recursive parser at `crates/rdocx-oxml/src/text.rs:2406-2469` only projects
+complete fields. The reader-facing hyperlink filter at
+`crates/rdocx-oxml/src/text.rs:743-763` excludes dirty or empty cached results.

--- a/.claude/reviews/F-203-correctness-pass-1.md
+++ b/.claude/reviews/F-203-correctness-pass-1.md
@@ -1,0 +1,29 @@
+# F-203, correctness, pass 1
+
+**Reviewed**: the uncommitted F-203 reader-compatibility portion of the working
+diff: `crates/rdocx-oxml/src/table.rs` (161 additions, 25 deletions),
+`crates/rdocx-oxml/src/numbering.rs` (14 additions, 4 deletions), the F-203
+plan, and the backlog and sprint records.
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Not found
+
+Correctness, contract, panics, OOXML namespace identity, schema order,
+raw-XML preservation, tests, and structure produced no findings. The table
+reader uses in-scope bindings at `crates/rdocx-oxml/src/table.rs:974-1058` and
+writes opaque children at their schema slots at
+`crates/rdocx-oxml/src/table.rs:1066-1133`. The numbering boundary fix at
+`crates/rdocx-oxml/src/numbering.rs:2361-2371` now emits raw boundary 5 before
+`w:suff`.

--- a/crates/rdocx-oxml/src/content_control.rs
+++ b/crates/rdocx-oxml/src/content_control.rs
@@ -610,6 +610,7 @@ fn parse_content(
                         content: Vec::new(),
                         extra_xml: Vec::new(),
                         extra_xml_positions: Vec::new(),
+                        field_markers: Vec::new(),
                         alt_drawings: Vec::new(),
                     }));
                 } else {

--- a/crates/rdocx-oxml/src/numbering.rs
+++ b/crates/rdocx-oxml/src/numbering.rs
@@ -2358,7 +2358,7 @@ impl CT_Lvl {
             writer.write_event(Event::Empty(e))?;
         }
 
-        for boundary in 2..=4 {
+        for boundary in 2..=5 {
             write_extras_at(writer, &self.extra_xml, boundary)?;
         }
         if let Some(suffix) = self.suffix {
@@ -2368,9 +2368,7 @@ impl CT_Lvl {
             e.push_attribute((val_name.as_str(), suffix.to_str()));
             writer.write_event(Event::Empty(e))?;
         }
-        for boundary in 5..=6 {
-            write_extras_at(writer, &self.extra_xml, boundary)?;
-        }
+        write_extras_at(writer, &self.extra_xml, 6)?;
         if let Some(ref text) = self.lvl_text {
             let name = qualified(word_prefix, "lvlText");
             let val_name = qualified(word_prefix, "val");
@@ -3163,6 +3161,18 @@ mod tests {
         let suffix = output.find("<w:suff").expect("suffix writes");
         let text = output.find("<w:lvlText").expect("level text writes");
         assert!(suffix < text, "suffix must precede level text: {output}");
+    }
+
+    #[test]
+    fn level_raw_is_lgl_stays_before_suffix() {
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:isLgl/><w:suff w:val="space"/></w:lvl></w:abstractNum></w:numbering>"#;
+        let numbering = CT_Numbering::from_xml(xml).expect("numbering parses");
+        let output =
+            String::from_utf8(numbering.to_xml().expect("numbering writes")).expect("XML is UTF-8");
+
+        let is_lgl = output.find("<w:isLgl/>").expect("raw isLgl writes");
+        let suffix = output.find("<w:suff").expect("suffix writes");
+        assert!(is_lgl < suffix, "isLgl must precede suffix: {output}");
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -950,26 +950,51 @@ pub struct CT_TcPr {
     pub text_direction: Option<String>,
     /// `w:cnfStyle` — which conditional parts of the table style this cell is.
     pub cnf_style: Option<String>,
+    /// Unmodelled property children retained at their schema insertion slots.
+    #[doc(hidden)]
+    pub extra_xml: Vec<(usize, Vec<u8>)>,
 }
 
 #[allow(non_snake_case)]
 impl CT_TcPr {
     pub fn from_xml(reader: &mut Reader<&[u8]>) -> Result<Self> {
+        Self::from_xml_with_prefixes(reader, &["w".to_owned()])
+    }
+
+    fn from_xml_with_prefixes(
+        reader: &mut Reader<&[u8]>,
+        word_prefixes: &[String],
+    ) -> Result<Self> {
         let mut pr = CT_TcPr::default();
+        let mut boundary = 0;
         let mut buf = Vec::new();
 
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Empty(ref e)) => {
-                    Self::parse_property_element(e, &mut pr)?;
+                    let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let (at, next) = tc_pr_raw_boundary(e.name().as_ref(), boundary);
+                    if Self::parse_property_element(e, &mut pr, &prefixes)? {
+                        boundary = next;
+                    } else {
+                        pr.extra_xml.push((at, capture_empty_element(e)?));
+                        boundary = next;
+                    }
                 }
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
-                    if matches_local_name(name.as_ref(), b"tcBorders") {
-                        pr.borders = Some(CT_TblBorders::from_xml(reader)?);
-                    } else {
-                        Self::parse_property_element(e, &mut pr)?;
+                    let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let (at, next) = tc_pr_raw_boundary(name.as_ref(), boundary);
+                    if is_word_element(name.as_ref(), b"tcBorders", &prefixes) {
+                        pr.borders =
+                            Some(CT_TblBorders::from_xml_with_prefixes(reader, &prefixes)?);
+                        boundary = next;
+                    } else if Self::parse_property_element(e, &mut pr, &prefixes)? {
                         reader.read_to_end_into(name, &mut Vec::new())?;
+                        boundary = next;
+                    } else {
+                        pr.extra_xml.push((at, capture_element(reader, e)?));
+                        boundary = next;
                     }
                 }
                 Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"tcPr") => {
@@ -985,12 +1010,16 @@ impl CT_TcPr {
         Ok(pr)
     }
 
-    fn parse_property_element(e: &BytesStart<'_>, pr: &mut Self) -> Result<()> {
+    fn parse_property_element(
+        e: &BytesStart<'_>,
+        pr: &mut Self,
+        word_prefixes: &[String],
+    ) -> Result<bool> {
         let name = e.name();
-        if matches_local_name(name.as_ref(), b"tcW") {
-            pr.width = Some(CT_TblWidth::from_xml_attrs(e)?);
-        } else if matches_local_name(name.as_ref(), b"gridSpan") {
-            if let Some(val) = get_val_attr(e)? {
+        if is_word_element(name.as_ref(), b"tcW", word_prefixes) {
+            pr.width = Some(CT_TblWidth::from_xml_attrs_with_prefixes(e, word_prefixes)?);
+        } else if is_word_element(name.as_ref(), b"gridSpan", word_prefixes) {
+            if let Some(val) = get_word_val_attr(e, word_prefixes)? {
                 let span: u32 = val.parse()?;
                 if span == 0 {
                     return Err(OxmlError::InvalidValue(
@@ -999,8 +1028,8 @@ impl CT_TcPr {
                 }
                 pr.grid_span = Some(span);
             }
-        } else if matches_local_name(name.as_ref(), b"vMerge") {
-            pr.v_merge = Some(match get_val_attr(e)?.as_deref() {
+        } else if is_word_element(name.as_ref(), b"vMerge", word_prefixes) {
+            pr.v_merge = Some(match get_word_val_attr(e, word_prefixes)?.as_deref() {
                 Some("restart") => VMerge::Restart,
                 Some("continue") | None => VMerge::Continue,
                 Some(value) => {
@@ -1009,22 +1038,24 @@ impl CT_TcPr {
                     )));
                 }
             });
-        } else if matches_local_name(name.as_ref(), b"vAlign") {
-            if let Some(val) = get_val_attr(e)? {
+        } else if is_word_element(name.as_ref(), b"vAlign", word_prefixes) {
+            if let Some(val) = get_word_val_attr(e, word_prefixes)? {
                 pr.v_align = Some(ST_VerticalJc::from_str(&val));
             }
-        } else if matches_local_name(name.as_ref(), b"shd") {
-            pr.shading = Some(CT_Shd::from_xml_attrs(e)?);
-        } else if matches_local_name(name.as_ref(), b"cnfStyle") {
-            pr.cnf_style = get_val_attr(e)?;
-        } else if matches_local_name(name.as_ref(), b"noWrap") {
+        } else if is_word_element(name.as_ref(), b"shd", word_prefixes) {
+            pr.shading = Some(CT_Shd::from_xml_attrs_with_prefixes(e, word_prefixes)?);
+        } else if is_word_element(name.as_ref(), b"cnfStyle", word_prefixes) {
+            pr.cnf_style = get_word_val_attr(e, word_prefixes)?;
+        } else if is_word_element(name.as_ref(), b"noWrap", word_prefixes) {
             pr.no_wrap = Some(true);
-        } else if matches_local_name(name.as_ref(), b"textDirection")
-            && let Some(val) = get_val_attr(e)?
+        } else if is_word_element(name.as_ref(), b"textDirection", word_prefixes)
+            && let Some(val) = get_word_val_attr(e, word_prefixes)?
         {
             pr.text_direction = Some(val);
+        } else {
+            return Ok(false);
         }
-        Ok(())
+        Ok(true)
     }
 
     pub fn to_xml<W: std::io::Write>(&self, writer: &mut Writer<W>) -> Result<()> {
@@ -1034,16 +1065,19 @@ impl CT_TcPr {
 
         writer.write_event(Event::Start(BytesStart::new("w:tcPr")))?;
 
+        write_extras_at(writer, &self.extra_xml, 0)?;
         if let Some(ref cnf) = self.cnf_style {
             let mut e = BytesStart::new("w:cnfStyle");
             e.push_attribute(("w:val", cnf.as_str()));
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 1)?;
         if let Some(ref width) = self.width {
             width.write_xml(writer, "w:tcW")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 2)?;
         if let Some(grid_span) = self.grid_span
             && grid_span > 1
         {
@@ -1053,6 +1087,7 @@ impl CT_TcPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 3)?;
         if let Some(ref vm) = self.v_merge {
             let mut e = BytesStart::new("w:vMerge");
             match vm {
@@ -1062,31 +1097,38 @@ impl CT_TcPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 4)?;
         if let Some(ref borders) = self.borders
             && !borders.is_empty()
         {
             borders.to_xml(writer, "w:tcBorders")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 5)?;
         if let Some(ref shd) = self.shading {
             shd.write_xml(writer, "w:shd")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 6)?;
         if let Some(true) = self.no_wrap {
             writer.write_event(Event::Empty(BytesStart::new("w:noWrap")))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 7)?;
         if let Some(ref va) = self.v_align {
             let mut e = BytesStart::new("w:vAlign");
             e.push_attribute(("w:val", va.to_str()));
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 8)?;
         if let Some(ref td) = self.text_direction {
             let mut e = BytesStart::new("w:textDirection");
             e.push_attribute(("w:val", td.as_str()));
             writer.write_event(Event::Empty(e))?;
         }
+
+        write_extras_at(writer, &self.extra_xml, 9)?;
 
         writer.write_event(Event::End(BytesEnd::new("w:tcPr")))?;
         Ok(())
@@ -1102,6 +1144,31 @@ impl CT_TcPr {
             && self.no_wrap.is_none()
             && self.text_direction.is_none()
             && self.cnf_style.is_none()
+            && self.extra_xml.is_empty()
+    }
+}
+
+fn tc_pr_raw_boundary(name: &[u8], current: usize) -> (usize, usize) {
+    if matches_local_name(name, b"cnfStyle") {
+        (0, 1)
+    } else if matches_local_name(name, b"tcW") {
+        (1, 2)
+    } else if matches_local_name(name, b"gridSpan") {
+        (2, 3)
+    } else if matches_local_name(name, b"vMerge") {
+        (3, 4)
+    } else if matches_local_name(name, b"tcBorders") {
+        (4, 5)
+    } else if matches_local_name(name, b"shd") {
+        (5, 6)
+    } else if matches_local_name(name, b"noWrap") {
+        (6, 7)
+    } else if matches_local_name(name, b"vAlign") {
+        (7, 8)
+    } else if matches_local_name(name, b"textDirection") {
+        (8, 9)
+    } else {
+        (current, current)
     }
 }
 
@@ -1184,8 +1251,8 @@ impl CT_Tc {
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
-                    if matches_local_name(name.as_ref(), b"tcPr") {
-                        properties = Some(CT_TcPr::from_xml(reader)?);
+                    if is_word_element(name.as_ref(), b"tcPr", &prefixes) {
+                        properties = Some(CT_TcPr::from_xml_with_prefixes(reader, &prefixes)?);
                     } else if is_word_element(name.as_ref(), b"p", &prefixes) {
                         content.push(CellContent::Paragraph(CT_P::from_xml_with_prefixes(
                             reader, &prefixes,
@@ -1211,7 +1278,8 @@ impl CT_Tc {
                 }
                 Ok(Event::Empty(ref e)) => {
                     let name = e.name();
-                    if !matches_local_name(name.as_ref(), b"tcPr") {
+                    let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    if !is_word_element(name.as_ref(), b"tcPr", &prefixes) {
                         extra_xml.push((content.len(), capture_empty_element(e)?));
                     }
                 }
@@ -1825,6 +1893,74 @@ mod tests {
         assert_eq!(properties.v_align, Some(ST_VerticalJc::Center));
         assert_eq!(properties.text_direction.as_deref(), Some("btLr"));
         assert_eq!(properties.cnf_style.as_deref(), Some("100000000000"));
+    }
+
+    #[test]
+    fn foreign_cell_width_remains_raw_and_unmodelled() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="100"/></w:tblGrid><w:tr><w:tc><w:tcPr><ext:tcW xmlns:ext="urn:producer" ext:w="72" ext:type="dxa"/><w:tcW w:w="90" w:type="dxa"/></w:tcPr><w:p/></w:tc></w:tr>"#,
+        );
+        let properties = table.rows[0].cells[0]
+            .properties
+            .as_ref()
+            .expect("cell properties parse");
+
+        assert_eq!(properties.width.as_ref().map(|width| width.w), Some(90));
+        assert_eq!(
+            properties.extra_xml,
+            vec![(
+                1,
+                br#"<ext:tcW xmlns:ext="urn:producer" ext:w="72" ext:type="dxa"/>"#.to_vec(),
+            )]
+        );
+
+        let mut output = Vec::new();
+        table
+            .to_xml(&mut Writer::new(&mut output))
+            .expect("table writes");
+        let output = String::from_utf8(output).expect("XML is UTF-8");
+        let foreign = output
+            .find(r#"<ext:tcW xmlns:ext="urn:producer" ext:w="72" ext:type="dxa"/>"#)
+            .expect("foreign width writes");
+        let typed = output.find("<w:tcW").expect("typed width writes");
+        assert!(
+            foreign < typed,
+            "foreign width stays before typed width: {output}"
+        );
+    }
+
+    #[test]
+    fn aliased_cell_width_uses_in_scope_word_bindings() {
+        let word_namespace = crate::namespace::W_NS;
+        let xml = format!(
+            r#"<q:tbl xmlns:q="{word_namespace}"><q:tblGrid><q:gridCol q:w="100"/></q:tblGrid><q:tr><q:tc><q:tcPr><q:tcW q:w="72" q:type="dxa"/></q:tcPr><q:p/></q:tc></q:tr></q:tbl>"#
+        );
+        let mut reader = Reader::from_str(&xml);
+        let mut buffer = Vec::new();
+        let table = loop {
+            match reader.read_event_into(&mut buffer) {
+                Ok(Event::Start(element))
+                    if matches_local_name(element.name().as_ref(), b"tbl") =>
+                {
+                    let prefixes = word_prefixes_at(&element, &[]).expect("root bindings");
+                    break CT_Tbl::from_xml_with_prefixes(&mut reader, &prefixes)
+                        .expect("table parses");
+                }
+                Ok(Event::Eof) => panic!("missing table"),
+                Ok(_) => {}
+                Err(error) => panic!("invalid fixture: {error}"),
+            }
+            buffer.clear();
+        };
+
+        assert_eq!(
+            table.rows[0].cells[0]
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.width.as_ref())
+                .map(|width| width.w),
+            Some(72)
+        );
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/text.rs
+++ b/crates/rdocx-oxml/src/text.rs
@@ -49,6 +49,43 @@ pub enum FieldType {
     Other(String),
 }
 
+/// One parsed field switch, without the leading backslash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldSwitch {
+    pub name: String,
+    pub argument: Option<String>,
+}
+
+/// A tokenized Word field instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldInstruction {
+    pub original: String,
+    pub name: String,
+    pub arguments: Vec<String>,
+    pub switches: Vec<FieldSwitch>,
+}
+
+/// A complete complex field projected from `w:fldChar` and `w:instrText` runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComplexField {
+    pub instruction: FieldInstruction,
+    pub run_start: usize,
+    pub run_end: usize,
+    pub cached_text: String,
+    pub dirty: bool,
+    pub children: Vec<ComplexField>,
+}
+
+/// A namespace-resolved complex-field marker retained alongside raw run XML.
+#[doc(hidden)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldMarker {
+    Begin { dirty: bool },
+    Instruction(String),
+    Separate { dirty: bool },
+    End { dirty: bool },
+}
+
 /// Content that can appear inside a run.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RunContent {
@@ -180,6 +217,9 @@ pub struct CT_R {
     /// Parsed raw-child positions among properties and typed run content.
     #[doc(hidden)]
     pub extra_xml_positions: Vec<usize>,
+    /// Namespace-resolved field markers retained alongside `extra_xml`.
+    #[doc(hidden)]
+    pub field_markers: Vec<FieldMarker>,
     /// Drawings read out of an `mc:AlternateContent` block, for layout only.
     ///
     /// Never serialised. The verbatim copy in `extra_xml` is what gets
@@ -195,6 +235,7 @@ impl CT_R {
             content: vec![RunContent::Text(CT_Text::new(text))],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
             alt_drawings: Vec::new(),
         }
     }
@@ -302,6 +343,7 @@ impl CT_R {
         let mut content = Vec::new();
         let mut extra_xml = Vec::new();
         let mut extra_xml_positions = Vec::new();
+        let mut field_markers = Vec::new();
         let mut alt_drawings = Vec::new();
         let mut modeled_children = 0usize;
         let mut buf = Vec::new();
@@ -379,7 +421,12 @@ impl CT_R {
                         extra_xml_positions.push(modeled_children);
                     } else {
                         // Capture unknown child elements as raw XML
-                        extra_xml.push(capture_element(reader, e)?);
+                        let marker = field_marker_from_element(e, &prefixes)?;
+                        let raw = capture_element(reader, e)?;
+                        if let Some(marker) = marker {
+                            field_markers.push(field_marker_with_instruction(marker, &raw)?);
+                        }
+                        extra_xml.push(raw);
                         extra_xml_positions.push(modeled_children);
                     }
                 }
@@ -429,6 +476,9 @@ impl CT_R {
                         // capturing it here would move it past <w:t> and
                         // produce schema-invalid output. An empty rPr carries
                         // no formatting, so dropping it loses nothing.
+                        if let Some(marker) = field_marker_from_element(e, &prefixes)? {
+                            field_markers.push(marker);
+                        }
                         extra_xml.push(capture_empty_element(e)?);
                         extra_xml_positions.push(modeled_children);
                     }
@@ -448,6 +498,7 @@ impl CT_R {
             content,
             extra_xml,
             extra_xml_positions,
+            field_markers,
             alt_drawings,
         })
     }
@@ -611,7 +662,7 @@ struct ParsedHyperlinkChildren {
     extra_xml: Vec<(usize, usize, Vec<u8>)>,
 }
 
-/// A hyperlink represented by a complex field sequence rather than `w:hyperlink`.
+/// A HYPERLINK represented by a valid complex field sequence.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComplexFieldHyperlink {
     pub run_start: usize,
@@ -620,19 +671,12 @@ pub struct ComplexFieldHyperlink {
 }
 
 #[derive(Debug)]
-enum ComplexFieldPart {
-    Begin { dirty: bool },
-    Instruction(String),
-    Separate { dirty: bool },
-    End { dirty: bool },
-}
-
-#[derive(Debug)]
 struct OpenComplexField {
     instruction: String,
     result_start: Option<usize>,
-    cached_text: String,
     dirty: bool,
+    valid: bool,
+    children: Vec<ComplexField>,
 }
 
 type ParsedHyperlinkAttributes = (Option<String>, Option<String>, Vec<(String, String)>);
@@ -687,12 +731,36 @@ impl CT_P {
         self.runs().iter().map(|run| run.text()).collect()
     }
 
+    /// Return recursively parsed complex fields with complete cached results.
+    pub fn complex_fields(&self) -> Vec<ComplexField> {
+        parse_complex_fields(&self.runs)
+    }
+
     /// Return the cached-result spans of valid complex `HYPERLINK` fields.
     ///
     /// Complex fields stay in their original run form for round-trip writing.
     /// This projection supplies their external targets to reader consumers.
     pub fn complex_field_hyperlinks(&self) -> Vec<ComplexFieldHyperlink> {
-        parse_complex_fields(&self.runs).unwrap_or_default()
+        self.complex_fields()
+            .into_iter()
+            .filter(|field| {
+                !field.dirty
+                    && !field.cached_text.is_empty()
+                    && field.instruction.name == "HYPERLINK"
+            })
+            .filter_map(|field| {
+                field
+                    .instruction
+                    .arguments
+                    .first()
+                    .cloned()
+                    .map(|target| ComplexFieldHyperlink {
+                        run_start: field.run_start,
+                        run_end: field.run_end,
+                        target,
+                    })
+            })
+            .collect()
     }
 
     /// Return direct and content-control-wrapped runs in document order.
@@ -1204,6 +1272,7 @@ impl CT_P {
                             }],
                             extra_xml: Vec::new(),
                             extra_xml_positions: Vec::new(),
+                            field_markers: Vec::new(),
                             alt_drawings: Vec::new(),
                         });
                     } else if is_word_element(name.as_ref(), b"commentRangeStart", &prefixes)
@@ -1310,7 +1379,7 @@ impl CT_P {
             buf.clear();
         }
 
-        let paragraph = CT_P {
+        Ok(CT_P {
             properties,
             runs,
             hyperlinks,
@@ -1319,9 +1388,7 @@ impl CT_P {
             extra_xml,
             content_controls,
             revisions,
-        };
-        parse_complex_fields(&paragraph.runs)?;
-        Ok(paragraph)
+        })
     }
 
     pub fn to_xml<W: std::io::Write>(&self, writer: &mut Writer<W>) -> Result<()> {
@@ -2254,232 +2321,196 @@ fn optional_word_attribute(
     None
 }
 
-/// Parse a field instruction string into a FieldType.
+impl FieldInstruction {
+    fn parse(instruction: &str) -> Self {
+        let original = instruction.to_owned();
+        let tokens = field_instruction_tokens(instruction);
+        let name = tokens
+            .first()
+            .map(|token| token.to_ascii_uppercase())
+            .unwrap_or_default();
+        let mut arguments = Vec::new();
+        let mut switches = Vec::new();
+        let mut index = 1;
+
+        while let Some(token) = tokens.get(index) {
+            if let Some(name) = token.strip_prefix('\\') {
+                index += 1;
+                let argument = tokens
+                    .get(index)
+                    .filter(|next| !next.starts_with('\\'))
+                    .cloned();
+                if argument.is_some() {
+                    index += 1;
+                }
+                switches.push(FieldSwitch {
+                    name: name.to_owned(),
+                    argument,
+                });
+            } else {
+                arguments.push(token.clone());
+                index += 1;
+            }
+        }
+
+        Self {
+            original,
+            name,
+            arguments,
+            switches,
+        }
+    }
+}
+
+fn field_instruction_tokens(instruction: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quoted = false;
+
+    for character in instruction.chars() {
+        match character {
+            '"' => quoted = !quoted,
+            character if character.is_whitespace() && !quoted => {
+                if !token.is_empty() {
+                    tokens.push(std::mem::take(&mut token));
+                }
+            }
+            _ => token.push(character),
+        }
+    }
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+    tokens
+}
+
+/// Parse a field instruction string into the existing renderer field type.
 fn parse_field_instruction(instr: &str) -> FieldType {
-    let instruction = instr.trim();
-    let trimmed = instruction.to_uppercase();
-    // Field instruction may have switches like "PAGE \* MERGEFORMAT"
-    let keyword = trimmed.split_whitespace().next().unwrap_or("");
-    match keyword {
+    let parsed = FieldInstruction::parse(instr.trim());
+    let bookmark = parsed.arguments.first().cloned().unwrap_or_default();
+    match parsed.name.as_str() {
         "PAGE" => FieldType::Page,
         "NUMPAGES" => FieldType::NumPages,
-        "REF" | "PAGEREF" => {
-            let bookmark = instruction
-                .split_whitespace()
-                .nth(1)
-                .unwrap_or("")
-                .trim_matches('"')
-                .to_owned();
-            if bookmark.is_empty() {
-                FieldType::Other(instruction.to_owned())
-            } else if keyword == "REF" {
-                FieldType::Ref {
-                    bookmark,
-                    instruction: instruction.to_owned(),
-                }
-            } else {
-                FieldType::PageRef {
-                    bookmark,
-                    instruction: instruction.to_owned(),
-                }
-            }
-        }
-        _ => FieldType::Other(instruction.to_owned()),
+        "REF" if !bookmark.is_empty() => FieldType::Ref {
+            bookmark,
+            instruction: parsed.original,
+        },
+        "PAGEREF" if !bookmark.is_empty() => FieldType::PageRef {
+            bookmark,
+            instruction: parsed.original,
+        },
+        _ => FieldType::Other(parsed.original.trim().to_owned()),
     }
 }
 
-fn parse_complex_fields(runs: &[CT_R]) -> Result<Vec<ComplexFieldHyperlink>> {
-    let mut field = None;
-    let mut hyperlinks = Vec::new();
+fn parse_complex_fields(runs: &[CT_R]) -> Vec<ComplexField> {
+    let mut roots = Vec::new();
+    let mut stack = Vec::<OpenComplexField>::new();
 
     for (run_index, run) in runs.iter().enumerate() {
-        let parts = complex_field_parts(run)?;
-        let had_result = field
-            .as_ref()
-            .is_some_and(|field: &OpenComplexField| field.result_start.is_some());
-        let mut ended = None;
-
-        for part in parts {
-            match part {
-                ComplexFieldPart::Begin { dirty } => {
-                    if field.is_some() {
-                        return Err(OxmlError::MissingElement(
-                            "nested complex field is unsupported".to_owned(),
-                        ));
-                    }
-                    field = Some(OpenComplexField {
-                        instruction: String::new(),
-                        result_start: None,
-                        cached_text: String::new(),
-                        dirty,
-                    });
-                }
-                ComplexFieldPart::Instruction(instruction) => {
-                    let Some(field) = field.as_mut() else {
-                        return Err(OxmlError::MissingElement(
-                            "w:instrText without a complex field begin".to_owned(),
-                        ));
-                    };
-                    if field.result_start.is_some() {
-                        return Err(OxmlError::MissingElement(
-                            "w:instrText after a complex field separator".to_owned(),
-                        ));
-                    }
-                    field.instruction.push_str(&instruction);
-                }
-                ComplexFieldPart::Separate { dirty } => {
-                    let Some(field) = field.as_mut() else {
-                        return Err(OxmlError::MissingElement(
-                            "complex field separator without a begin".to_owned(),
-                        ));
-                    };
-                    if field.result_start.replace(run_index + 1).is_some() {
-                        return Err(OxmlError::MissingElement(
-                            "complex field has more than one separator".to_owned(),
-                        ));
-                    }
-                    field.dirty |= dirty;
-                }
-                ComplexFieldPart::End { dirty } => {
-                    let Some(completed) = field.take() else {
-                        return Err(OxmlError::MissingElement(
-                            "complex field end without a begin".to_owned(),
-                        ));
-                    };
-                    ended = Some(OpenComplexField {
-                        dirty: completed.dirty || dirty,
-                        ..completed
-                    });
-                }
-            }
-        }
-
-        if (had_result
-            || field
-                .as_ref()
-                .is_some_and(|field| field.result_start == Some(run_index)))
-            && let Some(field) = field.as_mut()
-        {
-            field.cached_text.push_str(&run.text());
-        }
-        if let Some(mut completed) = ended {
-            if had_result {
-                completed.cached_text.push_str(&run.text());
-            }
-            let Some(result_start) = completed.result_start else {
-                return Err(OxmlError::MissingElement(
-                    "complex field has no cached result".to_owned(),
-                ));
-            };
-            if completed.instruction.trim().is_empty() {
-                return Err(OxmlError::MissingElement(
-                    "complex field has no instruction".to_owned(),
-                ));
-            }
-            if completed.dirty || completed.cached_text.is_empty() {
-                return Err(OxmlError::MissingElement(
-                    "complex field has an unsafe cached result".to_owned(),
-                ));
-            }
-            if complex_field_is_hyperlink(&completed.instruction) {
-                let target = hyperlink_target(&completed.instruction).ok_or_else(|| {
-                    OxmlError::InvalidValue("complex HYPERLINK field has no target".to_owned())
-                })?;
-                hyperlinks.push(ComplexFieldHyperlink {
-                    run_start: result_start,
-                    run_end: run_index + 1,
-                    target,
-                });
-            }
-        }
-    }
-
-    if field.is_some() {
-        return Err(OxmlError::MissingElement(
-            "unclosed complex field".to_owned(),
-        ));
-    }
-    Ok(hyperlinks)
-}
-
-fn complex_field_parts(run: &CT_R) -> Result<Vec<ComplexFieldPart>> {
-    let mut parts = Vec::new();
-    for raw in &run.extra_xml {
-        let mut reader = Reader::from_reader(raw.as_slice());
-        let mut buffer = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buffer)? {
-                Event::Start(element)
-                    if is_standard_word_element(element.name().as_ref(), b"instrText") =>
-                {
-                    let text = reader
-                        .read_text(element.name())
-                        .map(|text| crate::xml_text::decode_escaped(&text))?;
-                    parts.push(ComplexFieldPart::Instruction(text));
-                    break;
-                }
-                Event::Start(element) | Event::Empty(element)
-                    if is_standard_word_element(element.name().as_ref(), b"fldChar") =>
-                {
-                    let mut field_type = None;
-                    let mut dirty = false;
-                    for attribute in element.attributes() {
-                        let attribute = attribute?;
-                        if matches_local_name(attribute.key.as_ref(), b"fldCharType") {
-                            field_type = Some(std::str::from_utf8(&attribute.value)?.to_owned());
-                        } else if matches_local_name(attribute.key.as_ref(), b"dirty") {
-                            dirty = matches!(
-                                std::str::from_utf8(&attribute.value)?,
-                                "true" | "1" | "on"
-                            );
+        for marker in &run.field_markers {
+            match marker {
+                FieldMarker::Begin { dirty } => stack.push(OpenComplexField {
+                    instruction: String::new(),
+                    result_start: None,
+                    dirty: *dirty,
+                    valid: true,
+                    children: Vec::new(),
+                }),
+                FieldMarker::Instruction(instruction) => {
+                    if let Some(field) = stack.last_mut() {
+                        if field.result_start.is_some() {
+                            field.valid = false;
+                        } else {
+                            field.instruction.push_str(instruction);
                         }
                     }
-                    match field_type.as_deref() {
-                        Some("begin") => parts.push(ComplexFieldPart::Begin { dirty }),
-                        Some("separate") => parts.push(ComplexFieldPart::Separate { dirty }),
-                        Some("end") => parts.push(ComplexFieldPart::End { dirty }),
-                        _ => {}
-                    }
-                    break;
                 }
-                Event::Eof => break,
-                _ => {}
+                FieldMarker::Separate { dirty } => {
+                    if let Some(field) = stack.last_mut() {
+                        if field.result_start.replace(run_index + 1).is_some() {
+                            field.valid = false;
+                        }
+                        field.dirty |= *dirty;
+                    }
+                }
+                FieldMarker::End { dirty } => {
+                    let Some(mut field) = stack.pop() else {
+                        continue;
+                    };
+                    field.dirty |= *dirty;
+                    let parsed = field.result_start.and_then(|result_start| {
+                        let instruction = FieldInstruction::parse(&field.instruction);
+                        (!instruction.name.is_empty() && field.valid).then(|| ComplexField {
+                            instruction,
+                            run_start: result_start,
+                            run_end: run_index + 1,
+                            cached_text: runs[result_start..run_index + 1]
+                                .iter()
+                                .map(CT_R::text)
+                                .collect(),
+                            dirty: field.dirty,
+                            children: field.children,
+                        })
+                    });
+                    if let Some(parent) = stack.last_mut() {
+                        if let Some(parsed) = parsed {
+                            parent.children.push(parsed);
+                        } else {
+                            parent.valid = false;
+                        }
+                    } else if let Some(parsed) = parsed {
+                        roots.push(parsed);
+                    }
+                }
             }
-            buffer.clear();
         }
     }
-    Ok(parts)
+    roots
 }
 
-fn is_standard_word_element(name: &[u8], local: &[u8]) -> bool {
-    name.strip_prefix(b"w:") == Some(local)
-}
-
-fn hyperlink_target(instruction: &str) -> Option<String> {
-    let instruction = instruction.trim();
-    let rest = instruction.get(9..)?;
-    if !instruction
-        .get(..9)
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("HYPERLINK"))
-        || (!rest.is_empty() && !rest.chars().next().is_some_and(char::is_whitespace))
-    {
-        return None;
+fn field_marker_from_element(
+    element: &BytesStart<'_>,
+    word_prefixes: &[String],
+) -> Result<Option<FieldMarker>> {
+    if is_word_element(element.name().as_ref(), b"instrText", word_prefixes) {
+        return Ok(Some(FieldMarker::Instruction(String::new())));
     }
-    let rest = rest.trim_start();
-    if let Some(rest) = rest.strip_prefix('"') {
-        return rest.split_once('"').map(|(target, _)| target.to_owned());
+    if !is_word_element(element.name().as_ref(), b"fldChar", word_prefixes) {
+        return Ok(None);
     }
-    rest.split_whitespace()
-        .next()
-        .filter(|target| !target.starts_with('\\'))
-        .map(str::to_owned)
+
+    let dirty = optional_word_attribute(element, b"dirty", word_prefixes)
+        .is_some_and(|value| matches!(value.as_str(), "true" | "1" | "on"));
+    Ok(
+        match optional_word_attribute(element, b"fldCharType", word_prefixes).as_deref() {
+            Some("begin") => Some(FieldMarker::Begin { dirty }),
+            Some("separate") => Some(FieldMarker::Separate { dirty }),
+            Some("end") => Some(FieldMarker::End { dirty }),
+            _ => None,
+        },
+    )
 }
 
-fn complex_field_is_hyperlink(instruction: &str) -> bool {
-    instruction
-        .split_whitespace()
-        .next()
-        .is_some_and(|keyword| keyword.eq_ignore_ascii_case("HYPERLINK"))
+fn field_marker_with_instruction(marker: FieldMarker, raw: &[u8]) -> Result<FieldMarker> {
+    let FieldMarker::Instruction(_) = marker else {
+        return Ok(marker);
+    };
+    let mut reader = Reader::from_reader(raw);
+    let mut buffer = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buffer)? {
+            Event::Start(element) => {
+                let instruction = reader
+                    .read_text(element.name())
+                    .map(|text| crate::xml_text::decode_escaped(&text))?;
+                return Ok(FieldMarker::Instruction(instruction));
+            }
+            Event::Empty(_) | Event::Eof => return Ok(FieldMarker::Instruction(String::new())),
+            _ => {}
+        }
+        buffer.clear();
+    }
 }
 
 impl Default for CT_P {
@@ -2550,7 +2581,122 @@ mod tests {
     }
 
     #[test]
-    fn unsafe_complex_fields_fail_closed() {
+    fn complex_fields_parse_nested_operands_and_split_instructions() {
+        let p = parse_paragraph(concat!(
+            r#"<w:r><w:fldChar w:fldCharType="begin"/></w:r>"#,
+            r#"<w:r><w:instrText> HYPER</w:instrText></w:r>"#,
+            r#"<w:r><w:instrText>LINK </w:instrText></w:r>"#,
+            r#"<w:r><w:fldChar w:fldCharType="begin"/></w:r>"#,
+            r#"<w:r><w:instrText> REF destination </w:instrText></w:r>"#,
+            r#"<w:r><w:fldChar w:fldCharType="separate"/></w:r>"#,
+            r#"<w:r><w:t>https://example.test</w:t></w:r>"#,
+            r#"<w:r><w:fldChar w:fldCharType="end"/></w:r>"#,
+            r#"<w:r><w:fldChar w:fldCharType="separate"/></w:r>"#,
+            r#"<w:r><w:t>Example link</w:t></w:r>"#,
+            r#"<w:r><w:fldChar w:fldCharType="end"/></w:r>"#,
+        ));
+
+        assert_eq!(p.text(), "https://example.testExample link");
+        let field = &p.complex_fields()[0];
+        assert_eq!(field.instruction.name, "HYPERLINK");
+        assert_eq!(field.children[0].instruction.name, "REF");
+    }
+
+    #[test]
+    fn simple_and_complex_fields_share_the_instruction_tokenizer() {
+        let instruction = r#" REF "destination name" \h \* MERGEFORMAT "#;
+        let simple = parse_field_instruction(instruction);
+        let parsed = FieldInstruction::parse(instruction);
+
+        assert!(matches!(simple, FieldType::Ref { .. }));
+        assert_eq!(parsed.arguments, vec!["destination name"]);
+        assert_eq!(
+            parsed.switches,
+            vec![
+                FieldSwitch {
+                    name: "h".to_owned(),
+                    argument: None,
+                },
+                FieldSwitch {
+                    name: "*".to_owned(),
+                    argument: Some("MERGEFORMAT".to_owned()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn complex_fields_accept_aliases_and_default_word_namespaces() {
+        let word_namespace = crate::namespace::W_NS;
+        let alias = parse_paragraph(&format!(
+            r#"<q:r xmlns:q="{word_namespace}"><q:fldChar q:fldCharType="begin"/></q:r><q:r xmlns:q="{word_namespace}"><q:instrText> HYPERLINK &quot;https://alias.test&quot; </q:instrText></q:r><q:r xmlns:q="{word_namespace}"><q:fldChar q:fldCharType="separate"/></q:r><q:r xmlns:q="{word_namespace}"><q:t>Alias</q:t></q:r><q:r xmlns:q="{word_namespace}"><q:fldChar q:fldCharType="end"/></q:r>"#
+        ));
+        let default = parse_paragraph(&format!(
+            r#"<r xmlns="{word_namespace}" xmlns:w="{word_namespace}"><fldChar w:fldCharType="begin"/></r><r xmlns="{word_namespace}"><instrText> HYPERLINK &quot;https://default.test&quot; </instrText></r><r xmlns="{word_namespace}" xmlns:w="{word_namespace}"><fldChar w:fldCharType="separate"/></r><r xmlns="{word_namespace}"><t>Default</t></r><r xmlns="{word_namespace}" xmlns:w="{word_namespace}"><fldChar w:fldCharType="end"/></r>"#
+        ));
+
+        assert_eq!(
+            alias.complex_field_hyperlinks()[0].target,
+            "https://alias.test"
+        );
+        assert_eq!(
+            default.complex_field_hyperlinks()[0].target,
+            "https://default.test"
+        );
+    }
+
+    #[test]
+    fn foreign_field_marker_collisions_remain_opaque() {
+        let p = parse_paragraph(concat!(
+            r#"<ext:r xmlns:ext="urn:producer"><ext:fldChar ext:fldCharType="begin"/></ext:r>"#,
+            r#"<ext:r xmlns:ext="urn:producer"><ext:instrText> HYPERLINK https://foreign.test </ext:instrText></ext:r>"#,
+        ));
+
+        assert!(p.complex_fields().is_empty());
+        let mut output = Vec::new();
+        p.to_xml(&mut Writer::new(&mut output))
+            .expect("paragraph writes");
+        assert!(
+            String::from_utf8(output)
+                .expect("XML is UTF-8")
+                .contains(r#"<ext:fldChar ext:fldCharType="begin"/>"#)
+        );
+    }
+
+    #[test]
+    fn unsupported_complex_fields_remain_raw_without_failing_document_open() {
+        let xml = concat!(
+            r#"<w:p><w:r><w:fldChar w:fldCharType="begin" w:dirty="true"/></w:r>"#,
+            r#"<w:r><w:instrText> HYPERLINK &quot;https://example.test&quot; </w:instrText></w:r>"#,
+            r#"</w:p>"#,
+        );
+        let mut reader = Reader::from_str(xml);
+        let mut buffer = Vec::new();
+        loop {
+            match reader.read_event_into(&mut buffer) {
+                Ok(Event::Start(element)) if matches_local_name(element.name().as_ref(), b"p") => {
+                    let paragraph = CT_P::from_xml(&mut reader).expect("paragraph opens");
+                    let mut output = Vec::new();
+                    paragraph
+                        .to_xml(&mut Writer::new(&mut output))
+                        .expect("paragraph writes");
+                    assert!(
+                        String::from_utf8(output)
+                            .expect("XML is UTF-8")
+                            .contains(r#"<w:fldChar w:fldCharType="begin" w:dirty="true"/>"#)
+                    );
+                    break;
+                }
+                Ok(Event::Eof) => panic!("missing paragraph"),
+                Ok(_) => {}
+                Err(error) => panic!("invalid fixture: {error}"),
+            }
+            buffer.clear();
+        }
+    }
+
+    #[test]
+    fn unsafe_complex_fields_do_not_expose_hyperlinks() {
         let cases = [
             concat!(
                 r#"<w:r><w:fldChar w:fldCharType="begin"/></w:r>"#,
@@ -2594,7 +2740,8 @@ mod tests {
                     Ok(Event::Start(element))
                         if matches_local_name(element.name().as_ref(), b"p") =>
                     {
-                        assert!(CT_P::from_xml(&mut reader).is_err(), "{case}");
+                        let paragraph = CT_P::from_xml(&mut reader).expect("paragraph opens");
+                        assert!(paragraph.complex_field_hyperlinks().is_empty(), "{case}");
                         break;
                     }
                     Ok(Event::Eof) => panic!("missing paragraph"),
@@ -3066,6 +3213,7 @@ mod tests {
             }],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
             alt_drawings: Vec::new(),
         });
 
@@ -3149,6 +3297,7 @@ mod tests {
             content: vec![RunContent::FootnoteRef { id: 2 }],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
             alt_drawings: Vec::new(),
         });
         p.add_run(" text after");

--- a/crates/rdocx/src/comments.rs
+++ b/crates/rdocx/src/comments.rs
@@ -804,6 +804,7 @@ fn comment_reference_run(id: i32) -> CT_R {
         content: vec![RunContent::CommentReference { id, raw_before: 0 }],
         extra_xml: Vec::new(),
         extra_xml_positions: Vec::new(),
+        field_markers: Vec::new(),
         alt_drawings: Vec::new(),
     }
 }
@@ -1161,6 +1162,7 @@ mod tests {
             content: Vec::new(),
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
             alt_drawings: Vec::new(),
         });
         let mut reference = comment_reference_run(7);

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -819,6 +819,7 @@ impl Document {
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
         };
         let mut paragraph = CT_P::new();
         paragraph.runs.push(run);
@@ -1165,6 +1166,7 @@ impl Document {
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
         };
 
         let mut p = CT_P::new();
@@ -1258,6 +1260,7 @@ impl Document {
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
         };
 
         let mut p = CT_P::new();
@@ -1294,6 +1297,7 @@ impl Document {
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
         };
 
         let mut p = CT_P::new();
@@ -1746,6 +1750,7 @@ impl Document {
             content: vec![RunContent::Drawing(CT_Drawing::inline(inline))],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
         };
 
         let mut p = CT_P::new();
@@ -2433,6 +2438,7 @@ impl Document {
                 content: vec![rdocx_oxml::text::RunContent::Tab],
                 extra_xml: Vec::new(),
                 extra_xml_positions: Vec::new(),
+                field_markers: Vec::new(),
             });
 
             // Wrap the text run in a hyperlink to the bookmark
@@ -5808,20 +5814,34 @@ mod tests {
     fn links_exposes_a_complex_field_hyperlink_target() {
         let mut doc = Document::new();
         let mut paragraph = CT_P::new();
-        for xml in [
-            br#"<w:fldChar w:fldCharType="begin"/>"#.as_slice(),
-            br#"<w:instrText> HYPERLINK &quot;https://example.test&quot; </w:instrText>"#
-                .as_slice(),
-            br#"<w:fldChar w:fldCharType="separate"/>"#.as_slice(),
+        for (xml, marker) in [
+            (
+                br#"<w:fldChar w:fldCharType="begin"/>"#.as_slice(),
+                rdocx_oxml::text::FieldMarker::Begin { dirty: false },
+            ),
+            (
+                br#"<w:instrText> HYPERLINK &quot;https://example.test&quot; </w:instrText>"#
+                    .as_slice(),
+                rdocx_oxml::text::FieldMarker::Instruction(
+                    " HYPERLINK \"https://example.test\" ".to_owned(),
+                ),
+            ),
+            (
+                br#"<w:fldChar w:fldCharType="separate"/>"#.as_slice(),
+                rdocx_oxml::text::FieldMarker::Separate { dirty: false },
+            ),
         ] {
             let mut run = CT_R::new("");
             run.extra_xml.push(xml.to_vec());
+            run.field_markers.push(marker);
             paragraph.runs.push(run);
         }
         paragraph.runs.push(CT_R::new("Cached link"));
         let mut end = CT_R::new("");
         end.extra_xml
             .push(br#"<w:fldChar w:fldCharType="end"/>"#.to_vec());
+        end.field_markers
+            .push(rdocx_oxml::text::FieldMarker::End { dirty: false });
         paragraph.runs.push(end);
         doc.document
             .body

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -395,6 +395,7 @@ impl<'a> Cell<'a> {
             content: vec![RunContent::Drawing(drawing)],
             extra_xml: Vec::new(),
             extra_xml_positions: Vec::new(),
+            field_markers: Vec::new(),
         };
         let mut p = CT_P::new();
         p.runs.push(run);

--- a/docs/hld/03-architecture.md
+++ b/docs/hld/03-architecture.md
@@ -166,10 +166,16 @@ parts and coordinates them with the anchors in the main document.
 The Word text model also projects bookmark starts and ends at direct-run
 boundaries while retaining every marker as ordered raw XML. Structured simple
 fields distinguish `REF` and `PAGEREF`, keep the complete instruction including
-switches, and retain the stored display. The `rdocx` facade correlates bookmark
-ids and owns mutation across top-level body paragraphs. `rdocx-layout` resolves
-bookmark text and maps page targets, while the shared `oxml-layout` boundary
-exposes only format-neutral `Target` and `TargetPage` field kinds.
+switches, and retain the stored display. Complex fields use the same tokenizer
+and expose the normalized name, arguments, switches, cached result, dirty
+state, and nested fields. Markers are recognized only through their in-scope
+WordprocessingML namespace bindings. Malformed or unsupported sequences remain
+opaque raw XML, and dirty fields are not reported as `Document::links()` until
+the update policy defines how to handle them. The `rdocx` facade correlates
+bookmark ids and owns mutation across top-level body paragraphs.
+`rdocx-layout` resolves bookmark text and maps page targets, while the shared
+`oxml-layout` boundary exposes only format-neutral `Target` and `TargetPage`
+field kinds.
 
 The content-control model owns one recursive `CT_Sdt` grammar at block, row,
 cell, paragraph, and run placement boundaries. It reports tag, alias, numeric

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -1678,6 +1678,16 @@ session quadratic.
 **Test gate**: regression. Editing one paragraph of a thousand-page document
 re-lays out a bounded number of pages, asserted by counting layout invocations.
 
+### F-203, Reader compatibility corrections (M)
+Namespace-aware table-cell property recognition and schema-slot preservation for
+numbering-level raw XML. Foreign same-local-name elements remain opaque,
+byte-identical XML, and raw content before `w:suff` remains before that typed
+element after a round trip.
+**Depends on**: none.
+**Test gate**: regression. Foreign `tcW` XML remains unmodelled and
+byte-identical, and an `isLgl` raw child stays before `suff` after parse and
+write.
+
 ---
 
 ## Cross-cutting

--- a/docs/sprints/BACKLOG.md
+++ b/docs/sprints/BACKLOG.md
@@ -31,13 +31,13 @@ regenerated, never hand-edited.
 | M13, Bindings and tooling                   | 18 | 18 | 0 | 0  |
 | M14, Word collaboration layer                  | 9  | 9 | 0 | 0  |
 | M15, Charts beyond PowerPoint                  | 4  | 4 | 0 | 0  |
-| M16, Document automation                       | 9  | 0 | 0 | 9  |
+| M16, Document automation                       | 10 | 0 | 2 | 8  |
 | M17, Security and compliance                   | 7  | 0 | 0 | 7  |
 | M18, Format breadth                            | 8  | 0 | 0 | 8  |
 | M19, Spreadsheets                              | 12 | 0 | 0 | 12 |
 | M20, Fidelity at scale                         | 7  | 0 | 0 | 7  |
 | X, Cross-cutting (opportunistic)            | 34 | 32 | 0 | 1  |
-| **Total** | **244** | **199** | **0** | **44** |
+| **Total** | **245** | **199** | **2** | **43** |
 <!-- AUTOGEN:backlog-summary END -->
 
 ## All F-IDs
@@ -319,9 +319,10 @@ regenerated, never hand-edited.
 <!-- AUTOGEN:backlog-M16 START -->
 | F-ID | Title | Sprint | Size | Status |
 |------|-------|--------|------|--------|
-| F-160 | Field instruction parser                     | S49  | L | pending |
+| F-160 | Field instruction parser                     | S49  | L | in-progress |
 | F-161 | Field evaluation engine                      | S49  | L | pending |
 | F-162 | Field update policy                          | S49  | M | pending |
+| F-203 | Reader compatibility corrections             | S49  | M | in-progress |
 | F-163 | Template syntax                              | S50  | L | pending |
 | F-164 | Loops and conditionals                       | S50  | L | pending |
 | F-165 | Repeating table rows and lists               | S50  | M | pending |

--- a/docs/sprints/CURRENT_SPRINT.md
+++ b/docs/sprints/CURRENT_SPRINT.md
@@ -1,60 +1,46 @@
-# Current Sprint, S48
+# Current Sprint, S49
 
-**Milestone**: M14 Word collaboration layer.
+**Milestone**: M16 Document generation and analysis.
 
-**Goal**: close M14 by making tracked revisions visible during rendering and
-making the author's document-protection intent readable through the public API.
-The sprint combines the revision model completed in S47 with settings-level
-protection metadata, then proves the full collaboration-layer milestone gate.
+**Goal**: evaluate the field codes real documents are full of. The field
+instruction parser establishes the structured representation that evaluation,
+cached-result policy, and later templating build on.
 
 ## Spec references
 
-- `docs/hld/03-architecture.md`, for the `rdocx-oxml` ownership boundary, the
-  typed revision model, and facade coordination across document and settings
-  state.
-- `docs/hld/04-opc-and-packaging.md`, for package integrity, preservation of
-  settings metadata, and atomic document changes.
-- `docs/hld/08-rendering-spec.md`, for the shared renderer input, Word
-  pagination, and deterministic PDF and raster lowering used by the revision
-  display gate.
-- `docs/hld/10-bindings-spec.md`, for native Word facade stability and the
-  requirement that new inspection options leave existing Python, WASM, and CLI
-  surfaces compatible.
-- `docs/hld/12-testing-strategy.md`, for deterministic golden tests, in-code
-  fixtures, and the mixed-document milestone regression.
-- `docs/hld/14-development-backlog.md`, for the M14 end gate, the revision
-  display and document-protection stories, their dependencies, and their exact
-  acceptance gates.
+- `docs/hld/03-architecture.md`, for `rdocx-oxml` ownership of the
+  WordprocessingML grammar, prefix-tolerant readers, and raw subtree
+  preservation.
+- `docs/hld/04-opc-and-packaging.md`, for package-preserving reader behaviour
+  and schema-ordered serialization.
+- `docs/hld/12-testing-strategy.md`, for unit and round-trip evidence.
+- `docs/hld/14-development-backlog.md`, for the field-parser, evaluator, and
+  update-policy story contracts and acceptance gates.
 
 ## The wave
 
 | F-ID | Title | Size | Status | Owner |
 |------|-------|------|--------|-------|
-| F-151 | Revision display in the renderer | M | done | |
-| F-155 | Document protection | M | done | |
+| F-160 | Field instruction parser | L | pending | - |
+| F-161 | Field evaluation engine | L | pending | - |
+| F-162 | Field update policy | M | pending | - |
 
 ## Sequencing note
 
 Rows are listed in dependency order, not F-ID order.
 
-F-151 depends on the typed revision model completed by F-149 in S47. F-155 is
-independent and works through the document settings part, so the two stories
-may be implemented in parallel. Both must land before the combined M14 gate can
-run because it covers revisions, comments, content controls, and bookmarks in
-one document.
+F-160 defines the recursive field structure. F-161 consumes that structure and
+also depends on F-154. F-162 depends on evaluation because it decides when a
+field result may be recomputed.
 
 ## Definition of done for this sprint
 
-- A render option selects the accepted view or the tracked-change view, with
-  the accepted view as the default.
-- The tracked-change view underlines insertions, strikes through deletions, and
-  draws a change bar in the margin.
-- The accepted view is pixel-identical to rendering the same document after all
-  revisions have been accepted and removed.
-- Read-only, comments-only, tracked-changes-forced, and forms-only protection
-  modes round-trip with the recorded hash and salt intact.
-- The public native Word API reports the document-protection mode and its
-  recorded metadata without changing existing binding surfaces.
-- One document carrying tracked changes, comments, content controls, and
-  bookmarks round-trips byte-identically in every unmodelled part, and all four
-  subsystems are readable and writable through the public API.
+- Every supported simple and complex field form parses into field name,
+  arguments, switches, and cached-result structure without discarding unknown
+  WordprocessingML XML.
+- Supported fields evaluate to the value Word computes for the pinned expected
+  set.
+- Field-result update policies preserve cached results unless the selected
+  policy permits recomputation.
+- The M16 end gate is ready for template syntax, loops, conditionals, and
+  repeating table rows to consume the field representation.

--- a/docs/sprints/CURRENT_SPRINT.md
+++ b/docs/sprints/CURRENT_SPRINT.md
@@ -21,9 +21,10 @@ cached-result policy, and later templating build on.
 
 | F-ID | Title | Size | Status | Owner |
 |------|-------|------|--------|-------|
-| F-160 | Field instruction parser | L | pending | - |
+| F-160 | Field instruction parser | L | in-progress | codex |
 | F-161 | Field evaluation engine | L | pending | - |
 | F-162 | Field update policy | M | pending | - |
+| F-203 | Reader compatibility corrections | M | in-progress | codex |
 
 ## Sequencing note
 
@@ -31,7 +32,8 @@ Rows are listed in dependency order, not F-ID order.
 
 F-160 defines the recursive field structure. F-161 consumes that structure and
 also depends on F-154. F-162 depends on evaluation because it decides when a
-field result may be recomputed.
+field result may be recomputed. F-203 independently corrects reader
+preservation found during upstream review.
 
 ## Definition of done for this sprint
 

--- a/docs/sprints/SPRINT_PLAN.md
+++ b/docs/sprints/SPRINT_PLAN.md
@@ -837,9 +837,11 @@ M16 rests on this.
 | F-160 | Field instruction parser | L |
 | F-161 | Field evaluation engine | L |
 | F-162 | Field update policy | M |
+| F-203 | Reader compatibility corrections | M |
 
-Strictly ordered. F-161 also depends on F-154 from S46, which is why bookmarks
-landed early.
+F-160 through F-162 are strictly ordered. F-203 is an independent corrective
+story for reader preservation. F-161 also depends on F-154 from S46, which is
+why bookmarks landed early.
 
 #### Sprint S50, Templating
 


### PR DESCRIPTION
Follow-up to the now-merged #27 and #28 review feedback.

This keeps the documented reader contract intact:
- parse nested complex fields with namespace-aware Word element and attribute recognition
- preserve unsupported or unsafe fields as raw XML instead of failing document open
- preserve foreign table cell-width XML, including local-name collisions, in its schema slot
- retain raw numbering XML before w:suff

Commits are separated by F-160 and F-203.

Validation: cargo fmt, rdocx-oxml and rdocx tests, workspace all-features tests excluding bindings, clippy, hash harness, prose check, skill-sync check, no-default-features layout test, and wasm check.