### PR TITLE
Expose ordered document body items

### DIFF
--- a/crates/rdocx/src/content_control.rs
+++ b/crates/rdocx/src/content_control.rs
@@ -25,7 +25,7 @@ const CUSTOM_XML_PROPS_NS: &[u8] =
 /// Read-only view of one structured document tag in document order.
 #[derive(Debug, Clone, Copy)]
 pub struct ContentControlRef<'a> {
-    inner: &'a CT_Sdt,
+    pub(crate) inner: &'a CT_Sdt,
 }
 
 impl ContentControlRef<'_> {

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -32,6 +32,7 @@ use rdocx_oxml::text::{CT_P, CT_R, RunContent};
 use rdocx_oxml::core_properties::CoreProperties;
 
 use crate::Length;
+use crate::content_control::ContentControlRef;
 use crate::error::{Error, Result};
 use crate::paragraph::{Paragraph, ParagraphRef};
 use crate::revision::RevisionRef;
@@ -43,6 +44,18 @@ use crate::table::{Table, TableRef};
 pub struct RenderOptions {
     /// The tracked-revision view to render.
     pub revision_view: rdocx_layout::RevisionView,
+}
+
+/// One direct child of a document body, in source order.
+pub enum BodyItemRef<'a> {
+    /// A body paragraph.
+    Paragraph(ParagraphRef<'a>),
+    /// A body table.
+    Table(TableRef<'a>),
+    /// A body-level content control.
+    ContentControl(ContentControlRef<'a>),
+    /// A preserved body child that rdocx does not model.
+    UnsupportedXml(&'a [u8]),
 }
 
 /// A Word document (.docx file).
@@ -850,6 +863,24 @@ impl Document {
     }
 
     // ---- Paragraph access ----
+
+    /// Iterate over direct body items in source order.
+    ///
+    /// Unlike [`Self::paragraphs`] and [`Self::tables`], this retains the
+    /// interleaving of paragraphs, tables, content controls, and preserved
+    /// unmodelled XML.
+    pub fn body_items(&self) -> impl Iterator<Item = BodyItemRef<'_>> {
+        self.document.body.content.iter().map(|item| match item {
+            BodyContent::Paragraph(paragraph) => {
+                BodyItemRef::Paragraph(ParagraphRef { inner: paragraph })
+            }
+            BodyContent::Table(table) => BodyItemRef::Table(TableRef { inner: table }),
+            BodyContent::ContentControl(control) => {
+                BodyItemRef::ContentControl(ContentControlRef { inner: control })
+            }
+            BodyContent::RawXml(raw) => BodyItemRef::UnsupportedXml(raw),
+        })
+    }
 
     /// Get immutable references to all paragraphs.
     pub fn paragraphs(&self) -> Vec<ParagraphRef<'_>> {
@@ -4139,6 +4170,55 @@ mod tests {
 
     fn layout_invocations() -> usize {
         LAYOUT_INVOCATIONS.get()
+    }
+
+    #[test]
+    fn body_items_preserve_paragraph_table_control_and_raw_order() {
+        let mut doc = Document::new();
+        doc.add_paragraph("first");
+        doc.add_table(1, 1);
+        doc.document
+            .body
+            .content
+            .push(BodyContent::RawXml(b"<w:custom/>".to_vec()));
+
+        let mut reader = quick_xml::Reader::from_reader(
+            br#"<w:sdt xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:sdtContent><w:p><w:r><w:t>inside</w:t></w:r></w:p></w:sdtContent></w:sdt>"#
+                .as_slice(),
+        );
+        let mut buffer = Vec::new();
+        let control = match reader.read_event_into(&mut buffer).unwrap() {
+            Event::Start(start) => CT_Sdt::from_xml(&mut reader, &start).unwrap(),
+            event => panic!("expected content control start, got {event:?}"),
+        };
+        doc.document
+            .body
+            .content
+            .push(BodyContent::ContentControl(control));
+        doc.add_paragraph("last");
+
+        let items = doc
+            .body_items()
+            .map(|item| match item {
+                BodyItemRef::Paragraph(paragraph) => format!("paragraph:{}", paragraph.text()),
+                BodyItemRef::Table(_) => "table".to_owned(),
+                BodyItemRef::ContentControl(control) => format!("control:{}", control.text()),
+                BodyItemRef::UnsupportedXml(raw) => {
+                    format!("raw:{}", std::str::from_utf8(raw).unwrap())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            items,
+            [
+                "paragraph:first",
+                "table",
+                "raw:<w:custom/>",
+                "control:inside",
+                "paragraph:last",
+            ]
+        );
     }
 
     #[test]

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -34,8 +34,8 @@ pub mod table;
 pub use comments::{BookmarkRef, CommentRef, RunPosition, RunRange};
 pub use content_control::ContentControlRef;
 pub use document::{
-    AccessibilityIssue, Document, ImageInfo, IssueSeverity, LinkInfo, ListLevel, ListNumberFormat,
-    OutlineNode, RenderOptions,
+    AccessibilityIssue, BodyItemRef, Document, ImageInfo, IssueSeverity, LinkInfo, ListLevel,
+    ListNumberFormat, OutlineNode, RenderOptions,
 };
 pub use error::{Error, Result};
 pub use oxml_chart::{ChartData, ChartKind};


### PR DESCRIPTION
## Summary

- add the additive `Document::body_items()` reader API and its public `BodyItemRef` variants
- retain direct body ordering across paragraphs, tables, content controls, and preserved unmodelled XML
- cover the complete interleaving with a regression test

This is the first deliberately narrow slice of an ordered reader API. It does not revive the retired facade wholesale or change parsing and writing behavior. Follow-up slices can expose ordered cell and inline content, then resolved formatting and numbering semantics.

## Semver

Additive public API only.

## Verification

- `cargo fmt --all`
- `cargo test -p rdocx body_items_preserve_paragraph_table_control_and_raw_order`
- `cargo clippy -p rdocx --all-targets --all-features -- -D warnings`
- `cargo publish --workspace --dry-run` with local path patches
- archive-size check

`cargo test -p rdocx` reached 94 passing tests and 2 expected manual-test skips. The existing `word_and_powerpoint_chart_pixels_are_identical` test failed because this machine's rasterizer does not match the repository-pinned `RASTERIZER` version. The changed reader API test passed.