### PR TITLE
Add hyperlink tooltip and table indentation writers

### DIFF
--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -5980,6 +5980,39 @@ mod tests {
     }
 
     #[test]
+    fn writer_hyperlink_tooltip_and_table_indent_round_trip() {
+        let mut doc = Document::new();
+        let relationship_id = doc.add_hyperlink_relationship("https://example.com");
+        doc.add_paragraph("").add_hyperlink_with_tooltip(
+            "linked",
+            &relationship_id,
+            Some("Example site"),
+        );
+        doc.add_table(1, 1).set_indent(Length::twips(720));
+
+        let bytes = doc.to_bytes().expect("document writes");
+        let reopened = Document::from_bytes(&bytes).expect("document reopens");
+
+        let BodyContent::Paragraph(paragraph) = &reopened.document.body.content[0] else {
+            panic!("expected paragraph");
+        };
+        assert_eq!(
+            paragraph.hyperlinks[0].extra_attributes,
+            vec![("w:tooltip".to_string(), "Example site".to_string())]
+        );
+        let BodyContent::Table(table) = &reopened.document.body.content[1] else {
+            panic!("expected table");
+        };
+        assert_eq!(
+            table
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.indent.as_ref()),
+            Some(&rdocx_oxml::table::CT_TblWidth::dxa(720))
+        );
+    }
+
+    #[test]
     fn rejected_list_level_update_does_not_materialize_numbering() {
         let mut doc = Document::new();
         assert!(doc.numbering.is_none());

--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -153,6 +153,16 @@ impl<'a> Paragraph<'a> {
     /// allows the hyperlink text to receive the same direct formatting as any
     /// other run.
     pub fn add_hyperlink(&mut self, text: &str, relationship_id: &str) -> Run<'_> {
+        self.add_hyperlink_with_tooltip(text, relationship_id, None)
+    }
+
+    /// Add a hyperlink run and optionally set its user-facing hover tooltip.
+    pub fn add_hyperlink_with_tooltip(
+        &mut self,
+        text: &str,
+        relationship_id: &str,
+        tooltip: Option<&str>,
+    ) -> Run<'_> {
         let run_start = self.inner.runs.len();
         self.inner.runs.push(CT_R::new(text));
         self.inner.hyperlinks.push(HyperlinkSpan {
@@ -160,7 +170,9 @@ impl<'a> Paragraph<'a> {
             anchor: None,
             run_start,
             run_end: run_start + 1,
-            extra_attributes: Vec::new(),
+            extra_attributes: tooltip
+                .map(|tooltip| vec![("w:tooltip".to_string(), tooltip.to_string())])
+                .unwrap_or_default(),
             extra_xml: Vec::new(),
             preserved_raw_before: None,
         });

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -68,6 +68,11 @@ impl<'a> Table<'a> {
         self.ensure_tbl_pr().width = Some(CT_TblWidth::dxa(length.as_twips().0));
     }
 
+    /// Set the table indentation from the left margin in place.
+    pub fn set_indent(&mut self, length: Length) {
+        self.ensure_tbl_pr().indent = Some(CT_TblWidth::dxa(length.as_twips().0));
+    }
+
     /// Set the table width as a percentage (0–100).
     pub fn width_pct(mut self, percent: f64) -> Self {
         self.set_width_pct(percent);


### PR DESCRIPTION
Adds two OOXML writer capabilities derived from Symbolic-ai/rdocx, rebuilt against current upstream APIs.

- Paragraph::add_hyperlink_with_tooltip writes w:tooltip when provided.
- Table::set_indent writes w:tblInd in twips.
- Existing add_hyperlink behavior remains unchanged.

Validation: cargo fmt --all --check, cargo test -p rdocx writer_hyperlink_tooltip_and_table_indent_round_trip, cargo clippy -p rdocx --all-targets --all-features -- -D warnings.