### PR TITLE
Expose paragraph border reader facts

### DIFF
--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -41,7 +41,8 @@ pub use error::{Error, Result};
 pub use oxml_chart::{ChartData, ChartKind};
 pub use oxml_core::Length;
 pub use paragraph::{
-    Alignment, BorderStyle, Paragraph, ParagraphRef, SectionBreak, TabAlignment, TabLeader,
+    Alignment, BorderStyle, Paragraph, ParagraphBorderRef, ParagraphRef, SectionBreak,
+    TabAlignment, TabLeader,
 };
 pub use rdocx_layout::RevisionView;
 pub use rdocx_oxml::settings::{

--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -71,6 +71,34 @@ impl BorderStyle {
     }
 }
 
+/// An immutable paragraph border edge.
+#[derive(Debug, Clone, Copy)]
+pub struct ParagraphBorderRef<'a> {
+    inner: &'a CT_BorderEdge,
+}
+
+impl ParagraphBorderRef<'_> {
+    /// The OOXML border style name.
+    pub fn style(self) -> &'static str {
+        self.inner.val.to_str()
+    }
+
+    /// Border width in eighths of a point.
+    pub fn size_eighths_pt(self) -> Option<u32> {
+        self.inner.sz
+    }
+
+    /// Space between the border and content in points.
+    pub fn space_points(self) -> Option<u32> {
+        self.inner.space
+    }
+
+    /// Border color, normally a six-digit RGB hex value or `auto`.
+    pub fn color(&self) -> Option<&str> {
+        self.inner.color.as_deref()
+    }
+}
+
 /// Tab stop alignment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabAlignment {
@@ -874,6 +902,42 @@ impl<'a> ParagraphRef<'a> {
             .and_then(|ppr| ppr.borders.as_ref())
             .map(|b| !b.is_empty())
             .unwrap_or(false)
+    }
+
+    /// Get the direct bottom border, if present.
+    pub fn bottom_border(&self) -> Option<ParagraphBorderRef<'_>> {
+        self.inner
+            .properties
+            .as_ref()?
+            .borders
+            .as_ref()?
+            .bottom
+            .as_ref()
+            .map(|inner| ParagraphBorderRef { inner })
+    }
+
+    /// Count direct paragraph border edges.
+    pub fn border_count(&self) -> usize {
+        let Some(borders) = self
+            .inner
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.borders.as_ref())
+        else {
+            return 0;
+        };
+
+        [
+            borders.top.as_ref(),
+            borders.bottom.as_ref(),
+            borders.left.as_ref(),
+            borders.right.as_ref(),
+            borders.between.as_ref(),
+            borders.bar.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .count()
     }
 
     /// Get the number of tab stops defined.

--- a/crates/rdocx/tests/integration_test.rs
+++ b/crates/rdocx/tests/integration_test.rs
@@ -1193,6 +1193,25 @@ fn mixed_lists_round_trip() {
 }
 
 #[test]
+fn paragraph_facade_exposes_exact_bottom_border_facts() {
+    let mut document = Document::new();
+    document
+        .add_paragraph("")
+        .border_bottom(BorderStyle::Single, 8, "808080");
+
+    let bytes = document.to_bytes().unwrap();
+    let reopened = Document::from_bytes(&bytes).unwrap();
+    let paragraph = reopened.paragraph(0).unwrap();
+    let border = paragraph.bottom_border().unwrap();
+
+    assert_eq!(paragraph.border_count(), 1);
+    assert_eq!(border.style(), "single");
+    assert_eq!(border.size_eighths_pt(), Some(8));
+    assert_eq!(border.space_points(), Some(1));
+    assert_eq!(border.color(), Some("808080"));
+}
+
+#[test]
 fn custom_list_definitions_restart_numbering_per_list() {
     let mut doc = Document::new();
     let first = doc.add_list_definition(&[ListLevel::decimal()]);


### PR DESCRIPTION
Adds a small immutable facade for direct paragraph borders.

- ParagraphRef::bottom_border exposes the exact bottom-edge style, size, space, and color.
- ParagraphRef::border_count reports direct border edges.
- ParagraphBorderRef is re-exported from rdocx.

Validation: cargo fmt --all --check, cargo test -p rdocx paragraph_facade_exposes_exact_bottom_border_facts, cargo clippy -p rdocx --all-targets --all-features -- -D warnings.