### PR TITLE
Add bounded OPC package reads

### DIFF
--- a/crates/oxml-opc/src/error.rs
+++ b/crates/oxml-opc/src/error.rs
@@ -19,6 +19,9 @@ pub enum OpcError {
     #[error("part not found: {0}")]
     PartNotFound(String),
 
+    #[error("OPC package exceeds {kind} limit of {limit}")]
+    PackageLimitExceeded { kind: &'static str, limit: u64 },
+
     #[error("invalid content types XML")]
     InvalidContentTypes,
 

--- a/crates/oxml-opc/src/lib.rs
+++ b/crates/oxml-opc/src/lib.rs
@@ -13,5 +13,5 @@ pub mod relationship;
 
 pub use content_types::{ContentType, ContentTypes};
 pub use error::OpcError;
-pub use package::{OpcPackage, PackagePart};
+pub use package::{OpcPackage, PackagePart, PackageReadLimits};
 pub use relationship::{Relationship, Relationships};

--- a/crates/oxml-opc/src/package.rs
+++ b/crates/oxml-opc/src/package.rs
@@ -21,6 +21,22 @@ pub struct PackagePart {
     pub data: Vec<u8>,
 }
 
+/// Resource limits applied while expanding an OPC ZIP archive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PackageReadLimits {
+    pub max_entries: usize,
+    pub max_part_uncompressed_bytes: u64,
+    pub max_total_uncompressed_bytes: u64,
+}
+
+impl PackageReadLimits {
+    pub const UNBOUNDED: Self = Self {
+        max_entries: usize::MAX,
+        max_part_uncompressed_bytes: u64::MAX,
+        max_total_uncompressed_bytes: u64::MAX,
+    };
+}
+
 /// An in-memory representation of an OPC package (ZIP archive).
 #[derive(Debug, Clone)]
 pub struct OpcPackage {
@@ -45,8 +61,23 @@ impl OpcPackage {
 
     /// Open an OPC package from any reader that implements Read + Seek.
     pub fn from_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+        Self::from_reader_with_limits(reader, PackageReadLimits::UNBOUNDED)
+    }
+
+    /// Open an OPC package while bounding archive expansion.
+    pub fn from_reader_with_limits<R: Read + Seek>(
+        reader: R,
+        limits: PackageReadLimits,
+    ) -> Result<Self> {
         let mut archive = ZipArchive::new(reader)?;
+        if archive.len() > limits.max_entries {
+            return Err(OpcError::PackageLimitExceeded {
+                kind: "entry count",
+                limit: limits.max_entries as u64,
+            });
+        }
         let mut raw_parts: HashMap<String, Vec<u8>> = HashMap::new();
+        let mut total_uncompressed_bytes = 0_u64;
 
         // Read all entries from the ZIP
         for i in 0..archive.len() {
@@ -54,10 +85,45 @@ impl OpcPackage {
             if entry.is_dir() {
                 continue;
             }
+            if entry.size() > limits.max_part_uncompressed_bytes {
+                return Err(OpcError::PackageLimitExceeded {
+                    kind: "part size",
+                    limit: limits.max_part_uncompressed_bytes,
+                });
+            }
+            if total_uncompressed_bytes
+                .checked_add(entry.size())
+                .is_none_or(|total| total > limits.max_total_uncompressed_bytes)
+            {
+                return Err(OpcError::PackageLimitExceeded {
+                    kind: "total uncompressed size",
+                    limit: limits.max_total_uncompressed_bytes,
+                });
+            }
             let name = normalize_part_name(entry.name());
             let name = name.strip_prefix('/').unwrap_or(&name).to_string();
             let mut data = Vec::new();
-            entry.read_to_end(&mut data)?;
+            let read_limit = limits
+                .max_part_uncompressed_bytes
+                .min(limits.max_total_uncompressed_bytes - total_uncompressed_bytes);
+            entry
+                .by_ref()
+                .take(read_limit.saturating_add(1))
+                .read_to_end(&mut data)?;
+            let data_len = data.len() as u64;
+            if data_len > limits.max_part_uncompressed_bytes {
+                return Err(OpcError::PackageLimitExceeded {
+                    kind: "part size",
+                    limit: limits.max_part_uncompressed_bytes,
+                });
+            }
+            total_uncompressed_bytes = total_uncompressed_bytes
+                .checked_add(data_len)
+                .filter(|total| *total <= limits.max_total_uncompressed_bytes)
+                .ok_or(OpcError::PackageLimitExceeded {
+                    kind: "total uncompressed size",
+                    limit: limits.max_total_uncompressed_bytes,
+                })?;
             raw_parts.insert(name, data);
         }
 
@@ -344,6 +410,72 @@ mod tests {
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="xml" ContentType="application/xml"/>
 </Types>"#;
+
+    #[test]
+    fn bounded_reader_rejects_too_many_entries() {
+        let archive = package_zip(&[
+            ("[Content_Types].xml", MINIMAL_CONTENT_TYPES),
+            ("word/document.xml", b"<document/>"),
+        ]);
+        let error = OpcPackage::from_reader_with_limits(
+            archive,
+            PackageReadLimits {
+                max_entries: 1,
+                max_part_uncompressed_bytes: 1_024,
+                max_total_uncompressed_bytes: 2_048,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            OpcError::PackageLimitExceeded {
+                kind: "entry count",
+                limit: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn bounded_reader_rejects_oversized_parts_and_totals() {
+        let entries = [
+            ("[Content_Types].xml", MINIMAL_CONTENT_TYPES),
+            ("word/document.xml", b"<document/>".as_slice()),
+        ];
+        let part_error = OpcPackage::from_reader_with_limits(
+            package_zip(&entries),
+            PackageReadLimits {
+                max_entries: 8,
+                max_part_uncompressed_bytes: 16,
+                max_total_uncompressed_bytes: 1_024,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            part_error,
+            OpcError::PackageLimitExceeded {
+                kind: "part size",
+                limit: 16
+            }
+        ));
+
+        let total_error = OpcPackage::from_reader_with_limits(
+            package_zip(&entries),
+            PackageReadLimits {
+                max_entries: 8,
+                max_part_uncompressed_bytes: 1_024,
+                max_total_uncompressed_bytes: MINIMAL_CONTENT_TYPES.len() as u64,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            total_error,
+            OpcError::PackageLimitExceeded {
+                kind: "total uncompressed size",
+                ..
+            }
+        ));
+    }
 
     fn independently_built_pptx() -> std::io::Cursor<Vec<u8>> {
         const CONTENT_TYPES: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -9,9 +9,9 @@ use std::cell::Cell;
 
 use oxml_chart::{CT_ChartSpace, ChartData, ChartKind};
 use oxml_media::MediaNamer;
-use oxml_opc::OpcPackage;
 use oxml_opc::content_types;
 use oxml_opc::relationship::rel_types;
+use oxml_opc::{OpcPackage, PackageReadLimits};
 use oxml_sml::Workbook;
 use quick_xml::events::Event;
 use quick_xml::name::{Namespace, ResolveResult};
@@ -427,8 +427,13 @@ impl Document {
 
     /// Open a document from bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes_with_limits(bytes, PackageReadLimits::UNBOUNDED)
+    }
+
+    /// Open a document from bytes while bounding OPC archive expansion.
+    pub fn from_bytes_with_limits(bytes: &[u8], limits: PackageReadLimits) -> Result<Self> {
         let cursor = std::io::Cursor::new(bytes);
-        let package = OpcPackage::from_reader(cursor)?;
+        let package = OpcPackage::from_reader_with_limits(cursor, limits)?;
         Self::from_package(package)
     }
 

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -40,6 +40,7 @@ pub use document::{
 pub use error::{Error, Result};
 pub use oxml_chart::{ChartData, ChartKind};
 pub use oxml_core::Length;
+pub use oxml_opc::PackageReadLimits;
 pub use paragraph::{
     Alignment, BorderStyle, Paragraph, ParagraphRef, SectionBreak, TabAlignment, TabLeader,
 };

--- a/crates/rdocx/tests/integration_test.rs
+++ b/crates/rdocx/tests/integration_test.rs
@@ -8,7 +8,7 @@ use rdocx::{
     BorderStyle, Length, ListLevel, RunPosition, RunRange, SectionBreak, StyleBuilder,
     TabAlignment, TabLeader, UnderlineStyle,
 };
-use rdocx::{Document, RevisionKind};
+use rdocx::{Document, PackageReadLimits, RevisionKind};
 
 #[test]
 fn settings_relationship_target_is_resolved_instead_of_assumed() {
@@ -50,6 +50,29 @@ fn document_xml(document: &mut Document) -> Vec<u8> {
     let bytes = document.to_bytes().unwrap();
     let package = OpcPackage::from_reader(std::io::Cursor::new(bytes)).unwrap();
     package.get_part("/word/document.xml").unwrap().to_vec()
+}
+
+#[test]
+fn bounded_document_reader_rejects_package_expansion() {
+    let bytes = Document::new().to_bytes().unwrap();
+    let result = Document::from_bytes_with_limits(
+        &bytes,
+        PackageReadLimits {
+            max_entries: 1,
+            max_part_uncompressed_bytes: 1_024 * 1_024,
+            max_total_uncompressed_bytes: 2 * 1_024 * 1_024,
+        },
+    );
+
+    assert!(matches!(
+        result,
+        Err(rdocx::Error::Opc(
+            oxml_opc::OpcError::PackageLimitExceeded {
+                kind: "entry count",
+                limit: 1
+            }
+        ))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Adds opt-in limits for reading OPC ZIP packages and exposes them through rdocx.

- PackageReadLimits bounds archive entries, each part's uncompressed size, and total uncompressed size.
- OpcPackage::from_reader_with_limits and Document::from_bytes_with_limits accept those limits.
- Existing open and from_bytes calls remain unbounded for compatibility.

Validation: cargo fmt --all --check, cargo test -p oxml-opc bounded_reader, cargo test -p rdocx bounded_document_reader_rejects_package_expansion, cargo clippy -p oxml-opc --all-targets --all-features -- -D warnings, cargo clippy -p rdocx --all-targets --all-features -- -D warnings.