### PR TITLE
F-X039 draft: share layout payloads and transfer reusable engines

### DIFF
--- a/crates/oxml-layout/src/font.rs
+++ b/crates/oxml-layout/src/font.rs
@@ -887,7 +887,7 @@ impl FontManager {
         Ok(crate::output::FontData {
             id: font.id,
             family: font.family.clone(),
-            data: font.data.to_vec(),
+            data: font.data.clone(),
             face_index: font.face_index,
             bold: font.bold,
             italic: font.italic,
@@ -901,7 +901,7 @@ impl FontManager {
             .map(|f| crate::output::FontData {
                 id: f.id,
                 family: f.family.clone(),
-                data: f.data.to_vec(),
+                data: f.data.clone(),
                 face_index: f.face_index,
                 bold: f.bold,
                 italic: f.italic,

--- a/crates/oxml-layout/src/output.rs
+++ b/crates/oxml-layout/src/output.rs
@@ -345,8 +345,10 @@ pub struct OutlineEntry {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct LayoutResult {
-    /// Laid-out pages.
-    pub pages: Vec<PageFrame>,
+    /// Laid-out pages, shared: an interactive caller relayouting per edit
+    /// keeps unchanged pages alive across results instead of deep-copying
+    /// them. Pre-1.0 type break, like `FontData.data`.
+    pub pages: Vec<std::sync::Arc<PageFrame>>,
     /// Font data for all fonts used.
     pub fonts: Vec<FontData>,
     /// Optional document metadata for PDF output.
@@ -368,6 +370,21 @@ impl LayoutResult {
     /// ```
     pub fn new(
         pages: Vec<PageFrame>,
+        fonts: Vec<FontData>,
+        metadata: Option<DocumentMetadata>,
+        outlines: Vec<OutlineEntry>,
+    ) -> Self {
+        Self::from_shared(
+            pages.into_iter().map(std::sync::Arc::new).collect(),
+            fonts,
+            metadata,
+            outlines,
+        )
+    }
+
+    /// Construct a result from pages that are already shared.
+    pub fn from_shared(
+        pages: Vec<std::sync::Arc<PageFrame>>,
         fonts: Vec<FontData>,
         metadata: Option<DocumentMetadata>,
         outlines: Vec<OutlineEntry>,

--- a/crates/oxml-layout/src/output.rs
+++ b/crates/oxml-layout/src/output.rs
@@ -301,8 +301,10 @@ pub struct FontData {
     pub id: FontId,
     /// Font family name.
     pub family: String,
-    /// Raw TTF/OTF bytes for PDF embedding.
-    pub data: Vec<u8>,
+    /// Raw TTF/OTF bytes for PDF embedding. Shared, so producing a
+    /// `LayoutResult` does not copy every loaded face (tens of MB with CJK
+    /// fallbacks resident) on each layout. Pre-1.0 type break.
+    pub data: std::sync::Arc<[u8]>,
     /// Face index within a font collection.
     pub face_index: u32,
     /// Whether this is a bold variant.

--- a/crates/oxml-pdf/src/writer.rs
+++ b/crates/oxml-pdf/src/writer.rs
@@ -2264,7 +2264,7 @@ mod tests {
             font_data: FontData {
                 id: font_id,
                 family: "Test".to_owned(),
-                data: Vec::new(),
+                data: Vec::new().into(),
                 face_index: 0,
                 bold: false,
                 italic: false,

--- a/crates/oxml-pdf/src/writer.rs
+++ b/crates/oxml-pdf/src/writer.rs
@@ -28,10 +28,13 @@ struct AlphaStates {
 }
 
 impl AlphaStates {
-    fn new(pages: &[oxml_layout::PageFrame], alloc: &mut impl FnMut() -> Ref) -> Self {
+    fn new(
+        pages: &[impl std::borrow::Borrow<oxml_layout::PageFrame>],
+        alloc: &mut impl FnMut() -> Ref,
+    ) -> Self {
         let mut keys = BTreeSet::new();
         for page in pages {
-            collect_alpha_keys(&page.elements, &mut keys);
+            collect_alpha_keys(&page.borrow().elements, &mut keys);
         }
 
         let entries: Vec<AlphaEntry> = keys
@@ -140,13 +143,17 @@ struct GradientRegistry {
 }
 
 impl GradientRegistry {
-    fn new(pages: &[oxml_layout::PageFrame], alloc: &mut impl FnMut() -> Ref) -> Self {
+    fn new(
+        pages: &[impl std::borrow::Borrow<oxml_layout::PageFrame>],
+        alloc: &mut impl FnMut() -> Ref,
+    ) -> Self {
         let mut registry = Self {
             entries: Vec::new(),
             by_occurrence: HashMap::new(),
         };
 
         for (page_idx, page) in pages.iter().enumerate() {
+            let page = page.borrow();
             let mut leaf_idx = 0;
             let page_flip = Transform {
                 a: 1.0,

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -4621,7 +4621,7 @@ mod tests {
                     .layout
                     .fonts
                     .iter()
-                    .any(|font| font.data == input.fonts[0].data),
+                    .any(|font| font.data.as_ref() == input.fonts[0].data.as_slice()),
                 "the caller-provided font bytes shaped the result"
             );
             let runs = result

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -734,6 +734,16 @@ impl Engine {
             })
             .collect::<HashMap<_, _>>();
         for page in &mut pages {
+            // Pages are shared with the relayout caches; only unshare the
+            // ones substitution would actually rewrite, so field-free pages
+            // stay a pointer copy across relayouts.
+            let has_field = page.elements.iter().any(|element| {
+                matches!(element, PositionedElement::Text(run) if run.field_kind.is_some())
+            });
+            if !has_field {
+                continue;
+            }
+            let page = std::sync::Arc::make_mut(page);
             let page_num = page.page_number;
             substitute_fields(
                 &mut page.elements,
@@ -765,7 +775,7 @@ impl Engine {
             creator: Some("rdocx".to_string()),
         });
 
-        let mut result = LayoutResult::new(pages, fonts, metadata, outlines);
+        let mut result = LayoutResult::from_shared(pages, fonts, metadata, outlines);
         result.diagnostics = diagnostics;
         Ok(result)
     }
@@ -968,7 +978,7 @@ fn paragraph_is_cache_safe(paragraph: &CT_P, styles: &CT_Styles) -> bool {
 }
 
 fn canonicalize_layout_fonts(
-    pages: &mut [PageFrame],
+    pages: &mut [std::sync::Arc<PageFrame>],
     font_manager: &FontManager,
     current_fonts: &[FontId],
 ) -> Result<Vec<oxml_layout::FontData>> {
@@ -1024,8 +1034,13 @@ fn canonicalize_layout_fonts(
         font.id = remap[&persistent_id];
         fonts.push(font);
     }
-    for page in pages {
-        rewrite(&mut page.elements, &remap);
+    // Pages are shared with the relayout caches; when the remap is the
+    // identity (persistent ids already dense and in order, the usual case
+    // for a retained engine) leave them shared instead of unsharing all.
+    if remap.iter().any(|(persistent, local)| persistent != local) {
+        for page in pages {
+            rewrite(&mut std::sync::Arc::make_mut(page).elements, &remap);
+        }
     }
     Ok(fonts)
 }
@@ -1267,7 +1282,7 @@ fn paragraph_cache_entry_bytes(
 }
 
 /// Apply page background color from `w:background` element to all pages.
-fn apply_page_background(pages: &mut [PageFrame], input: &LayoutInput) {
+fn apply_page_background(pages: &mut [std::sync::Arc<PageFrame>], input: &LayoutInput) {
     let bg_xml = match &input.document.background_xml {
         Some(xml) => xml,
         None => return,
@@ -1283,6 +1298,7 @@ fn apply_page_background(pages: &mut [PageFrame], input: &LayoutInput) {
 
     // Insert a full-page FilledRect at position 0 on every page (renders underneath everything)
     for page in pages.iter_mut() {
+        let page = std::sync::Arc::make_mut(page);
         page.elements.insert(
             0,
             PositionedElement::FilledRect {
@@ -4587,6 +4603,7 @@ mod tests {
             .expect("provenance layout")
             .into_layout_result();
         for page in &mut sourced.pages {
+            let page = std::sync::Arc::make_mut(page);
             for element in &mut page.elements {
                 if let PositionedElement::Text(run) = element {
                     run.source = None;
@@ -5720,7 +5737,7 @@ mod tests {
         let all: String = output
             .pages
             .iter()
-            .map(page_text)
+            .map(|page| page_text(page))
             .collect::<Vec<_>>()
             .join(" | ");
         assert!(

--- a/crates/rdocx-layout/src/lib.rs
+++ b/crates/rdocx-layout/src/lib.rs
@@ -109,6 +109,17 @@ pub fn layout_document_with_fallback_fonts_and_provenance(
     input: &LayoutInput,
 ) -> Result<WordLayoutResult> {
     let mut engine = engine::Engine::new_deterministic()?;
+    layout_document_with_fallback_fonts_engine(&mut engine, input)
+}
+
+/// SVG PoC patch: the reusable-engine form of
+/// [`layout_document_with_fallback_fonts_and_provenance`], so an editor can
+/// keep the engine's relayout caches warm across edits (mirrors the hidden
+/// `layout_document_with_reusable_engine` facade).
+pub fn layout_document_with_fallback_fonts_engine(
+    engine: &mut engine::Engine,
+    input: &LayoutInput,
+) -> Result<WordLayoutResult> {
     let (layout, source_nodes) = engine.layout_with_provenance(input)?;
     Ok(WordLayoutResult {
         layout,

--- a/crates/rdocx-layout/src/lib.rs
+++ b/crates/rdocx-layout/src/lib.rs
@@ -100,7 +100,6 @@ pub fn layout_document_with_caller_fonts_and_provenance(
     })
 }
 
-
 /// SVG PoC patch: lay out with caller fonts on top of the bundled
 /// metric-compatible set — for wasm editors that inject one or two fonts
 /// and still need Calibri/Times to resolve. A separate entry point so the

--- a/crates/rdocx-layout/src/lib.rs
+++ b/crates/rdocx-layout/src/lib.rs
@@ -100,6 +100,24 @@ pub fn layout_document_with_caller_fonts_and_provenance(
     })
 }
 
+
+/// SVG PoC patch: lay out with caller fonts on top of the bundled
+/// metric-compatible set — for wasm editors that inject one or two fonts
+/// and still need Calibri/Times to resolve. A separate entry point so the
+/// strict caller-fonts isolation of
+/// [`layout_document_with_caller_fonts_and_provenance`] stays intact.
+pub fn layout_document_with_fallback_fonts_and_provenance(
+    input: &LayoutInput,
+) -> Result<WordLayoutResult> {
+    let mut engine = engine::Engine::new_deterministic()?;
+    let (layout, source_nodes) = engine.layout_with_provenance(input)?;
+    Ok(WordLayoutResult {
+        layout,
+        revision_view: input.revision_view,
+        source_nodes,
+    })
+}
+
 /// Lay out a DOCX using bundled fonts without system font discovery.
 pub fn layout_document_deterministic(input: &LayoutInput) -> Result<LayoutResult> {
     engine::Engine::new_deterministic()?.layout(input)

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -5,6 +5,7 @@
 
 use crate::block::{AnchoredContent, AnchoredDrawing, LayoutBlock, ParagraphBlock, ShapePreset};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use oxml_layout::{
     Align, Color, FontManager, GlyphRun, LayoutLine, LineItem, MediaId, NoteRef, NoteStream,
@@ -127,11 +128,11 @@ pub fn paginate_sections(
     fm: &FontManager,
     media: &MediaRegistry,
     notes: &NoteRegistry,
-) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
     let media = media.media();
     if sections.is_empty() {
         return (
-            vec![PageFrame::new(1, 612.0, 792.0, Vec::new())],
+            vec![Arc::new(PageFrame::new(1, 612.0, 792.0, Vec::new()))],
             Vec::new(),
         );
     }
@@ -183,7 +184,7 @@ pub fn paginate_sections(
     // If a section produced no pages (empty blocks), we might have duplicates
     // Renumber pages sequentially
     for (i, page) in all_pages.iter_mut().enumerate() {
-        page.page_number = i + 1;
+        Arc::make_mut(page).page_number = i + 1;
     }
 
     (all_pages, all_outlines)
@@ -198,7 +199,7 @@ pub fn paginate(
     _fm: &FontManager,
     media: &MediaRegistry,
     notes: &NoteRegistry,
-) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
     paginate_with_media(
         blocks,
         geometry,
@@ -251,7 +252,7 @@ fn paginate_with_media(
     notes: &NoteRegistry,
     first_page_number: usize,
     first_header_page_number: usize,
-) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
     let context = PassContext {
         geometry,
         header_footer,
@@ -283,7 +284,7 @@ fn paginate_with_media(
 
 /// One pagination pass, and what it learned about paragraph-relative wraps.
 struct PassResult {
-    pages: Vec<PageFrame>,
+    pages: Vec<Arc<PageFrame>>,
     outlines: Vec<OutlineEntry>,
     resolved: ResolvedWraps,
 }
@@ -399,7 +400,7 @@ fn paginate_pass(
 
 /// Helper struct to track page state during pagination.
 struct Pager<'a> {
-    pages: Vec<PageFrame>,
+    pages: Vec<Arc<PageFrame>>,
     elements: Vec<PositionedElement>,
     /// Anchored drawings marked behindDoc. Held apart from the normal element
     /// list so they can be emitted before everything else on the page, which
@@ -987,12 +988,12 @@ impl<'a> Pager<'a> {
             }
         }
 
-        self.pages.push(PageFrame::new(
+        self.pages.push(Arc::new(PageFrame::new(
             self.page_number,
             self.geometry.page_width,
             self.geometry.page_height,
             all_elements,
-        ));
+        )));
         self.page_number += 1;
         self.header_page_number += 1;
         self.cursor_y = 0.0;
@@ -1002,7 +1003,7 @@ impl<'a> Pager<'a> {
         self.is_first_page = false;
     }
 
-    fn flush(mut self) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+    fn flush(mut self) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
         // Always create at least one page
         if self.has_content() || self.pages.is_empty() {
             self.finish_page();
@@ -1209,7 +1210,7 @@ fn draw_note(
 /// the top of a fresh page and carry no separator rule. There is no body text
 /// on these pages for a rule to divide them from.
 pub fn append_endnote_pages(
-    pages: &mut Vec<PageFrame>,
+    pages: &mut Vec<Arc<PageFrame>>,
     notes: &NoteRegistry,
     geometry: PageGeometry,
 ) {
@@ -1239,12 +1240,12 @@ pub fn append_endnote_pages(
     let mut page_number = pages.len() + 1;
 
     let mut flush = |elements: &mut Vec<PositionedElement>, page_number: &mut usize| {
-        pages.push(PageFrame::new(
+        pages.push(Arc::new(PageFrame::new(
             *page_number,
             geometry.page_width,
             geometry.page_height,
             std::mem::take(elements),
-        ));
+        )));
         *page_number += 1;
     };
 

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3308,6 +3308,24 @@ impl Document {
         Ok(rdocx_layout::layout_document_with_caller_fonts_and_provenance(&input)?)
     }
 
+    /// SVG PoC patch: like [`Self::layout_with_fonts`], but the injected
+    /// fonts sit on top of the bundled metric-compatible set, so a wasm
+    /// editor that only injects a Korean font still resolves Calibri/Times.
+    /// Separate from the strictly isolated caller-fonts path on purpose.
+    pub fn layout_with_fonts_and_bundled_fallback(
+        &self,
+        font_files: &[(&str, &[u8])],
+    ) -> Result<rdocx_layout::WordLayoutResult> {
+        let mut input = self.build_layout_input();
+        for (family, data) in font_files {
+            input.fonts.push(rdocx_layout::FontFile {
+                family: family.to_string(),
+                data: data.to_vec(),
+            });
+        }
+        Ok(rdocx_layout::layout_document_with_fallback_fonts_and_provenance(&input)?)
+    }
+
     /// Render the document to PDF bytes.
     ///
     /// This performs a full layout pass (font shaping, line breaking, pagination)
@@ -5081,7 +5099,7 @@ mod tests {
                     .find(|font| font.id == run.font_id)
                     .expect("caller-font glyph run should resolve its font id");
                 assert_eq!(font.family, family);
-                assert_eq!(font.data, bytes);
+                assert_eq!(font.data.as_ref(), bytes.as_slice());
                 let source = run
                     .source
                     .expect("caller-font text should retain source provenance");
@@ -6142,7 +6160,7 @@ mod tests {
             assert!(
                 bundled_fonts
                     .iter()
-                    .any(|(_family, data)| *data == font.data.as_slice()),
+                    .any(|(_family, data)| *data == font.data.as_ref()),
                 "resolved font '{}' did not come from the bundled font set",
                 font.family
             );

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -115,6 +115,9 @@ pub struct Document {
     normal_layout_engine: Mutex<Option<rdocx_layout::engine::Engine>>,
     /// Bundled-font-only layout used by deterministic rendering.
     deterministic_layout_cache: Mutex<Option<Arc<rdocx_layout::WordLayoutResult>>>,
+    /// SVG PoC patch: reusable engine for the bundled-fallback caller-fonts
+    /// path (wasm editors), kept across edits like `normal_layout_engine`.
+    fallback_layout_engine: Mutex<Option<rdocx_layout::engine::Engine>>,
 }
 
 enum ChartPackageSource<'a> {
@@ -445,6 +448,7 @@ impl Document {
             layout_cache: Mutex::new(None),
             normal_layout_engine: Mutex::new(None),
             deterministic_layout_cache: Mutex::new(None),
+            fallback_layout_engine: Mutex::new(None),
         }
     }
 
@@ -476,6 +480,7 @@ impl Document {
             layout_cache: Mutex::new(None),
             normal_layout_engine: Mutex::new(None),
             deterministic_layout_cache: Mutex::new(None),
+            fallback_layout_engine: Mutex::new(None),
         }
     }
 
@@ -625,6 +630,7 @@ impl Document {
             layout_cache: Mutex::new(None),
             normal_layout_engine: Mutex::new(None),
             deterministic_layout_cache: Mutex::new(None),
+            fallback_layout_engine: Mutex::new(None),
         })
     }
 
@@ -3323,7 +3329,39 @@ impl Document {
                 data: data.to_vec(),
             });
         }
-        Ok(rdocx_layout::layout_document_with_fallback_fonts_and_provenance(&input)?)
+        let mut engine = self
+            .fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let engine = match engine.as_mut() {
+            Some(engine) => engine,
+            None => {
+                *engine = Some(rdocx_layout::engine::Engine::new_deterministic()?);
+                engine.as_mut().expect("just inserted")
+            }
+        };
+        Ok(rdocx_layout::layout_document_with_fallback_fonts_engine(
+            engine, &input,
+        )?)
+    }
+
+    /// SVG PoC patch: hand the bundled-fallback engine (and its content-keyed
+    /// relayout caches) to a caller restoring an undo snapshot, so the
+    /// rebuilt Document does not go cache-cold. Interim shape until the
+    /// upstream F-X039 session/handle design lands.
+    pub fn take_layout_engine(&self) -> Option<rdocx_layout::engine::Engine> {
+        self.fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
+
+    /// SVG PoC patch: counterpart of [`Self::take_layout_engine`].
+    pub fn set_layout_engine(&self, engine: rdocx_layout::engine::Engine) {
+        *self
+            .fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(engine);
     }
 
     /// Render the document to PDF bytes.

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3541,7 +3541,10 @@ impl Document {
     /// Return a cloned positioned page from the cached normal-font layout.
     ///
     /// `page_index` is zero-based. An index beyond the document returns `None`.
-    pub fn layout_page(&self, page_index: usize) -> Result<Option<oxml_layout::PageFrame>> {
+    pub fn layout_page(
+        &self,
+        page_index: usize,
+    ) -> Result<Option<std::sync::Arc<oxml_layout::PageFrame>>> {
         self.layout_page_with_options(page_index, RenderOptions::default())
     }
 
@@ -3550,7 +3553,7 @@ impl Document {
         &self,
         page_index: usize,
         options: RenderOptions,
-    ) -> Result<Option<oxml_layout::PageFrame>> {
+    ) -> Result<Option<std::sync::Arc<oxml_layout::PageFrame>>> {
         let layout = self.layout_with_options(options)?;
         Ok(layout.layout.pages.get(page_index).cloned())
     }


### PR DESCRIPTION
Draft PR for F-X039 (Share layout payloads and transfer reusable engines),
as requested in #39. Based on v0.8.0; four commits, each an independent
review boundary. The two public type breaks are isolated exactly so the
F-X040 draft (which stacks on this branch) can be reviewed without making
shared ownership an implicit prerequisite.

**1. `FontData.data` becomes `Arc<[u8]>`.** The manager already holds
`Arc<[u8]>`; `all_font_data`/`font_data` deep-copied every face into each
`LayoutResult` (~50MB per layout with CJK fallbacks resident, 39–52ms on
the 63-page editor document). Now a pointer copy end to end. Public
low-level type break; construction sites migrate with `.into()`.

**2. `LayoutResult.pages` becomes `Vec<Arc<PageFrame>>`.** An interactive
caller relayouting per edit keeps unchanged pages alive across results
instead of deep-copying them (~12ms per copy at 63 pages). Post-pagination
passes unshare copy-on-write: field substitution only pages that contain a
field, page background only when one exists, and
`canonicalize_layout_fonts` skips its rewrite when the remap is the
identity (the usual case for a retained engine). PDF writer helpers take
`Borrow<PageFrame>` so owned and shared pages both work. Second isolated
type break.

**3. A bundled-fallback caller-fonts entry point.** Not a change to the
strict caller-fonts path — its isolation contract test still passes. A wasm
editor that injects one CJK font cannot resolve Calibri/Times through
`Engine::new_with_caller_fonts` (layout fails with FontNotFound);
`layout_document_with_fallback_fonts_and_provenance` runs on the
deterministic bundled set with caller fonts on top, never touching the
process system-font snapshot.

**4. A reusable engine for that path, plus an interim handoff.** The
fallback entry keeps one engine on the `Document` (mirroring
`normal_layout_engine`) so F-X038's caches survive across edits in a wasm
editor. `take_layout_engine`/`set_layout_engine` let an undo-snapshot
restore carry the engine to the rebuilt `Document` — measured effect in our
editor: undo/redo at parity with typing instead of cache-cold. We expect
this last piece to become whatever session/handle shape F-X039 lands on;
it is included as a working reference for the ownership and stale-context
questions you raised, not as a proposed final API.

Editor-level numbers (63-page mixed Latin/Korean document, per keystroke,
with the F-X040 branch on top): native 160ms on stock v0.8.0 → 31ms; wasm
typing ~75–135ms, undo ~80ms. Suites: full workspace, zero failures on our
machine at the time of the sweep (the handful of fixture tests that vary
with machine load unchanged).
