### PR TITLE
Dense-form layout: nested tables, vertical merges, exact rows, table-style cascade, cell-anchored drawings

### DIFF
--- a/crates/oxml-layout/src/font.rs
+++ b/crates/oxml-layout/src/font.rs
@@ -887,7 +887,7 @@ impl FontManager {
         Ok(crate::output::FontData {
             id: font.id,
             family: font.family.clone(),
-            data: font.data.to_vec(),
+            data: font.data.clone(),
             face_index: font.face_index,
             bold: font.bold,
             italic: font.italic,
@@ -901,7 +901,7 @@ impl FontManager {
             .map(|f| crate::output::FontData {
                 id: f.id,
                 family: f.family.clone(),
-                data: f.data.to_vec(),
+                data: f.data.clone(),
                 face_index: f.face_index,
                 bold: f.bold,
                 italic: f.italic,

--- a/crates/oxml-layout/src/output.rs
+++ b/crates/oxml-layout/src/output.rs
@@ -345,8 +345,10 @@ pub struct OutlineEntry {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct LayoutResult {
-    /// Laid-out pages.
-    pub pages: Vec<PageFrame>,
+    /// Laid-out pages, shared: an interactive caller relayouting per edit
+    /// keeps unchanged pages alive across results instead of deep-copying
+    /// them. Pre-1.0 type break, like `FontData.data`.
+    pub pages: Vec<std::sync::Arc<PageFrame>>,
     /// Font data for all fonts used.
     pub fonts: Vec<FontData>,
     /// Optional document metadata for PDF output.
@@ -368,6 +370,21 @@ impl LayoutResult {
     /// ```
     pub fn new(
         pages: Vec<PageFrame>,
+        fonts: Vec<FontData>,
+        metadata: Option<DocumentMetadata>,
+        outlines: Vec<OutlineEntry>,
+    ) -> Self {
+        Self::from_shared(
+            pages.into_iter().map(std::sync::Arc::new).collect(),
+            fonts,
+            metadata,
+            outlines,
+        )
+    }
+
+    /// Construct a result from pages that are already shared.
+    pub fn from_shared(
+        pages: Vec<std::sync::Arc<PageFrame>>,
         fonts: Vec<FontData>,
         metadata: Option<DocumentMetadata>,
         outlines: Vec<OutlineEntry>,

--- a/crates/oxml-layout/src/output.rs
+++ b/crates/oxml-layout/src/output.rs
@@ -301,8 +301,10 @@ pub struct FontData {
     pub id: FontId,
     /// Font family name.
     pub family: String,
-    /// Raw TTF/OTF bytes for PDF embedding.
-    pub data: Vec<u8>,
+    /// Raw TTF/OTF bytes for PDF embedding. Shared, so producing a
+    /// `LayoutResult` does not copy every loaded face (tens of MB with CJK
+    /// fallbacks resident) on each layout. Pre-1.0 type break.
+    pub data: std::sync::Arc<[u8]>,
     /// Face index within a font collection.
     pub face_index: u32,
     /// Whether this is a bold variant.

--- a/crates/oxml-pdf/src/writer.rs
+++ b/crates/oxml-pdf/src/writer.rs
@@ -2264,7 +2264,7 @@ mod tests {
             font_data: FontData {
                 id: font_id,
                 family: "Test".to_owned(),
-                data: Vec::new(),
+                data: Vec::new().into(),
                 face_index: 0,
                 bold: false,
                 italic: false,

--- a/crates/oxml-pdf/src/writer.rs
+++ b/crates/oxml-pdf/src/writer.rs
@@ -28,10 +28,13 @@ struct AlphaStates {
 }
 
 impl AlphaStates {
-    fn new(pages: &[oxml_layout::PageFrame], alloc: &mut impl FnMut() -> Ref) -> Self {
+    fn new(
+        pages: &[impl std::borrow::Borrow<oxml_layout::PageFrame>],
+        alloc: &mut impl FnMut() -> Ref,
+    ) -> Self {
         let mut keys = BTreeSet::new();
         for page in pages {
-            collect_alpha_keys(&page.elements, &mut keys);
+            collect_alpha_keys(&page.borrow().elements, &mut keys);
         }
 
         let entries: Vec<AlphaEntry> = keys
@@ -140,13 +143,17 @@ struct GradientRegistry {
 }
 
 impl GradientRegistry {
-    fn new(pages: &[oxml_layout::PageFrame], alloc: &mut impl FnMut() -> Ref) -> Self {
+    fn new(
+        pages: &[impl std::borrow::Borrow<oxml_layout::PageFrame>],
+        alloc: &mut impl FnMut() -> Ref,
+    ) -> Self {
         let mut registry = Self {
             entries: Vec::new(),
             by_occurrence: HashMap::new(),
         };
 
         for (page_idx, page) in pages.iter().enumerate() {
+            let page = page.borrow();
             let mut leaf_idx = 0;
             let page_flip = Transform {
                 a: 1.0,

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -4621,7 +4621,7 @@ mod tests {
                     .layout
                     .fonts
                     .iter()
-                    .any(|font| font.data == input.fonts[0].data),
+                    .any(|font| font.data.as_ref() == input.fonts[0].data.as_slice()),
                 "the caller-provided font bytes shaped the result"
             );
             let runs = result

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -2356,6 +2356,54 @@ pub(crate) fn layout_paragraph_with_source(
     let mut lines = break_into_lines(&inline_items, &line_params, fm)?;
     convert::restore_word_line_heights(&mut lines, &effective_ppr);
 
+    // An empty paragraph renders no elements, which leaves an interactive
+    // caller with no way to click into it or draw a caret there. Give its
+    // line one zero-width empty text segment carrying the paragraph's
+    // resolved default font and its source identity (char span 0..0).
+    // Emitted whether or not a source registry is in use, so ordinary and
+    // provenance layouts stay structurally identical.
+    if inline_items.is_empty()
+        && let Some(line) = lines.first_mut()
+        && line.items.is_empty()
+    {
+        let default_rpr = style_resolver::resolve_run_properties(para_style_id, None, styles);
+        let font_size = default_rpr.sz.map(|hp| hp.to_pt()).unwrap_or(11.0);
+        let bold = default_rpr.bold.unwrap_or(false);
+        let italic = default_rpr.italic.unwrap_or(false);
+        if let Ok(font_id) =
+            fm.resolve_font_for_text(default_rpr.font_ascii.as_deref(), bold, italic, " ")
+            && let Ok(metrics) = fm.metrics(font_id, font_size)
+        {
+            line.items.push(LineItem::Text(TextSegment {
+                text: String::new(),
+                source: source_node.map(|node| oxml_layout::SourceSpan {
+                    node,
+                    char_start: 0,
+                    char_end: 0,
+                }),
+                font_id,
+                font_size,
+                glyph_ids: Vec::new(),
+                advances: Vec::new(),
+                width: 0.0,
+                ascent: metrics.ascent,
+                descent: metrics.descent,
+                line_gap: 0.0,
+                color: Color::BLACK,
+                bold,
+                italic,
+                underline: None,
+                strike: false,
+                dstrike: false,
+                highlight: None,
+                baseline_offset: 0.0,
+                hyperlink_url: None,
+                field_kind: None,
+                note: None,
+            }));
+        }
+    }
+
     let mut result = block::build_paragraph_block(
         lines,
         space_before,

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -1774,10 +1774,41 @@ pub(crate) fn layout_paragraph_with_source(
     diagnostics: &mut Vec<Diagnostic>,
     source_node: Option<SourceNodeId>,
 ) -> Result<ParagraphBlock> {
+    layout_paragraph_with_source_in_table(
+        para,
+        available_width,
+        styles,
+        input,
+        media,
+        fm,
+        num_state,
+        diagnostics,
+        source_node,
+        None,
+    )
+}
+
+/// [`layout_paragraph_with_source`] with the table-style paragraph
+/// properties of the enclosing table, merged between docDefaults and the
+/// paragraph style per the OOXML cascade.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn layout_paragraph_with_source_in_table(
+    para: &CT_P,
+    available_width: f64,
+    styles: &CT_Styles,
+    input: &LayoutInput,
+    media: &MediaRegistry,
+    fm: &mut FontManager,
+    num_state: &mut NumberingState,
+    diagnostics: &mut Vec<Diagnostic>,
+    source_node: Option<SourceNodeId>,
+    table_ppr: Option<&rdocx_oxml::properties::CT_PPr>,
+) -> Result<ParagraphBlock> {
     // Resolve paragraph properties
     let para_style_id = para.properties.as_ref().and_then(|p| p.style_id.as_deref());
 
-    let resolved_ppr = style_resolver::resolve_paragraph_properties(para_style_id, styles);
+    let resolved_ppr =
+        style_resolver::resolve_paragraph_properties_in_table(para_style_id, styles, table_ppr);
 
     let mut effective_ppr = resolved_ppr;
 
@@ -2366,7 +2397,23 @@ pub(crate) fn layout_paragraph_with_source(
         && let Some(line) = lines.first_mut()
         && line.items.is_empty()
     {
-        let default_rpr = style_resolver::resolve_run_properties(para_style_id, None, styles);
+        let mut default_rpr = style_resolver::resolve_run_properties(para_style_id, None, styles);
+        // The paragraph mark's own run properties (pPr/rPr) size an empty
+        // paragraph in Word — a 7pt mark makes a ~8.4pt line, not 11pt.
+        if let Some(mark_rpr) = para.properties.as_ref().and_then(|p| p.rpr.as_ref()) {
+            if mark_rpr.sz.is_some() {
+                default_rpr.sz = mark_rpr.sz;
+            }
+            if mark_rpr.bold.is_some() {
+                default_rpr.bold = mark_rpr.bold;
+            }
+            if mark_rpr.italic.is_some() {
+                default_rpr.italic = mark_rpr.italic;
+            }
+            if mark_rpr.font_ascii.is_some() {
+                default_rpr.font_ascii = mark_rpr.font_ascii.clone();
+            }
+        }
         let font_size = default_rpr.sz.map(|hp| hp.to_pt()).unwrap_or(11.0);
         let bold = default_rpr.bold.unwrap_or(false);
         let italic = default_rpr.italic.unwrap_or(false);
@@ -2401,7 +2448,15 @@ pub(crate) fn layout_paragraph_with_source(
                 field_kind: None,
                 note: None,
             }));
+            // The line was sized before this segment existed, so it still
+            // carries the 12pt no-metrics fallback; give it the real font
+            // metrics (an empty 7pt paragraph is ~8.4pt tall, not 12).
+            line.ascent = metrics.ascent;
+            line.descent = metrics.descent;
         }
+    }
+    if inline_items.is_empty() {
+        convert::restore_word_line_heights(&mut lines, &effective_ppr);
     }
 
     let mut result = block::build_paragraph_block(

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -734,6 +734,16 @@ impl Engine {
             })
             .collect::<HashMap<_, _>>();
         for page in &mut pages {
+            // Pages are shared with the relayout caches; only unshare the
+            // ones substitution would actually rewrite, so field-free pages
+            // stay a pointer copy across relayouts.
+            let has_field = page.elements.iter().any(|element| {
+                matches!(element, PositionedElement::Text(run) if run.field_kind.is_some())
+            });
+            if !has_field {
+                continue;
+            }
+            let page = std::sync::Arc::make_mut(page);
             let page_num = page.page_number;
             substitute_fields(
                 &mut page.elements,
@@ -765,7 +775,7 @@ impl Engine {
             creator: Some("rdocx".to_string()),
         });
 
-        let mut result = LayoutResult::new(pages, fonts, metadata, outlines);
+        let mut result = LayoutResult::from_shared(pages, fonts, metadata, outlines);
         result.diagnostics = diagnostics;
         Ok(result)
     }
@@ -968,7 +978,7 @@ fn paragraph_is_cache_safe(paragraph: &CT_P, styles: &CT_Styles) -> bool {
 }
 
 fn canonicalize_layout_fonts(
-    pages: &mut [PageFrame],
+    pages: &mut [std::sync::Arc<PageFrame>],
     font_manager: &FontManager,
     current_fonts: &[FontId],
 ) -> Result<Vec<oxml_layout::FontData>> {
@@ -1024,8 +1034,13 @@ fn canonicalize_layout_fonts(
         font.id = remap[&persistent_id];
         fonts.push(font);
     }
-    for page in pages {
-        rewrite(&mut page.elements, &remap);
+    // Pages are shared with the relayout caches; when the remap is the
+    // identity (persistent ids already dense and in order, the usual case
+    // for a retained engine) leave them shared instead of unsharing all.
+    if remap.iter().any(|(persistent, local)| persistent != local) {
+        for page in pages {
+            rewrite(&mut std::sync::Arc::make_mut(page).elements, &remap);
+        }
     }
     Ok(fonts)
 }
@@ -1267,7 +1282,7 @@ fn paragraph_cache_entry_bytes(
 }
 
 /// Apply page background color from `w:background` element to all pages.
-fn apply_page_background(pages: &mut [PageFrame], input: &LayoutInput) {
+fn apply_page_background(pages: &mut [std::sync::Arc<PageFrame>], input: &LayoutInput) {
     let bg_xml = match &input.document.background_xml {
         Some(xml) => xml,
         None => return,
@@ -1283,6 +1298,7 @@ fn apply_page_background(pages: &mut [PageFrame], input: &LayoutInput) {
 
     // Insert a full-page FilledRect at position 0 on every page (renders underneath everything)
     for page in pages.iter_mut() {
+        let page = std::sync::Arc::make_mut(page);
         page.elements.insert(
             0,
             PositionedElement::FilledRect {
@@ -4587,6 +4603,7 @@ mod tests {
             .expect("provenance layout")
             .into_layout_result();
         for page in &mut sourced.pages {
+            let page = std::sync::Arc::make_mut(page);
             for element in &mut page.elements {
                 if let PositionedElement::Text(run) = element {
                     run.source = None;
@@ -5720,7 +5737,7 @@ mod tests {
         let all: String = output
             .pages
             .iter()
-            .map(page_text)
+            .map(|page| page_text(page))
             .collect::<Vec<_>>()
             .join(" | ");
         assert!(

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -402,6 +402,41 @@ pub struct Engine {
     #[cfg(test)]
     pending_paragraph_cache_peak_bytes: usize,
     paragraph_cache_reads_enabled: bool,
+    /// Pages from the previous relayout of a single-section document, so an
+    /// edit repaginates only the pages around the change. See
+    /// [`paginator::PaginationCache`].
+    pagination_cache: Option<paginator::PaginationCache>,
+    /// Bumped whenever the caller/document font set changes; folded into the
+    /// pagination environment fingerprint.
+    fonts_generation: u64,
+    /// Laid-out tables, keyed on source fingerprint, body position and the
+    /// source-node table (cached blocks carry baked source spans).
+    table_cache: HashMap<u64, TableCacheEntry>,
+    /// Laid-out header/footer content per section source, same key regime.
+    hf_cache: HashMap<u64, HfCacheEntry>,
+    /// Post-field-substitution page pairs `(pristine, substituted)` from the
+    /// previous relayout; while the field environment is unchanged, a page
+    /// that is still the same shared pristine Arc reuses its substituted
+    /// form instead of being unshared and reshaped.
+    subst_prev: Vec<(std::sync::Arc<PageFrame>, std::sync::Arc<PageFrame>)>,
+    /// Field environment of `subst_prev`: total pages + bookmark targets.
+    subst_env: u64,
+}
+
+/// A laid-out table plus what a cache hit must replay, mirroring
+/// [`ParagraphCacheEntry`]. Tables whose cells render numbering markers or
+/// note references are never stored.
+struct TableCacheEntry {
+    block: crate::table::TableBlock,
+    diagnostics: Vec<Diagnostic>,
+    font_trace: Vec<FontId>,
+}
+
+/// Laid-out header/footer content for one section source, plus replay data.
+struct HfCacheEntry {
+    content: Option<paginator::HeaderFooterContent>,
+    diagnostics: Vec<Diagnostic>,
+    font_trace: Vec<FontId>,
 }
 
 #[derive(Clone, PartialEq)]
@@ -463,6 +498,12 @@ impl Engine {
             #[cfg(test)]
             pending_paragraph_cache_peak_bytes: 0,
             paragraph_cache_reads_enabled: false,
+            pagination_cache: None,
+            fonts_generation: 0,
+            table_cache: HashMap::new(),
+            hf_cache: HashMap::new(),
+            subst_prev: Vec::new(),
+            subst_env: 0,
         }
     }
 
@@ -514,6 +555,21 @@ impl Engine {
         let context_matches =
             !fonts_changed && self.paragraph_cache_context.as_ref() == Some(&paragraph_context);
         self.paragraph_cache_reads_enabled = context_matches;
+        if fonts_changed {
+            self.fonts_generation = self.fonts_generation.wrapping_add(1);
+        }
+        if !context_matches {
+            // Styles/theme/fonts changed (or first layout): every
+            // cross-relayout cache keyed on that context is stale. This is
+            // the styles/numbering/theme invalidation boundary F-X038 keys
+            // paragraph reuse on, applied to page and block reuse as well
+            // (numbering definitions additionally join the pagination
+            // environment fingerprint below).
+            self.pagination_cache = None;
+            self.table_cache.clear();
+            self.hf_cache.clear();
+            self.subst_prev.clear();
+        }
         self.pending_paragraph_cache = Some(VecDeque::new());
         self.pending_paragraph_cache_bytes = 0;
         #[cfg(test)]
@@ -580,6 +636,14 @@ impl Engine {
         // Build sections: each section has blocks + geometry + header/footer
         let mut sections: Vec<paginator::Section> = Vec::new();
         let mut current_blocks: Vec<LayoutBlock> = Vec::new();
+        // Pagination identity per block, aligned with the block list of a
+        // single-section document (the only shape the pagination cache
+        // accepts; a section break mid-list leaves this misaligned, unused).
+        let mut block_fps: Vec<u64> = Vec::new();
+        // Reused pages and cached table/header blocks carry baked
+        // result-local SourceSpans; they stay valid only while the whole
+        // source-node table (ids and paths) is unchanged.
+        let source_fold = sources.map_or(0, |s| fingerprint_source_nodes(&s.nodes));
         let mut current_sect_pr: Option<CT_SectPr> = None; // Will be set from paragraph sect_pr
 
         for (body_index, content) in input.document.body.content.iter().enumerate() {
@@ -618,20 +682,29 @@ impl Engine {
                             Some(projected_paragraph_text(para, input.revision_view));
                     }
 
-                    current_blocks.push(LayoutBlock::Paragraph(para_block));
+                    let block = LayoutBlock::Paragraph(para_block);
+                    block_fps.push(combine_fp(
+                        fingerprint_paragraph(
+                            para,
+                            geometry.content_width(),
+                            input.revision_view as u8,
+                        ),
+                        pagination_salt(&block),
+                    ));
+                    current_blocks.push(block);
 
                     // If this paragraph has sect_pr, it ends a section
                     if let Some(sect_pr) = para_sect_pr {
                         let geometry = sect_pr_to_geometry(&sect_pr);
-                        let header_footer = layout_header_footer(
+                        let header_footer = self.layout_header_footer_cached(
                             &sect_pr,
                             input,
                             styles,
                             &media,
-                            &mut self.font_manager,
                             &mut num_state,
                             &mut diagnostics,
                             sources,
+                            source_fold,
                         )?;
                         let title_pg = sect_pr.title_pg.unwrap_or(false);
                         sections.push(paginator::Section {
@@ -648,20 +721,60 @@ impl Engine {
                     let sect_pr_for_layout = current_sect_pr.as_ref().unwrap_or(&final_sect_pr);
                     let geometry = sect_pr_to_geometry(sect_pr_for_layout);
 
-                    let table_block = table::layout_table_with_provenance(
-                        tbl,
-                        geometry.content_width(),
-                        styles,
-                        input,
-                        &media,
-                        &mut self.font_manager,
-                        &mut num_state,
-                        &mut diagnostics,
-                        sources,
-                        &WordStory::Document,
-                        &[body_index],
-                    )?;
-                    current_blocks.push(LayoutBlock::Table(table_block));
+                    let table_src_fp =
+                        fingerprint_table(tbl, geometry.content_width(), input.revision_view as u8);
+                    let table_key = {
+                        let mut fp = Fingerprint::new();
+                        fp.eat(&table_src_fp.to_le_bytes());
+                        fp.eat(&(body_index as u64).to_le_bytes());
+                        fp.eat(&source_fold.to_le_bytes());
+                        fp.finish()
+                    };
+                    let table_block = if let Some(hit) = self.table_cache.get(&table_key) {
+                        diagnostics.extend(hit.diagnostics.iter().cloned());
+                        self.font_manager.replay_layout_font_trace(&hit.font_trace);
+                        hit.block.clone()
+                    } else {
+                        let diagnostics_start = diagnostics.len();
+                        self.font_manager.begin_paragraph_font_trace();
+                        let block = table::layout_table_with_provenance(
+                            tbl,
+                            geometry.content_width(),
+                            styles,
+                            input,
+                            &media,
+                            &mut self.font_manager,
+                            &mut num_state,
+                            &mut diagnostics,
+                            sources,
+                            &WordStory::Document,
+                            &[body_index],
+                        )?;
+                        let font_trace = self.font_manager.finish_paragraph_font_trace();
+                        // A cache hit skips layout_table, so NumberingState
+                        // would not advance through numbered cell paragraphs
+                        // and note markers would freeze: such tables stay
+                        // uncached, exactly like marker paragraphs.
+                        if let Some(font_trace) = font_trace
+                            && !table_renders_shared_state(&block)
+                        {
+                            if self.table_cache.len() >= 256 {
+                                self.table_cache.clear();
+                            }
+                            self.table_cache.insert(
+                                table_key,
+                                TableCacheEntry {
+                                    block: block.clone(),
+                                    diagnostics: diagnostics[diagnostics_start..].to_vec(),
+                                    font_trace,
+                                },
+                            );
+                        }
+                        block
+                    };
+                    let block = LayoutBlock::Table(table_block);
+                    block_fps.push(combine_fp(table_src_fp, pagination_salt(&block)));
+                    current_blocks.push(block);
                 }
                 _ => {} // Skip RawXml elements during layout
             }
@@ -669,15 +782,15 @@ impl Engine {
 
         // Remaining blocks belong to the final section
         let final_geometry = sect_pr_to_geometry(&final_sect_pr);
-        let final_hf = layout_header_footer(
+        let final_hf = self.layout_header_footer_cached(
             &final_sect_pr,
             input,
             styles,
             &media,
-            &mut self.font_manager,
             &mut num_state,
             &mut diagnostics,
             sources,
+            source_fold,
         )?;
         let final_title_pg = final_sect_pr.title_pg.unwrap_or(false);
         sections.push(paginator::Section {
@@ -710,8 +823,44 @@ impl Engine {
         )?;
 
         // Paginate across all sections
-        let (mut pages, outlines) =
-            paginator::paginate_sections(&sections, &self.font_manager, &media, &notes);
+        // Everything pagination reads besides the block stream; a change in
+        // any of it invalidates the whole pagination cache. Styles and theme
+        // invalidate via the paragraph-cache context gate in layout_inner;
+        // numbering definitions, note parts, header/footer parts, section
+        // properties, fonts, revision view and the source-node table are
+        // folded here.
+        let env_fp = {
+            let mut fp = Fingerprint::new();
+            fp.eat_debug(&final_sect_pr);
+            let mut ids: Vec<&String> = input.headers.keys().collect();
+            ids.sort();
+            for id in ids {
+                fp.eat(id.as_bytes());
+                fp.eat_hdr_ftr(&input.headers[id]);
+            }
+            let mut ids: Vec<&String> = input.footers.keys().collect();
+            ids.sort();
+            for id in ids {
+                fp.eat(id.as_bytes());
+                fp.eat_hdr_ftr(&input.footers[id]);
+            }
+            fp.eat_notes(&input.footnotes);
+            fp.eat_notes(&input.endnotes);
+            fp.eat_debug(&input.numbering);
+            fp.eat(&[input.revision_view as u8]);
+            fp.eat(&self.fonts_generation.to_le_bytes());
+            fp.eat(&source_fold.to_le_bytes());
+            fp.finish()
+        };
+        let (mut pages, outlines) = paginator::paginate_sections_cached(
+            &sections,
+            &self.font_manager,
+            &media,
+            &notes,
+            (sections.len() == 1).then_some(block_fps.as_slice()),
+            env_fp,
+            &mut self.pagination_cache,
+        );
 
         // Endnotes read at the end of the document, so they follow the last
         // body page rather than sitting at the foot of their reference's page.
@@ -733,7 +882,23 @@ impl Engine {
                 })
             })
             .collect::<HashMap<_, _>>();
-        for page in &mut pages {
+        // Everything substitution reads besides the page itself; while it is
+        // unchanged, a page that is still the same shared pristine page as
+        // last relayout substitutes to the same result.
+        let subst_env = {
+            let mut fp = Fingerprint::new();
+            fp.eat(&(total_pages as u64).to_le_bytes());
+            let mut targets: Vec<(usize, usize)> =
+                bookmark_pages.iter().map(|(t, p)| (*t, *p)).collect();
+            targets.sort_unstable();
+            for (t, p) in targets {
+                fp.eat(&(t as u64).to_le_bytes());
+                fp.eat(&(p as u64).to_le_bytes());
+            }
+            fp.finish()
+        };
+        let pristine: Vec<std::sync::Arc<PageFrame>> = pages.clone();
+        for (i, page) in pages.iter_mut().enumerate() {
             // Pages are shared with the relayout caches; only unshare the
             // ones substitution would actually rewrite, so field-free pages
             // stay a pointer copy across relayouts.
@@ -741,6 +906,13 @@ impl Engine {
                 matches!(element, PositionedElement::Text(run) if run.field_kind.is_some())
             });
             if !has_field {
+                continue;
+            }
+            if subst_env == self.subst_env
+                && let Some((old_pristine, old_subst)) = self.subst_prev.get(i)
+                && std::sync::Arc::ptr_eq(old_pristine, &pristine[i])
+            {
+                *page = std::sync::Arc::clone(old_subst);
                 continue;
             }
             let page = std::sync::Arc::make_mut(page);
@@ -753,6 +925,8 @@ impl Engine {
                 &mut self.font_manager,
             );
         }
+        self.subst_prev = pristine.into_iter().zip(pages.iter().cloned()).collect();
+        self.subst_env = subst_env;
 
         // Post-pagination pass: apply page background color
         apply_page_background(&mut pages, input);
@@ -1043,6 +1217,96 @@ fn canonicalize_layout_fonts(
         }
     }
     Ok(fonts)
+}
+
+impl Engine {
+    /// [`layout_header_footer`] behind a content-keyed cache, so a relayout
+    /// does not re-shape the same header/footer parts on every edit.
+    ///
+    /// Entries whose blocks render numbering markers or note references are
+    /// not cached: a hit skips `layout_header_footer`, which would stop
+    /// NumberingState from advancing and freeze note-marker numbering. The
+    /// key folds the source-node table because header paragraphs carry
+    /// result-local source spans.
+    #[allow(clippy::too_many_arguments)]
+    fn layout_header_footer_cached(
+        &mut self,
+        sect_pr: &CT_SectPr,
+        input: &LayoutInput,
+        styles: &CT_Styles,
+        media: &MediaRegistry,
+        num_state: &mut NumberingState,
+        diagnostics: &mut Vec<Diagnostic>,
+        sources: Option<&SourceRegistry>,
+        source_fold: u64,
+    ) -> Result<Option<paginator::HeaderFooterContent>> {
+        let key = {
+            let mut fp = Fingerprint::new();
+            fp.eat_debug(&sect_pr.header_refs);
+            fp.eat_debug(&sect_pr.footer_refs);
+            for href in &sect_pr.header_refs {
+                if let Some(part) = input.headers.get(&href.rel_id) {
+                    fp.eat_hdr_ftr(part);
+                }
+            }
+            for fref in &sect_pr.footer_refs {
+                if let Some(part) = input.footers.get(&fref.rel_id) {
+                    fp.eat_hdr_ftr(part);
+                }
+            }
+            let geometry = sect_pr_to_geometry(sect_pr);
+            fp.eat(&geometry.content_width().to_bits().to_le_bytes());
+            fp.eat(&[input.revision_view as u8]);
+            fp.eat(&source_fold.to_le_bytes());
+            fp.finish()
+        };
+        if let Some(hit) = self.hf_cache.get(&key) {
+            diagnostics.extend(hit.diagnostics.iter().cloned());
+            self.font_manager.replay_layout_font_trace(&hit.font_trace);
+            return Ok(hit.content.clone());
+        }
+        let diagnostics_start = diagnostics.len();
+        self.font_manager.begin_paragraph_font_trace();
+        let built = layout_header_footer(
+            sect_pr,
+            input,
+            styles,
+            media,
+            &mut self.font_manager,
+            num_state,
+            diagnostics,
+            sources,
+        )?;
+        let font_trace = self.font_manager.finish_paragraph_font_trace();
+        let cacheable = built.as_ref().is_none_or(|hf| {
+            ![
+                &hf.header_blocks,
+                &hf.footer_blocks,
+                &hf.first_header_blocks,
+                &hf.first_footer_blocks,
+                &hf.even_header_blocks,
+                &hf.even_footer_blocks,
+            ]
+            .iter()
+            .any(|blocks| para_blocks_render_shared_state(blocks))
+        });
+        if let Some(font_trace) = font_trace
+            && cacheable
+        {
+            if self.hf_cache.len() >= 64 {
+                self.hf_cache.clear();
+            }
+            self.hf_cache.insert(
+                key,
+                HfCacheEntry {
+                    content: built.clone(),
+                    diagnostics: diagnostics[diagnostics_start..].to_vec(),
+                    font_trace,
+                },
+            );
+        }
+        Ok(built)
+    }
 }
 
 fn rebind_text_source(text: &mut TextSegment, source_node: Option<SourceNodeId>) {
@@ -3096,6 +3360,320 @@ mod tests {
     use crate::input::ImageData;
     use oxml_layout::MediaId;
     use std::collections::HashMap;
+
+    // --- restartable pagination -------------------------------------------
+
+    fn many_paragraph_input(n: usize) -> LayoutInput {
+        let mut doc = rdocx_oxml::document::CT_Document::new();
+        for i in 0..n {
+            let mut p = CT_P::new();
+            if i % 30 == 5 {
+                p.properties.get_or_insert_with(Default::default).style_id =
+                    Some("Heading1".to_string());
+                p.add_run(&format!("Heading {i}"));
+            } else {
+                p.add_run(&format!(
+                    "Paragraph {i}: the quick brown fox jumps over the lazy dog, \
+                     again and again, until the page runs out of room and the \
+                     paginator has to start another one to hold the rest."
+                ));
+            }
+            doc.body.add_paragraph(p);
+        }
+        let mut input = make_input_with_text("");
+        input.document = doc;
+        input
+    }
+
+    fn set_paragraph_text(input: &mut LayoutInput, idx: usize, text: &str) {
+        let BodyContent::Paragraph(p) = &mut input.document.body.content[idx] else {
+            panic!("expected paragraph at {idx}");
+        };
+        *p = CT_P::new();
+        p.add_run(text);
+    }
+
+    fn pages_debug(result: &LayoutResult) -> Vec<String> {
+        result.pages.iter().map(|p| format!("{p:?}")).collect()
+    }
+
+    /// Attach a text header and a "Page {PAGE}" footer to the input's body
+    /// section, the common shape that exercises the header/footer cache and
+    /// per-page field substitution reuse.
+    fn attach_page_footer(input: &mut LayoutInput) {
+        use rdocx_oxml::header_footer::{CT_HdrFtr, HdrFtrRef, HdrFtrType};
+        use rdocx_oxml::text::{CT_R, Field, RunContent};
+
+        let mut header = CT_HdrFtr::new();
+        let mut hp = CT_P::new();
+        hp.add_run("Equivalence header");
+        header.paragraphs.push(hp);
+        input.headers.insert("rIdH1".to_string(), header);
+
+        let mut footer = CT_HdrFtr::new();
+        let mut fp = CT_P::new();
+        fp.add_run("Page ");
+        let mut run = CT_R::new("");
+        run.content = vec![RunContent::Field(Field::new(" PAGE ", "1"))];
+        fp.runs.push(run);
+        footer.paragraphs.push(fp);
+        input.footers.insert("rIdF1".to_string(), footer);
+
+        let sect_pr = input
+            .document
+            .body
+            .sect_pr
+            .get_or_insert_with(rdocx_oxml::document::CT_SectPr::default_letter);
+        sect_pr.header_refs.push(HdrFtrRef {
+            hdr_ftr_type: HdrFtrType::Default,
+            rel_id: "rIdH1".to_string(),
+        });
+        sect_pr.footer_refs.push(HdrFtrRef {
+            hdr_ftr_type: HdrFtrType::Default,
+            rel_id: "rIdF1".to_string(),
+        });
+    }
+
+    /// The invariant restartable pagination must never break: a relayout on
+    /// an engine holding cached pages produces byte-for-byte what a fresh
+    /// engine computes from scratch.
+    fn assert_cached_relayout_matches_fresh(edit: impl Fn(&mut LayoutInput)) {
+        assert_cached_relayout_matches_fresh_on(many_paragraph_input(120), edit);
+    }
+
+    fn assert_cached_relayout_matches_fresh_on(
+        input: LayoutInput,
+        edit: impl Fn(&mut LayoutInput),
+    ) {
+        let mut input = input;
+        let mut engine = Engine::new_deterministic().expect("deterministic engine");
+        let first = engine.layout(&input).expect("first layout");
+        assert!(
+            first.pages.len() >= 4,
+            "test document must span several pages, got {}",
+            first.pages.len()
+        );
+        edit(&mut input);
+        let cached = engine.layout(&input).expect("cached relayout");
+        let fresh = Engine::new_deterministic()
+            .expect("deterministic engine")
+            .layout(&input)
+            .expect("fresh layout");
+        assert_eq!(cached.pages.len(), fresh.pages.len(), "page count");
+        let (a, b) = (pages_debug(&cached), pages_debug(&fresh));
+        for (i, (a, b)) in a.iter().zip(&b).enumerate() {
+            assert_eq!(a, b, "page {} differs between cached and fresh", i + 1);
+        }
+        assert_eq!(
+            format!("{:?}", cached.outlines),
+            format!("{:?}", fresh.outlines),
+            "outlines"
+        );
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_on_a_tail_edit() {
+        assert_cached_relayout_matches_fresh(|input| {
+            set_paragraph_text(input, 110, "changed near the end");
+        });
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_on_a_middle_edit() {
+        assert_cached_relayout_matches_fresh(|input| {
+            set_paragraph_text(
+                input,
+                60,
+                "changed in the middle, with enough new text that this \
+                 paragraph re-breaks into a different number of lines than \
+                 it had before the edit came in and moved everything around",
+            );
+        });
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_on_a_first_page_edit() {
+        assert_cached_relayout_matches_fresh(|input| {
+            set_paragraph_text(input, 0, "changed on page one");
+        });
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_on_insert_and_delete() {
+        assert_cached_relayout_matches_fresh(|input| {
+            let mut p = CT_P::new();
+            p.add_run("a brand new paragraph pushed into the middle");
+            input
+                .document
+                .body
+                .content
+                .insert(60, BodyContent::Paragraph(p));
+        });
+        assert_cached_relayout_matches_fresh(|input| {
+            input.document.body.content.remove(60);
+        });
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_without_any_edit() {
+        assert_cached_relayout_matches_fresh(|_| {});
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_when_a_heading_moves_pages() {
+        // Outline entries are filtered by page index during reuse; growing a
+        // paragraph right before a heading exercises that filtering.
+        assert_cached_relayout_matches_fresh(|input| {
+            set_paragraph_text(
+                input,
+                64,
+                "grown just before the heading at index 65 so the heading \
+                 slides toward the next page: the quick brown fox jumps over \
+                 the lazy dog and keeps going for a good while longer, well \
+                 past where the old paragraph used to stop, adding lines",
+            );
+        });
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_with_a_page_number_footer() {
+        // Middle edit: page numbers unchanged, so reused pages take the
+        // substituted-page shortcut — output must still be byte-identical.
+        let mut input = many_paragraph_input(120);
+        attach_page_footer(&mut input);
+        assert_cached_relayout_matches_fresh_on(input, |input| {
+            set_paragraph_text(input, 60, "changed in the middle");
+        });
+        // Insert enough text to change the page count: the substitution
+        // environment changes and every field page must be redone.
+        let mut input = many_paragraph_input(120);
+        attach_page_footer(&mut input);
+        assert_cached_relayout_matches_fresh_on(input, |input| {
+            for i in 0..6 {
+                let mut p = CT_P::new();
+                p.add_run(
+                    "a long inserted paragraph that adds real height to the \
+                     document so the total page count moves, invalidating \
+                     every page-number field after the insertion point",
+                );
+                input
+                    .document
+                    .body
+                    .content
+                    .insert(60 + i, BodyContent::Paragraph(p));
+            }
+        });
+    }
+
+    #[test]
+    fn editing_the_header_part_invalidates_cached_pages() {
+        let mut input = many_paragraph_input(120);
+        attach_page_footer(&mut input);
+        assert_cached_relayout_matches_fresh_on(input, |input| {
+            let header = input.headers.get_mut("rIdH1").expect("header part");
+            header.paragraphs[0] = {
+                let mut p = CT_P::new();
+                p.add_run("Rewritten header text");
+                p
+            };
+        });
+    }
+
+    #[test]
+    fn multi_section_documents_bypass_the_pagination_cache() {
+        let input = make_two_section_input(6 * 1440, false);
+        let mut engine = Engine::new_deterministic().expect("deterministic engine");
+        let first = engine.layout(&input).expect("first layout");
+        assert!(
+            engine.pagination_cache.is_none(),
+            "multi-section documents must not populate the pagination cache"
+        );
+        let second = engine.layout(&input).expect("second layout");
+        assert_eq!(pages_debug(&first), pages_debug(&second));
+    }
+
+    #[test]
+    fn editing_a_footnote_definition_invalidates_cached_pages() {
+        // The paragraph fingerprints do not change when only the footnote
+        // part changes, so this relies entirely on the environment
+        // fingerprint.
+        let mut input = make_input_with_footnote(&["original note text"]);
+        let mut engine = Engine::new_deterministic().expect("deterministic engine");
+        engine.layout(&input).expect("first layout");
+        let replacement = make_input_with_footnote(&["rewritten note text"]);
+        input.footnotes = replacement.footnotes.clone();
+        let cached = engine.layout(&input).expect("cached relayout");
+        let fresh = Engine::new_deterministic()
+            .expect("deterministic engine")
+            .layout(&input)
+            .expect("fresh layout");
+        assert_eq!(pages_debug(&cached), pages_debug(&fresh));
+    }
+
+    #[test]
+    fn cached_repagination_matches_fresh_with_provenance() {
+        let mut input = many_paragraph_input(120);
+        let mut engine = Engine::new_deterministic().expect("deterministic engine");
+        engine.layout_with_provenance(&input).expect("first layout");
+        set_paragraph_text(&mut input, 60, "changed in the middle");
+        let (cached, cached_nodes) = engine
+            .layout_with_provenance(&input)
+            .expect("cached relayout");
+        let (fresh, fresh_nodes) = Engine::new_deterministic()
+            .expect("deterministic engine")
+            .layout_with_provenance(&input)
+            .expect("fresh layout");
+        assert_eq!(pages_debug(&cached), pages_debug(&fresh));
+        assert_eq!(format!("{cached_nodes:?}"), format!("{fresh_nodes:?}"));
+    }
+
+    #[test]
+    fn provenance_stays_correct_when_the_paragraph_count_changes() {
+        // Inserting a paragraph shifts every later source id; the source-node
+        // fold must refuse page reuse so no stale span survives.
+        let mut input = many_paragraph_input(120);
+        let mut engine = Engine::new_deterministic().expect("deterministic engine");
+        engine.layout_with_provenance(&input).expect("first layout");
+        let mut p = CT_P::new();
+        p.add_run("a brand new paragraph pushed into the middle");
+        input
+            .document
+            .body
+            .content
+            .insert(60, BodyContent::Paragraph(p));
+        let (cached, cached_nodes) = engine
+            .layout_with_provenance(&input)
+            .expect("cached relayout");
+        let (fresh, fresh_nodes) = Engine::new_deterministic()
+            .expect("deterministic engine")
+            .layout_with_provenance(&input)
+            .expect("fresh layout");
+        assert_eq!(pages_debug(&cached), pages_debug(&fresh));
+        assert_eq!(format!("{cached_nodes:?}"), format!("{fresh_nodes:?}"));
+    }
+
+    #[test]
+    fn changing_a_style_definition_invalidates_cached_pages() {
+        // The F-X040 requirement: style/numbering/theme definitions join the
+        // reuse boundary. A doc-defaults size change must not serve pages
+        // laid out under the old definitions.
+        let mut input = many_paragraph_input(120);
+        let mut engine = Engine::new_deterministic().expect("deterministic engine");
+        engine.layout(&input).expect("first layout");
+        input.styles.doc_defaults = Some(rdocx_oxml::styles::CT_DocDefaults {
+            rpr: Some(rdocx_oxml::CT_RPr {
+                sz: Some(rdocx_oxml::HalfPoint(32)),
+                ..Default::default()
+            }),
+            ppr: None,
+        });
+        let cached = engine.layout(&input).expect("cached relayout");
+        let fresh = Engine::new_deterministic()
+            .expect("deterministic engine")
+            .layout(&input)
+            .expect("fresh layout");
+        assert_eq!(pages_debug(&cached), pages_debug(&fresh));
+    }
 
     #[test]
     fn revision_views_project_wrapped_runs_in_document_order() {
@@ -6884,4 +7462,268 @@ mod tests {
         assert!(text.iter().any(|value| value == "2"), "{text:?}");
         assert!(!text.iter().any(|value| value == "cached"), "{text:?}");
     }
+}
+
+fn fingerprint_paragraph(
+    para: &rdocx_oxml::text::CT_P,
+    content_width: f64,
+    revision_view: u8,
+) -> u64 {
+    let mut fp = Fingerprint::new();
+    fp.eat_paragraph(para);
+    fp.eat(&content_width.to_bits().to_le_bytes());
+    fp.eat(&[revision_view]);
+    fp.finish()
+}
+
+/// FNV-1a folding with a scratch buffer for the `Debug`-formatted pieces, so
+/// every fingerprint walker shares one hashing discipline.
+struct Fingerprint {
+    h: u64,
+    buf: String,
+}
+
+impl Fingerprint {
+    fn new() -> Self {
+        Fingerprint {
+            h: 0xcbf2_9ce4_8422_2325,
+            buf: String::new(),
+        }
+    }
+
+    fn eat(&mut self, bytes: &[u8]) {
+        for b in bytes {
+            self.h ^= u64::from(*b);
+            self.h = self.h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    fn eat_debug<T: std::fmt::Debug>(&mut self, value: &T) {
+        use std::fmt::Write as _;
+        let mut buf = std::mem::take(&mut self.buf);
+        buf.clear();
+        let _ = write!(buf, "{value:?}");
+        self.eat(buf.as_bytes());
+        self.buf = buf;
+    }
+
+    /// The paragraph walk shared by the block cache and the table
+    /// fingerprint: run text as raw bytes (the hot path), the small or
+    /// usually-empty property/projection structures via `Debug`.
+    fn eat_paragraph(&mut self, para: &rdocx_oxml::text::CT_P) {
+        use rdocx_oxml::text::RunContent;
+
+        self.eat_debug(&para.properties);
+        for run in &para.runs {
+            self.eat(b"\x01r");
+            self.eat_debug(&run.properties);
+            for content in &run.content {
+                match content {
+                    RunContent::Text(t) => {
+                        self.eat(b"\x02t");
+                        self.eat(t.text.as_bytes());
+                        self.eat(&[u8::from(t.preserve_space)]);
+                    }
+                    // A field's Debug form includes a per-parse source_id
+                    // (a global counter), so hashing it wholesale would give
+                    // the same XML a different fingerprint on every
+                    // build_input. Hash what layout actually reads instead.
+                    RunContent::Field(field) => {
+                        self.eat(b"\x02f");
+                        self.eat(field.instruction.raw.as_bytes());
+                        self.eat(field.cached_result.as_bytes());
+                        self.eat_debug(&field.dirty);
+                    }
+                    other => {
+                        self.eat(b"\x02o");
+                        self.eat_debug(other);
+                    }
+                }
+            }
+        }
+        if !(para.hyperlinks.is_empty()
+            && para.comment_ranges.is_empty()
+            && para.bookmark_markers.is_empty()
+            && para.extra_xml.is_empty()
+            && para.content_controls.is_empty()
+            && para.revisions.is_empty())
+        {
+            self.eat_debug(&para.hyperlinks);
+            self.eat_debug(&para.comment_ranges);
+            self.eat_debug(&para.bookmark_markers);
+            self.eat_debug(&para.extra_xml);
+            self.eat_debug(&para.content_controls);
+            self.eat_debug(&para.revisions);
+        }
+    }
+
+    /// A header/footer part, walked so fields inside it hash by content
+    /// (see the `RunContent::Field` arm of `eat_paragraph`).
+    fn eat_hdr_ftr(&mut self, part: &rdocx_oxml::header_footer::CT_HdrFtr) {
+        for para in &part.paragraphs {
+            self.eat(b"\x01P");
+            self.eat_paragraph(para);
+        }
+        if !(part.extra_namespaces.is_empty() && part.extra_xml.is_empty()) {
+            self.eat_debug(&part.extra_namespaces);
+            self.eat_debug(&part.extra_xml);
+        }
+    }
+
+    /// A footnotes/endnotes part, walked for the same reason.
+    fn eat_notes(&mut self, part: &Option<rdocx_oxml::footnotes::CT_Footnotes>) {
+        let Some(part) = part else {
+            self.eat(b"\x01-");
+            return;
+        };
+        for note in &part.footnotes {
+            self.eat(b"\x01N");
+            self.eat_debug(&note.id);
+            self.eat_debug(&note.note_type);
+            for para in &note.paragraphs {
+                self.eat_paragraph(para);
+            }
+        }
+    }
+
+    fn finish(&self) -> u64 {
+        self.h
+    }
+}
+
+/// Content fingerprint of a table for pagination identity, walking rows,
+/// cells and cell paragraphs the same way `fingerprint_paragraph` walks a
+/// body paragraph. Nested tables and content controls are rare enough to go
+/// through `Debug` wholesale.
+fn fingerprint_table(
+    tbl: &rdocx_oxml::table::CT_Tbl,
+    content_width: f64,
+    revision_view: u8,
+) -> u64 {
+    use rdocx_oxml::table::CellContent;
+
+    let mut fp = Fingerprint::new();
+    fp.eat_debug(&tbl.properties);
+    fp.eat_debug(&tbl.grid);
+    if !(tbl.extra_xml.is_empty() && tbl.content_controls.is_empty()) {
+        fp.eat_debug(&tbl.extra_xml);
+        fp.eat_debug(&tbl.content_controls);
+    }
+    for row in &tbl.rows {
+        fp.eat(b"\x01R");
+        fp.eat_debug(&row.properties);
+        if !(row.extra_xml.is_empty() && row.content_controls.is_empty()) {
+            fp.eat_debug(&row.extra_xml);
+            fp.eat_debug(&row.content_controls);
+        }
+        for cell in &row.cells {
+            fp.eat(b"\x02C");
+            fp.eat_debug(&cell.properties);
+            if !cell.extra_xml.is_empty() {
+                fp.eat_debug(&cell.extra_xml);
+            }
+            for content in &cell.content {
+                match content {
+                    CellContent::Paragraph(p) => {
+                        fp.eat(b"\x03p");
+                        fp.eat_paragraph(p);
+                    }
+                    other => {
+                        fp.eat(b"\x03x");
+                        fp.eat_debug(other);
+                    }
+                }
+            }
+        }
+    }
+    fp.eat(&content_width.to_bits().to_le_bytes());
+    fp.eat(&[revision_view]);
+    fp.finish()
+}
+
+/// Whether any of these paragraph blocks renders a numbering marker or a
+/// note reference — the cross-block state that makes a block unsafe to
+/// cache (a cache hit would skip the NumberingState / note-order advance
+/// that produced the marker text).
+fn para_blocks_render_shared_state(blocks: &[ParagraphBlock]) -> bool {
+    use oxml_layout::LineItem;
+    blocks.iter().any(|para| {
+        para.lines.iter().any(|line| {
+            line.items.iter().any(|item| match item {
+                LineItem::Marker(_) => true,
+                LineItem::Text(seg) => seg.note.is_some(),
+                _ => false,
+            })
+        })
+    })
+}
+
+/// Whether any cell paragraph renders a numbering marker or a note
+/// reference — the cross-block state that makes a table unsafe to cache.
+fn table_renders_shared_state(table: &crate::table::TableBlock) -> bool {
+    table.rows.iter().any(|row| {
+        row.cells
+            .iter()
+            .any(|cell| para_blocks_render_shared_state(&cell.paragraphs))
+    })
+}
+
+/// One pagination-identity value from a block's source fingerprint and its
+/// rendered-marker salt.
+fn combine_fp(source: u64, salt: u64) -> u64 {
+    source.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ salt
+}
+
+/// What a block renders from cross-block state that its source fingerprint
+/// cannot see: list numbering markers (NumberingState) and note reference
+/// markers (note numbering). Folding the rendered text of both into the
+/// pagination fingerprint makes "same fingerprint" mean "paginates AND
+/// renders identically", so inserting a numbered paragraph or a footnote
+/// reference invalidates every block whose marker text shifts.
+fn pagination_salt(block: &LayoutBlock) -> u64 {
+    use oxml_layout::LineItem;
+
+    fn eat_lines(fp: &mut Fingerprint, lines: &[oxml_layout::LayoutLine]) {
+        for line in lines {
+            for item in &line.items {
+                match item {
+                    LineItem::Marker(seg) => {
+                        fp.eat(b"\x01m");
+                        fp.eat(seg.text.as_bytes());
+                    }
+                    LineItem::Text(seg) if seg.note.is_some() => {
+                        fp.eat(b"\x01n");
+                        fp.eat(seg.text.as_bytes());
+                        fp.eat_debug(&seg.note);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let mut fp = Fingerprint::new();
+    match block {
+        LayoutBlock::Paragraph(para) => eat_lines(&mut fp, &para.lines),
+        LayoutBlock::Table(table) => {
+            for row in &table.rows {
+                for cell in &row.cells {
+                    for para in &cell.paragraphs {
+                        eat_lines(&mut fp, &para.lines);
+                    }
+                }
+            }
+        }
+    }
+    fp.finish()
+}
+
+/// Fold the result-local source-node table: reused pages carry baked
+/// `SourceSpan`s, which stay valid only while ids and paths are unchanged.
+fn fingerprint_source_nodes(nodes: &[WordSourcePath]) -> u64 {
+    let mut fp = Fingerprint::new();
+    for node in nodes {
+        fp.eat_debug(node);
+    }
+    fp.finish()
 }

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -462,6 +462,8 @@ struct ParagraphCacheKey {
 }
 
 struct ParagraphCacheEntry {
+    /// Collision-tolerant prefilter for lookups; `key` stays the authority.
+    fp: u64,
     key: ParagraphCacheKey,
     block: ParagraphBlock,
     diagnostics: Vec<Diagnostic>,
@@ -469,8 +471,25 @@ struct ParagraphCacheEntry {
     bytes: usize,
 }
 
-const PARAGRAPH_CACHE_MAX_ENTRIES: usize = 256;
-const PARAGRAPH_CACHE_MAX_BYTES: usize = 16 * 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+thread_local! {
+    /// RDOCX_TIMING profiling: per-layout accumulated sub-phase costs of the
+    /// block-building walk, in ms. Slots: 0 safe-check, 1 fingerprint,
+    /// 2 cache scan, 3 hit path (clone+rebind+replay), 4 miss layout,
+    /// 5 staging, 6 tables, 7 headers/footers.
+    static BLOCK_TIMERS: std::cell::RefCell<[f64; 8]> =
+        const { std::cell::RefCell::new([0.0; 8]) };
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn timer_add(slot: usize, since: std::time::Instant) {
+    BLOCK_TIMERS.with(|cell| {
+        cell.borrow_mut()[slot] += since.elapsed().as_secs_f64() * 1000.0;
+    });
+}
+
+const PARAGRAPH_CACHE_MAX_ENTRIES: usize = 4096;
+const PARAGRAPH_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
 const CACHE_SOURCE_NODE: SourceNodeId = match SourceNodeId::new(1) {
     Some(node) => node,
     None => panic!("one is a valid source node id"),
@@ -646,6 +665,10 @@ impl Engine {
         let source_fold = sources.map_or(0, |s| fingerprint_source_nodes(&s.nodes));
         let mut current_sect_pr: Option<CT_SectPr> = None; // Will be set from paragraph sect_pr
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let t_blocks = std::time::Instant::now();
+        #[cfg(not(target_arch = "wasm32"))]
+        BLOCK_TIMERS.with(|cell| *cell.borrow_mut() = [0.0; 8]);
         for (body_index, content) in input.document.body.content.iter().enumerate() {
             match content {
                 BodyContent::Paragraph(para) => {
@@ -721,6 +744,8 @@ impl Engine {
                     let sect_pr_for_layout = current_sect_pr.as_ref().unwrap_or(&final_sect_pr);
                     let geometry = sect_pr_to_geometry(sect_pr_for_layout);
 
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let t_table = std::time::Instant::now();
                     let table_src_fp =
                         fingerprint_table(tbl, geometry.content_width(), input.revision_view as u8);
                     let table_key = {
@@ -775,6 +800,8 @@ impl Engine {
                     let block = LayoutBlock::Table(table_block);
                     block_fps.push(combine_fp(table_src_fp, pagination_salt(&block)));
                     current_blocks.push(block);
+                    #[cfg(not(target_arch = "wasm32"))]
+                    timer_add(6, t_table);
                 }
                 _ => {} // Skip RawXml elements during layout
             }
@@ -782,6 +809,8 @@ impl Engine {
 
         // Remaining blocks belong to the final section
         let final_geometry = sect_pr_to_geometry(&final_sect_pr);
+        #[cfg(not(target_arch = "wasm32"))]
+        let t_hf = std::time::Instant::now();
         let final_hf = self.layout_header_footer_cached(
             &final_sect_pr,
             input,
@@ -792,6 +821,8 @@ impl Engine {
             sources,
             source_fold,
         )?;
+        #[cfg(not(target_arch = "wasm32"))]
+        timer_add(7, t_hf);
         let final_title_pg = final_sect_pr.title_pg.unwrap_or(false);
         sections.push(paginator::Section {
             blocks: current_blocks,
@@ -807,6 +838,10 @@ impl Engine {
         // width is registered. The endnote pages that follow the last body page
         // are drawn against `final_geometry`, which belongs to the section
         // pushed just above and is therefore already in this list.
+        #[cfg(not(target_arch = "wasm32"))]
+        let blocks_ms = t_blocks.elapsed().as_secs_f64() * 1000.0;
+        #[cfg(not(target_arch = "wasm32"))]
+        let t_notes = std::time::Instant::now();
         let content_widths: Vec<f64> = sections
             .iter()
             .map(|section| section.geometry.content_width())
@@ -852,6 +887,10 @@ impl Engine {
             fp.eat(&source_fold.to_le_bytes());
             fp.finish()
         };
+        #[cfg(not(target_arch = "wasm32"))]
+        let notes_ms = t_notes.elapsed().as_secs_f64() * 1000.0;
+        #[cfg(not(target_arch = "wasm32"))]
+        let t_pag = std::time::Instant::now();
         let (mut pages, outlines) = paginator::paginate_sections_cached(
             &sections,
             &self.font_manager,
@@ -933,6 +972,20 @@ impl Engine {
 
         // Remap persistent manager ids to result-local ids and omit faces that
         // are no longer present in the current layout.
+        #[cfg(not(target_arch = "wasm32"))]
+        if std::env::var("RDOCX_TIMING").is_ok() {
+            eprintln!(
+                "timing: blocks {blocks_ms:.0} ms, notes {notes_ms:.0} ms, paginate+post {:.0} ms",
+                t_pag.elapsed().as_secs_f64() * 1000.0
+            );
+            BLOCK_TIMERS.with(|cell| {
+                let t = cell.borrow();
+                eprintln!(
+                    "timing: blocks split - safe {:.1}, fp {:.1}, scan {:.1}, hit {:.1}, miss {:.1}, stage {:.1}, tables {:.1}, hf {:.1}",
+                    t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]
+                );
+            });
+        }
         let fonts = if self.font_manager.every_loaded_font_is_current() {
             self.font_manager.all_font_data()
         } else {
@@ -966,7 +1019,12 @@ impl Engine {
         diagnostics: &mut Vec<Diagnostic>,
         source_node: Option<SourceNodeId>,
     ) -> Result<ParagraphBlock> {
-        if !paragraph_is_cache_safe(paragraph, styles) {
+        #[cfg(not(target_arch = "wasm32"))]
+        let t = std::time::Instant::now();
+        let cache_safe = paragraph_is_cache_safe(paragraph, styles);
+        #[cfg(not(target_arch = "wasm32"))]
+        timer_add(0, t);
+        if !cache_safe {
             return layout_paragraph_with_source(
                 paragraph,
                 content_width,
@@ -980,32 +1038,51 @@ impl Engine {
             );
         }
 
-        let key = ParagraphCacheKey {
-            paragraph: paragraph.clone(),
-            content_width_bits: content_width.to_bits(),
-            revision_view: input.revision_view,
+        // A cheap fingerprint prefilters the scan; the typed key equality
+        // below stays the authority, so a hash collision cannot alias two
+        // different paragraphs. This also keeps the hot lookup path free of
+        // the CT_P clone the key used to need.
+        #[cfg(not(target_arch = "wasm32"))]
+        let t = std::time::Instant::now();
+        let fp = fingerprint_paragraph(paragraph, content_width, input.revision_view as u8);
+        #[cfg(not(target_arch = "wasm32"))]
+        timer_add(1, t);
+        #[cfg(not(target_arch = "wasm32"))]
+        let t = std::time::Instant::now();
+        let found = if self.paragraph_cache_reads_enabled {
+            self.paragraph_cache.iter().position(|entry| {
+                entry.fp == fp
+                    && entry.key.content_width_bits == content_width.to_bits()
+                    && entry.key.revision_view == input.revision_view
+                    && entry.key.paragraph == *paragraph
+            })
+        } else {
+            None
         };
-        if self.paragraph_cache_reads_enabled
-            && let Some(index) = self
-                .paragraph_cache
-                .iter()
-                .position(|entry| entry.key == key)
-        {
-            let entry = self
-                .paragraph_cache
-                .remove(index)
-                .expect("paragraph cache index exists");
+        #[cfg(not(target_arch = "wasm32"))]
+        timer_add(2, t);
+        if let Some(index) = found {
+            #[cfg(not(target_arch = "wasm32"))]
+            let t = std::time::Instant::now();
+            let entry = &self.paragraph_cache[index];
             let mut block = entry.block.clone();
-            rebind_paragraph_source(&mut block, source_node);
             diagnostics.extend(entry.diagnostics.iter().cloned());
-            self.font_manager
-                .replay_layout_font_trace(&entry.font_trace);
-            self.paragraph_cache.push_back(entry);
+            let font_trace = entry.font_trace.clone();
+            rebind_paragraph_source(&mut block, source_node);
+            self.font_manager.replay_layout_font_trace(&font_trace);
+            // No LRU refresh: VecDeque::remove is O(len) and a 700-paragraph
+            // document pays it per paragraph per relayout. Eviction order
+            // degrades to insertion order, which only matters once the cache
+            // is actually full.
             self.paragraph_cache_hits += 1;
+            #[cfg(not(target_arch = "wasm32"))]
+            timer_add(3, t);
             return Ok(block);
         }
 
         let diagnostics_start = diagnostics.len();
+        #[cfg(not(target_arch = "wasm32"))]
+        let t = std::time::Instant::now();
         self.font_manager.begin_paragraph_font_trace();
         let block_result = layout_paragraph_with_source(
             paragraph,
@@ -1019,11 +1096,20 @@ impl Engine {
             Some(CACHE_SOURCE_NODE),
         );
         let font_trace = self.font_manager.finish_paragraph_font_trace();
+        #[cfg(not(target_arch = "wasm32"))]
+        timer_add(4, t);
         let mut block = block_result?;
         self.paragraph_cache_builds += 1;
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let t = std::time::Instant::now();
         let cached_diagnostics = diagnostics[diagnostics_start..].to_vec();
         if let Some(font_trace) = font_trace {
+            let key = ParagraphCacheKey {
+                paragraph: paragraph.clone(),
+                content_width_bits: content_width.to_bits(),
+                revision_view: input.revision_view,
+            };
             let bytes = paragraph_cache_entry_bytes(
                 &key.paragraph,
                 &block,
@@ -1031,6 +1117,7 @@ impl Engine {
                 font_trace.len(),
             );
             self.stage_paragraph_cache_entry(ParagraphCacheEntry {
+                fp,
                 key,
                 block: block.clone(),
                 diagnostics: cached_diagnostics,
@@ -1039,6 +1126,8 @@ impl Engine {
             });
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        timer_add(5, t);
         rebind_paragraph_source(&mut block, source_node);
         Ok(block)
     }
@@ -4546,9 +4635,13 @@ mod tests {
         engine
             .layout(&input)
             .expect("transactional layout succeeds");
-        assert_eq!(
-            engine.pending_paragraph_cache_peak_entries,
-            PARAGRAPH_CACHE_MAX_ENTRIES
+        // With the larger entry cap the byte ceiling can bind first; either
+        // way staging must stay bounded well below the paragraph count.
+        assert!(engine.pending_paragraph_cache_peak_entries <= PARAGRAPH_CACHE_MAX_ENTRIES);
+        assert!(
+            engine.pending_paragraph_cache_peak_entries < PARAGRAPH_CACHE_MAX_ENTRIES * 2,
+            "staging must evict, got {}",
+            engine.pending_paragraph_cache_peak_entries
         );
         assert!(engine.pending_paragraph_cache_peak_bytes <= PARAGRAPH_CACHE_MAX_BYTES);
     }
@@ -4584,6 +4677,7 @@ mod tests {
         engine.paragraph_cache.clear();
         engine.paragraph_cache_bytes = 0;
         engine.publish_paragraph_cache_entry(ParagraphCacheEntry {
+            fp: 0,
             key: ParagraphCacheKey {
                 paragraph: paragraph.clone(),
                 content_width_bits: PageGeometry::default().content_width().to_bits(),
@@ -4685,6 +4779,7 @@ mod tests {
         engine.paragraph_cache.clear();
         engine.paragraph_cache_bytes = 0;
         engine.publish_paragraph_cache_entry(ParagraphCacheEntry {
+            fp: 0,
             key: ParagraphCacheKey {
                 paragraph,
                 content_width_bits: PageGeometry::default().content_width().to_bits(),

--- a/crates/rdocx-layout/src/lib.rs
+++ b/crates/rdocx-layout/src/lib.rs
@@ -109,6 +109,17 @@ pub fn layout_document_with_fallback_fonts_and_provenance(
     input: &LayoutInput,
 ) -> Result<WordLayoutResult> {
     let mut engine = engine::Engine::new_deterministic()?;
+    layout_document_with_fallback_fonts_engine(&mut engine, input)
+}
+
+/// SVG PoC patch: the reusable-engine form of
+/// [`layout_document_with_fallback_fonts_and_provenance`], so an editor can
+/// keep the engine's relayout caches warm across edits (mirrors the hidden
+/// `layout_document_with_reusable_engine` facade).
+pub fn layout_document_with_fallback_fonts_engine(
+    engine: &mut engine::Engine,
+    input: &LayoutInput,
+) -> Result<WordLayoutResult> {
     let (layout, source_nodes) = engine.layout_with_provenance(input)?;
     Ok(WordLayoutResult {
         layout,

--- a/crates/rdocx-layout/src/lib.rs
+++ b/crates/rdocx-layout/src/lib.rs
@@ -100,7 +100,6 @@ pub fn layout_document_with_caller_fonts_and_provenance(
     })
 }
 
-
 /// SVG PoC patch: lay out with caller fonts on top of the bundled
 /// metric-compatible set — for wasm editors that inject one or two fonts
 /// and still need Calibri/Times to resolve. A separate entry point so the

--- a/crates/rdocx-layout/src/lib.rs
+++ b/crates/rdocx-layout/src/lib.rs
@@ -100,6 +100,24 @@ pub fn layout_document_with_caller_fonts_and_provenance(
     })
 }
 
+
+/// SVG PoC patch: lay out with caller fonts on top of the bundled
+/// metric-compatible set — for wasm editors that inject one or two fonts
+/// and still need Calibri/Times to resolve. A separate entry point so the
+/// strict caller-fonts isolation of
+/// [`layout_document_with_caller_fonts_and_provenance`] stays intact.
+pub fn layout_document_with_fallback_fonts_and_provenance(
+    input: &LayoutInput,
+) -> Result<WordLayoutResult> {
+    let mut engine = engine::Engine::new_deterministic()?;
+    let (layout, source_nodes) = engine.layout_with_provenance(input)?;
+    Ok(WordLayoutResult {
+        layout,
+        revision_view: input.revision_view,
+        source_nodes,
+    })
+}
+
 /// Lay out a DOCX using bundled fonts without system font discovery.
 pub fn layout_document_deterministic(input: &LayoutInput) -> Result<LayoutResult> {
     engine::Engine::new_deterministic()?.layout(input)

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -5,6 +5,7 @@
 
 use crate::block::{AnchoredContent, AnchoredDrawing, LayoutBlock, ParagraphBlock, ShapePreset};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use oxml_layout::{
     Align, Color, FontManager, GlyphRun, LayoutLine, LineItem, MediaId, NoteRef, NoteStream,
@@ -127,11 +128,11 @@ pub fn paginate_sections(
     fm: &FontManager,
     media: &MediaRegistry,
     notes: &NoteRegistry,
-) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
     let media = media.media();
     if sections.is_empty() {
         return (
-            vec![PageFrame::new(1, 612.0, 792.0, Vec::new())],
+            vec![Arc::new(PageFrame::new(1, 612.0, 792.0, Vec::new()))],
             Vec::new(),
         );
     }
@@ -183,7 +184,7 @@ pub fn paginate_sections(
     // If a section produced no pages (empty blocks), we might have duplicates
     // Renumber pages sequentially
     for (i, page) in all_pages.iter_mut().enumerate() {
-        page.page_number = i + 1;
+        Arc::make_mut(page).page_number = i + 1;
     }
 
     (all_pages, all_outlines)
@@ -198,7 +199,7 @@ pub fn paginate(
     _fm: &FontManager,
     media: &MediaRegistry,
     notes: &NoteRegistry,
-) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
     paginate_with_media(
         blocks,
         geometry,
@@ -251,7 +252,7 @@ fn paginate_with_media(
     notes: &NoteRegistry,
     first_page_number: usize,
     first_header_page_number: usize,
-) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
     let context = PassContext {
         geometry,
         header_footer,
@@ -283,7 +284,7 @@ fn paginate_with_media(
 
 /// One pagination pass, and what it learned about paragraph-relative wraps.
 struct PassResult {
-    pages: Vec<PageFrame>,
+    pages: Vec<Arc<PageFrame>>,
     outlines: Vec<OutlineEntry>,
     resolved: ResolvedWraps,
 }
@@ -399,7 +400,7 @@ fn paginate_pass(
 
 /// Helper struct to track page state during pagination.
 struct Pager<'a> {
-    pages: Vec<PageFrame>,
+    pages: Vec<Arc<PageFrame>>,
     elements: Vec<PositionedElement>,
     /// Anchored drawings marked behindDoc. Held apart from the normal element
     /// list so they can be emitted before everything else on the page, which
@@ -987,12 +988,12 @@ impl<'a> Pager<'a> {
             }
         }
 
-        self.pages.push(PageFrame::new(
+        self.pages.push(Arc::new(PageFrame::new(
             self.page_number,
             self.geometry.page_width,
             self.geometry.page_height,
             all_elements,
-        ));
+        )));
         self.page_number += 1;
         self.header_page_number += 1;
         self.cursor_y = 0.0;
@@ -1002,7 +1003,7 @@ impl<'a> Pager<'a> {
         self.is_first_page = false;
     }
 
-    fn flush(mut self) -> (Vec<PageFrame>, Vec<OutlineEntry>) {
+    fn flush(mut self) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
         // Always create at least one page
         if self.has_content() || self.pages.is_empty() {
             self.finish_page();
@@ -1209,7 +1210,7 @@ fn draw_note(
 /// the top of a fresh page and carry no separator rule. There is no body text
 /// on these pages for a rule to divide them from.
 pub fn append_endnote_pages(
-    pages: &mut Vec<PageFrame>,
+    pages: &mut Vec<Arc<PageFrame>>,
     notes: &NoteRegistry,
     geometry: PageGeometry,
 ) {
@@ -1239,12 +1240,12 @@ pub fn append_endnote_pages(
     let mut page_number = pages.len() + 1;
 
     let mut flush = |elements: &mut Vec<PositionedElement>, page_number: &mut usize| {
-        pages.push(PageFrame::new(
+        pages.push(Arc::new(PageFrame::new(
             *page_number,
             geometry.page_width,
             geometry.page_height,
             std::mem::take(elements),
-        ));
+        )));
         *page_number += 1;
     };
 

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -90,6 +90,7 @@ impl Default for PageGeometry {
 }
 
 /// Header/footer content already laid out as paragraph blocks.
+#[derive(Clone)]
 pub struct HeaderFooterContent {
     pub header_blocks: Vec<ParagraphBlock>,
     pub footer_blocks: Vec<ParagraphBlock>,
@@ -190,6 +191,269 @@ pub fn paginate_sections(
     (all_pages, all_outlines)
 }
 
+/// A page boundary a later run can resume from: block `block_idx` opened a
+/// fresh page after `pages_done` finished pages, and the pager carried no
+/// state across the boundary (no split paragraph, no footnote continuation,
+/// no floats). At such a point the whole pager state is those two numbers
+/// (page and header numbers derive from `pages_done` plus the section's
+/// starting numbers).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Checkpoint {
+    block_idx: usize,
+    pages_done: usize,
+}
+
+/// Lookup for stopping a resumed pass early. Boundaries are keyed by how many
+/// blocks REMAIN after them (an end offset survives insertions and deletions
+/// earlier in the document, a block index does not); the value is how many
+/// pages the previous run had finished at that boundary. A resumed pass that
+/// reaches a clean page start whose end offset lies inside the unchanged tail
+/// and whose page count matches can adopt the old pages from there on.
+struct SpliceMap {
+    total_blocks: usize,
+    /// Blocks from `total_blocks - max_suffix` on are identical to the old run.
+    max_suffix: usize,
+    by_end_offset: HashMap<usize, usize>,
+}
+
+/// The previous relayout's pagination of a single-section document, pristine:
+/// pages here predate endnote append, field substitution, page background and
+/// font canonicalization, so the engine's post-passes treat reused pages
+/// exactly like fresh ones.
+///
+/// Owned by whoever calls [`paginate_sections_cached`] across relayouts
+/// (in practice the layout engine).
+pub struct PaginationCache {
+    /// Everything outside the block stream that pagination reads — geometry,
+    /// header/footer content, notes, fonts, revision view, styles/numbering/
+    /// theme context, and the document's source-node table (reused pages
+    /// carry baked `SourceSpan`s). Any change invalidates the whole cache.
+    env_fp: u64,
+    /// One fingerprint per block; equality means "paginates identically".
+    block_fps: Vec<u64>,
+    pages: Vec<Arc<PageFrame>>,
+    outlines: Vec<OutlineEntry>,
+    checkpoints: Vec<Checkpoint>,
+}
+
+/// [`paginate_sections`] with page reuse across relayouts.
+///
+/// On a cache hit only the pages around the first changed block are rebuilt:
+/// pages before the last checkpoint preceding the change are taken from the
+/// cache, and when the document's tail is unchanged and lands on the same
+/// page number as before, the old tail pages are spliced back in — a typing
+/// edit inside one paragraph repaginates one or two pages instead of all.
+///
+/// Reuse is refused (falling back to a full run, clearing the cache) whenever
+/// it could change output: multiple sections (their pagination renumbers
+/// pages globally), any floating drawing (the look-ahead lets a later block
+/// place a drawing on an earlier page, and paragraph-relative wraps need two
+/// passes), a changed environment, or no usable checkpoint. `block_fps` is
+/// one fingerprint per block of the single section; pass `None` when the
+/// caller cannot vouch for the blocks and a plain full run is wanted.
+pub fn paginate_sections_cached(
+    sections: &[Section],
+    fm: &FontManager,
+    media: &MediaRegistry,
+    notes: &NoteRegistry,
+    block_fps: Option<&[u64]>,
+    env_fp: u64,
+    cache: &mut Option<PaginationCache>,
+) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
+    let cacheable = sections.len() == 1
+        && block_fps.is_some_and(|fps| fps.len() == sections[0].blocks.len())
+        && !sections[0].blocks.iter().any(|block| match block {
+            LayoutBlock::Paragraph(para) => !para.anchored.is_empty(),
+            LayoutBlock::Table(_) => false,
+        });
+    if !cacheable {
+        *cache = None;
+        return paginate_sections(sections, fm, media, notes);
+    }
+    let section = &sections[0];
+    let fps = block_fps.expect("checked by cacheable");
+    let context = PassContext {
+        geometry: section.geometry,
+        header_footer: section.header_footer.as_ref(),
+        title_pg: section.title_pg,
+        fm,
+        media: media.media(),
+        notes,
+        first_page_number: 1,
+        first_header_page_number: section.page_number_start.unwrap_or(1),
+    };
+
+    // No floating drawings (checked above) means the single pass is exact,
+    // so the two-pass logic of `paginate_with_media` is not needed here.
+    let full = |cache: &mut Option<PaginationCache>| {
+        let result =
+            paginate_pass_resumable(&section.blocks, &context, &ResolvedWraps::new(), 0, 0, None);
+        let built = PaginationCache {
+            env_fp,
+            block_fps: fps.to_vec(),
+            pages: result.pages,
+            outlines: result.outlines,
+            checkpoints: result.checkpoints,
+        };
+        let out = (built.pages.clone(), built.outlines.clone());
+        *cache = Some(built);
+        out
+    };
+
+    let old = match cache.take() {
+        Some(c) if c.env_fp == env_fp => c,
+        other => {
+            #[cfg(not(target_arch = "wasm32"))]
+            if std::env::var("RDOCX_TIMING").is_ok() {
+                eprintln!(
+                    "timing: pagination cache miss ({})",
+                    if other.is_none() {
+                        "cold"
+                    } else {
+                        "env changed"
+                    }
+                );
+            }
+            let _ = other;
+            return full(cache);
+        }
+    };
+
+    let new_len = fps.len();
+    let old_len = old.block_fps.len();
+    let prefix = fps
+        .iter()
+        .zip(&old.block_fps)
+        .take_while(|(a, b)| a == b)
+        .count();
+    if prefix == new_len && prefix == old_len {
+        let out = (old.pages.clone(), old.outlines.clone());
+        *cache = Some(old);
+        return out;
+    }
+    // Longest identical tail, clamped so it cannot reach into the changed
+    // region on either side.
+    let max_suffix = fps
+        .iter()
+        .rev()
+        .zip(old.block_fps.iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count()
+        .min(new_len - prefix)
+        .min(old_len - prefix);
+
+    // Resume from the last boundary strictly before the first changed block:
+    // the page before a boundary was decided with a one-block look-ahead
+    // (keep-with-next peeks the boundary block's first line), so the
+    // boundary block itself must be unchanged too.
+    let Some(resume) = old
+        .checkpoints
+        .iter()
+        .rev()
+        .copied()
+        .find(|c| c.block_idx < prefix && c.pages_done > 0)
+    else {
+        #[cfg(not(target_arch = "wasm32"))]
+        if std::env::var("RDOCX_TIMING").is_ok() {
+            eprintln!(
+                "timing: pagination cache unusable (change at block {prefix}, no earlier checkpoint)"
+            );
+        }
+        return full(cache);
+    };
+
+    let splice_map = SpliceMap {
+        total_blocks: new_len,
+        max_suffix,
+        by_end_offset: old
+            .checkpoints
+            .iter()
+            .filter(|c| c.block_idx + max_suffix >= old_len && c.pages_done > 0)
+            .map(|c| (old_len - c.block_idx, c.pages_done))
+            .collect(),
+    };
+    let mid = paginate_pass_resumable(
+        &section.blocks,
+        &context,
+        &ResolvedWraps::new(),
+        resume.block_idx,
+        resume.pages_done,
+        Some(&splice_map),
+    );
+
+    // Reassemble, moving the reused old pages rather than cloning them.
+    let mut pages = old.pages;
+    let old_outlines = old.outlines;
+    let mut checkpoints: Vec<Checkpoint> = old
+        .checkpoints
+        .iter()
+        .copied()
+        .filter(|c| c.block_idx < resume.block_idx)
+        .collect();
+    let (suffix_pages, suffix_outlines, suffix_cps) = if let Some(sp) = mid.spliced_at {
+        let old_splice_block = old_len - (new_len - sp.block_idx);
+        let tail_pages = pages.split_off(sp.pages_done);
+        let tail_outlines: Vec<OutlineEntry> = old_outlines
+            .iter()
+            .filter(|o| o.page_index >= sp.pages_done)
+            .cloned()
+            .collect();
+        let shift = new_len as isize - old_len as isize;
+        let tail_cps: Vec<Checkpoint> = old
+            .checkpoints
+            .iter()
+            .filter(|c| c.block_idx > old_splice_block)
+            .map(|c| Checkpoint {
+                block_idx: (c.block_idx as isize + shift) as usize,
+                pages_done: c.pages_done,
+            })
+            .collect();
+        (tail_pages, tail_outlines, tail_cps)
+    } else {
+        (Vec::new(), Vec::new(), Vec::new())
+    };
+    pages.truncate(resume.pages_done);
+    let mut outlines: Vec<OutlineEntry> = old_outlines
+        .into_iter()
+        .filter(|o| o.page_index < resume.pages_done)
+        .collect();
+
+    #[cfg(not(target_arch = "wasm32"))]
+    if std::env::var("RDOCX_TIMING").is_ok() {
+        eprintln!(
+            "timing: pagination reuse — {} prefix + {} rebuilt + {} spliced pages",
+            pages.len(),
+            mid.pages.len(),
+            suffix_pages.len()
+        );
+    }
+
+    pages.extend(mid.pages);
+    pages.extend(suffix_pages);
+    outlines.extend(mid.outlines);
+    outlines.extend(suffix_outlines);
+    checkpoints.extend(mid.checkpoints);
+    checkpoints.extend(suffix_cps);
+    debug_assert!(
+        pages
+            .iter()
+            .enumerate()
+            .all(|(i, p)| p.page_number == context.first_page_number + i),
+        "reassembled pages must stay sequentially numbered"
+    );
+
+    let built = PaginationCache {
+        env_fp,
+        block_fps: fps.to_vec(),
+        pages,
+        outlines,
+        checkpoints,
+    };
+    let out = (built.pages.clone(), built.outlines.clone());
+    *cache = Some(built);
+    out
+}
+
 /// Paginate a sequence of blocks into pages.
 pub fn paginate(
     blocks: &[LayoutBlock],
@@ -287,6 +551,11 @@ struct PassResult {
     pages: Vec<Arc<PageFrame>>,
     outlines: Vec<OutlineEntry>,
     resolved: ResolvedWraps,
+    /// Page boundaries where a block started cleanly, for [`PaginationCache`].
+    checkpoints: Vec<Checkpoint>,
+    /// When the pass stopped early because the rest of the document matched
+    /// the previous run: the boundary it stopped at.
+    spliced_at: Option<Checkpoint>,
 }
 
 /// Everything a pass needs that is the same for both passes.
@@ -309,6 +578,24 @@ fn paginate_pass(
     context: &PassContext,
     resolved_in: &ResolvedWraps,
 ) -> PassResult {
+    paginate_pass_resumable(blocks, context, resolved_in, 0, 0, None)
+}
+
+/// The pagination loop, generalized so a run can start mid-document.
+///
+/// `start_block`/`pages_done` seed the pager as if the blocks before
+/// `start_block` had already filled `pages_done` pages and the last of them
+/// ended exactly at the page boundary (which is what a [`Checkpoint`]
+/// certifies). `splice` optionally lets the pass stop early when the rest of
+/// the document is known to paginate identically to the previous run.
+fn paginate_pass_resumable(
+    blocks: &[LayoutBlock],
+    context: &PassContext,
+    resolved_in: &ResolvedWraps,
+    start_block: usize,
+    pages_done: usize,
+    splice: Option<&SpliceMap>,
+) -> PassResult {
     let geometry = context.geometry;
     let mut pager = Pager::new(
         geometry,
@@ -318,11 +605,23 @@ fn paginate_pass(
         context.notes,
         context.fm,
         resolved_in,
-        context.first_page_number,
-        context.first_header_page_number,
+        context.first_page_number + pages_done,
+        context.first_header_page_number + pages_done,
     );
+    pager.is_first_page = pages_done == 0;
+    pager.first_page_number = context.first_page_number;
+    pager.splice = splice;
 
-    for (block_idx, block) in blocks.iter().enumerate() {
+    'blocks: for (block_idx, block) in blocks.iter().enumerate().skip(start_block) {
+        if pager.block_boundary(block_idx) {
+            break 'blocks;
+        }
+        // A block that moves to a fresh page inside its own placement code
+        // (paragraph that does not fit, page-break-before) reaches another
+        // boundary there; those call sites run `block_boundary` themselves.
+        // When one of them flags a splice the block was not placed, so undo
+        // its loop-top bookkeeping (the heading outline entry).
+        let outline_mark = pager.outlines.len();
         // Check for page break before
         if block.page_break_before() && pager.has_content() {
             pager.finish_page();
@@ -342,6 +641,11 @@ fn paginate_pass(
                 paginate_paragraph(para, block_idx, blocks, &mut pager);
             }
             LayoutBlock::Table(table) => {
+                // A page-break-before above may have opened a fresh page
+                // after the loop-top boundary check ran.
+                if pager.block_boundary(block_idx) {
+                    break 'blocks;
+                }
                 let table_x = geometry.margin_left + table.table_indent;
                 let tbl_borders = table.borders.as_ref();
 
@@ -387,14 +691,31 @@ fn paginate_pass(
                 }
             }
         }
+        if pager.splice_hit.is_some() {
+            pager.outlines.truncate(outline_mark);
+            break 'blocks;
+        }
     }
 
     let resolved = std::mem::take(&mut pager.resolved_out);
-    let (pages, outlines) = pager.flush();
+    let checkpoints = std::mem::take(&mut pager.checkpoints);
+    let spliced_at = pager.splice_hit;
+    let (pages, outlines) = if spliced_at.is_some() {
+        // The current page is clean by the splice condition; the old suffix
+        // pages the caller re-attaches include the document's final page, so
+        // there is nothing to flush.
+        (pager.pages, pager.outlines)
+    } else {
+        // Only a run that owns the whole document guarantees "at least one
+        // page"; a resumed run may legitimately add none.
+        pager.flush_impl(start_block == 0)
+    };
     PassResult {
         pages,
         outlines,
         resolved,
+        checkpoints,
+        spliced_at,
     }
 }
 
@@ -446,6 +767,18 @@ struct Pager<'a> {
     resolved_in: &'a ResolvedWraps,
     /// Where this pass is placing them, for the pass that follows.
     resolved_out: ResolvedWraps,
+    /// The section's first page number, so checkpoint bookkeeping can turn
+    /// `page_number` back into "pages finished since the section started".
+    first_page_number: usize,
+    /// Page boundaries where a block started on a fresh page with no carried
+    /// state, recorded as the pass runs. See [`Checkpoint`].
+    checkpoints: Vec<Checkpoint>,
+    /// When set, `block_boundary` may stop the pass at a boundary the
+    /// previous run also reached. See [`SpliceMap`].
+    splice: Option<&'a SpliceMap>,
+    /// Set by `block_boundary` when the splice condition fired; the pass
+    /// unwinds without placing the boundary block.
+    splice_hit: Option<Checkpoint>,
 }
 
 impl<'a> Pager<'a> {
@@ -483,11 +816,63 @@ impl<'a> Pager<'a> {
             ink_bottom: 0.0,
             resolved_in,
             resolved_out: ResolvedWraps::new(),
+            first_page_number: 1,
+            checkpoints: Vec::new(),
+            splice: None,
+            splice_hit: None,
         }
     }
 
     fn has_content(&self) -> bool {
         self.has_content_flag
+    }
+
+    /// Whether the pager sits exactly at the top of a fresh page with nothing
+    /// carried over: no placed elements, no floats, no footnote lines waiting
+    /// to continue. At such a point the pager's whole state is captured by
+    /// (next block index, pages finished), which is what makes a
+    /// [`Checkpoint`] sufficient to resume from.
+    fn at_clean_page_start(&self) -> bool {
+        !self.has_content_flag
+            && self.elements.is_empty()
+            && self.behind_elements.is_empty()
+            && self.cursor_y == 0.0
+            && self.page_wraps.is_empty()
+            && self.page_note_ids.is_empty()
+            && self.pending_notes.is_empty()
+            && self.ink_bottom == 0.0
+    }
+
+    /// Called wherever a block is about to be placed: the pass loop top, a
+    /// paragraph's placement entry (which is reached again on a fresh page
+    /// when the paragraph moves there whole), and the table arm. Records a
+    /// checkpoint when the pager sits at a clean page start, and returns
+    /// `true` — stop paginating, the block was NOT placed — when the splice
+    /// map certifies the rest of the document paginates as it did before.
+    fn block_boundary(&mut self, block_idx: usize) -> bool {
+        if !self.at_clean_page_start() {
+            return false;
+        }
+        let cp = Checkpoint {
+            block_idx,
+            pages_done: self.page_number - self.first_page_number,
+        };
+        if self.checkpoints.last() == Some(&cp) {
+            // The loop top already handled this boundary.
+            return false;
+        }
+        self.checkpoints.push(cp);
+        if let Some(map) = self.splice {
+            let end_offset = map.total_blocks - block_idx;
+            if cp.pages_done > 0
+                && end_offset <= map.max_suffix
+                && map.by_end_offset.get(&end_offset) == Some(&cp.pages_done)
+            {
+                self.splice_hit = Some(cp);
+                return true;
+            }
+        }
+        false
     }
 
     /// Height the note area needs for a given set of notes, in full.
@@ -1003,9 +1388,9 @@ impl<'a> Pager<'a> {
         self.is_first_page = false;
     }
 
-    fn flush(mut self) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
+    fn flush_impl(mut self, ensure_page: bool) -> (Vec<Arc<PageFrame>>, Vec<OutlineEntry>) {
         // Always create at least one page
-        if self.has_content() || self.pages.is_empty() {
+        if self.has_content() || (ensure_page && self.pages.is_empty()) {
             self.finish_page();
         }
         // A note that ran past the last page of body text still has to land
@@ -1559,6 +1944,12 @@ fn paginate_paragraph(
     blocks: &[LayoutBlock],
     pager: &mut Pager,
 ) {
+    // Placement entry doubles as a page-boundary probe: when the paragraph
+    // could not fit and was moved here whole, or a page-break-before just
+    // finished the page, this is the first moment the fresh page is visible.
+    if pager.block_boundary(block_idx) {
+        return;
+    }
     let space_before = if pager.cursor_y == 0.0 {
         0.0
     } else {

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -667,6 +667,7 @@ fn paginate_pass_resumable(
                                     pager.page_number,
                                     tbl_borders,
                                     &mut pager.elements,
+                                    &mut pager.behind_elements,
                                     pager.media,
                                 );
                                 pager.cursor_y += hdr_row.height;
@@ -684,6 +685,7 @@ fn paginate_pass_resumable(
                         pager.page_number,
                         tbl_borders,
                         &mut pager.elements,
+                        &mut pager.behind_elements,
                         pager.media,
                     );
                     pager.cursor_y += row.height;
@@ -2552,9 +2554,17 @@ fn place_cell_anchored(
     cell_geometry: &PageGeometry,
     para_top_abs: f64,
     elements: &mut Vec<PositionedElement>,
+    behind_elements: &mut Vec<PositionedElement>,
     media: &HashMap<MediaId, ImageData>,
 ) {
     for a in anchored {
+        // behindDoc watermarks go to the page's behind layer so they stay
+        // under every cell's text and borders, not just this cell's own.
+        let sink: &mut Vec<PositionedElement> = if a.behind_doc {
+            &mut *behind_elements
+        } else {
+            &mut *elements
+        };
         let x = resolve_anchor_h(a.rel_h, a.off_h, a.align_h, a.width, cell_geometry, 0.0);
         let y = resolve_anchor_v(
             a.rel_v,
@@ -2573,7 +2583,7 @@ fn place_cell_anchored(
         match &a.content {
             AnchoredContent::Image { media_id } => {
                 let image = media.get(media_id);
-                elements.push(PositionedElement::Image {
+                sink.push(PositionedElement::Image {
                     rect,
                     data: image.map_or_else(Vec::new, |image| image.data.clone()),
                     content_type: image
@@ -2588,15 +2598,15 @@ fn place_cell_anchored(
                     f: rect.y,
                     ..oxml_layout::Transform::IDENTITY
                 });
-                elements.push(PositionedElement::Group(positioned));
+                sink.push(PositionedElement::Group(positioned));
             }
             AnchoredContent::Shape { preset, fill, text } => {
                 match (preset, fill) {
                     (ShapePreset::Rect, Some(color)) => {
-                        elements.push(PositionedElement::FilledRect { rect, color: *color });
+                        sink.push(PositionedElement::FilledRect { rect, color: *color });
                     }
                     (ShapePreset::Line, Some(color)) => {
-                        elements.push(PositionedElement::Line {
+                        sink.push(PositionedElement::Line {
                             start: Point { x, y },
                             end: Point {
                                 x: x + a.width,
@@ -2609,7 +2619,7 @@ fn place_cell_anchored(
                     }
                     _ => {}
                 }
-                elements.extend(render_shape_text(text, cell_geometry, rect, media));
+                sink.extend(render_shape_text(text, cell_geometry, rect, media));
             }
         }
     }
@@ -2624,6 +2634,7 @@ fn render_table_row(
     page_number: usize,
     table_borders: Option<&rdocx_oxml::table::CT_TblBorders>,
     elements: &mut Vec<PositionedElement>,
+    behind_elements: &mut Vec<PositionedElement>,
     media: &HashMap<MediaId, ImageData>,
 ) {
     let mut cell_x = table_x;
@@ -2697,7 +2708,10 @@ fn render_table_row(
             // Paragraphs and nested tables interleave in document order:
             // a nested entry at position i renders before paragraphs[i].
             let mut para_y = row_y - geometry.margin_top + cell_margin_top + v_offset;
-            let mut render_nested_at = |pos: usize, para_y: &mut f64, elements: &mut Vec<PositionedElement>| {
+            let mut render_nested_at = |pos: usize,
+                                        para_y: &mut f64,
+                                        elements: &mut Vec<PositionedElement>,
+                                        behind_elements: &mut Vec<PositionedElement>| {
                 for (at, block) in &cell.nested {
                     if *at != pos {
                         continue;
@@ -2713,6 +2727,7 @@ fn render_table_row(
                             page_number,
                             block.borders.as_ref(),
                             elements,
+                            behind_elements,
                             media,
                         );
                         nested_row_y += nested_row.height;
@@ -2721,7 +2736,7 @@ fn render_table_row(
                 }
             };
             for (i, para) in cell.paragraphs.iter().enumerate() {
-                render_nested_at(i, &mut para_y, elements);
+                render_nested_at(i, &mut para_y, elements, behind_elements);
                 let cell_geometry = PageGeometry {
                     margin_left: cell_x + cell_margin_left,
                     ..*geometry
@@ -2732,6 +2747,7 @@ fn render_table_row(
                         &cell_geometry,
                         geometry.margin_top + para_y,
                         elements,
+                        behind_elements,
                         media,
                     );
                 }
@@ -2753,7 +2769,7 @@ fn render_table_row(
                 );
                 para_y += para.total_height();
             }
-            render_nested_at(cell.paragraphs.len(), &mut para_y, elements);
+            render_nested_at(cell.paragraphs.len(), &mut para_y, elements, behind_elements);
         }
         cell_x += cell.width;
     }

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -2775,13 +2775,26 @@ fn render_cell_borders(
     suppress_bottom: bool,
     elements: &mut Vec<PositionedElement>,
 ) {
-    // Determine effective border for each edge (cell overrides table)
+    // Determine effective border for each edge (cell overrides table).
+    // At the table's OUTER boundary a cell border of none/nil yields to the
+    // table-level border instead of erasing it — matching how Word renders
+    // form documents whose first-row cells say `<w:top w:val="nil"/>` while
+    // the table style supplies the box outline. Between cells (insideH/V),
+    // an explicit none still suppresses the line.
     let get_edge = |cell_edge: Option<&rdocx_oxml::borders::CT_BorderEdge>,
-                    table_edge: Option<&rdocx_oxml::borders::CT_BorderEdge>|
+                    table_edge: Option<&rdocx_oxml::borders::CT_BorderEdge>,
+                    outer: bool|
      -> Option<BorderEdge> {
-        let edge = cell_edge.or(table_edge)?;
+        let mut edge = cell_edge.or(table_edge)?;
         if edge.val == ST_Border::None {
-            return None;
+            if outer && cell_edge.is_some() {
+                edge = table_edge?;
+                if edge.val == ST_Border::None {
+                    return None;
+                }
+            } else {
+                return None;
+            }
         }
         let thickness = edge.sz.unwrap_or(4) as f64 / 8.0; // sz is in 1/8 pt
         let color = edge
@@ -2803,7 +2816,7 @@ fn render_cell_borders(
         }
     });
     let cell_top = cell_borders.as_ref().and_then(|b| b.top.as_ref());
-    if let Some((thickness, color, dash_pattern)) = get_edge(cell_top, table_top)
+    if let Some((thickness, color, dash_pattern)) = get_edge(cell_top, table_top, is_first_row)
         && !suppress_top
     {
         elements.push(PositionedElement::Line {
@@ -2824,7 +2837,7 @@ fn render_cell_borders(
         }
     });
     let cell_bottom = cell_borders.as_ref().and_then(|b| b.bottom.as_ref());
-    if let Some((thickness, color, dash_pattern)) = get_edge(cell_bottom, table_bottom)
+    if let Some((thickness, color, dash_pattern)) = get_edge(cell_bottom, table_bottom, is_last_row)
         && !suppress_bottom
     {
         elements.push(PositionedElement::Line {
@@ -2845,7 +2858,7 @@ fn render_cell_borders(
         }
     });
     let cell_left = cell_borders.as_ref().and_then(|b| b.left.as_ref());
-    if let Some((thickness, color, dash_pattern)) = get_edge(cell_left, table_left) {
+    if let Some((thickness, color, dash_pattern)) = get_edge(cell_left, table_left, cell_idx == 0) {
         elements.push(PositionedElement::Line {
             start: Point { x, y },
             end: Point { x, y: y + h },
@@ -2864,7 +2877,7 @@ fn render_cell_borders(
         }
     });
     let cell_right = cell_borders.as_ref().and_then(|b| b.right.as_ref());
-    if let Some((thickness, color, dash_pattern)) = get_edge(cell_right, table_right) {
+    if let Some((thickness, color, dash_pattern)) = get_edge(cell_right, table_right, cell_idx == num_cells - 1) {
         elements.push(PositionedElement::Line {
             start: Point { x: x + w, y },
             end: Point { x: x + w, y: y + h },

--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -2542,6 +2542,79 @@ fn render_hf_blocks(
 }
 
 /// Render a table row.
+/// Floating drawings anchored to a paragraph inside a table cell (stamps,
+/// seals, watermarks on forms). The cell's text area stands in for the
+/// anchor's "column"/"margin" reference, wrapping is ignored (such drawings
+/// overlap or sit behind the form), and elements are pushed before the
+/// cell's text so the text paints on top.
+fn place_cell_anchored(
+    anchored: &[AnchoredDrawing],
+    cell_geometry: &PageGeometry,
+    para_top_abs: f64,
+    elements: &mut Vec<PositionedElement>,
+    media: &HashMap<MediaId, ImageData>,
+) {
+    for a in anchored {
+        let x = resolve_anchor_h(a.rel_h, a.off_h, a.align_h, a.width, cell_geometry, 0.0);
+        let y = resolve_anchor_v(
+            a.rel_v,
+            a.off_v,
+            a.align_v,
+            a.height,
+            cell_geometry,
+            para_top_abs - cell_geometry.margin_top,
+        );
+        let rect = Rect {
+            x,
+            y,
+            width: a.width,
+            height: a.height,
+        };
+        match &a.content {
+            AnchoredContent::Image { media_id } => {
+                let image = media.get(media_id);
+                elements.push(PositionedElement::Image {
+                    rect,
+                    data: image.map_or_else(Vec::new, |image| image.data.clone()),
+                    content_type: image
+                        .map_or_else(String::new, |image| image.content_type.clone()),
+                    media_id: *media_id,
+                });
+            }
+            AnchoredContent::Group(group) => {
+                let mut positioned = group.clone();
+                positioned.transform = positioned.transform.then(oxml_layout::Transform {
+                    e: rect.x,
+                    f: rect.y,
+                    ..oxml_layout::Transform::IDENTITY
+                });
+                elements.push(PositionedElement::Group(positioned));
+            }
+            AnchoredContent::Shape { preset, fill, text } => {
+                match (preset, fill) {
+                    (ShapePreset::Rect, Some(color)) => {
+                        elements.push(PositionedElement::FilledRect { rect, color: *color });
+                    }
+                    (ShapePreset::Line, Some(color)) => {
+                        elements.push(PositionedElement::Line {
+                            start: Point { x, y },
+                            end: Point {
+                                x: x + a.width,
+                                y: y + a.height,
+                            },
+                            width: 1.0,
+                            color: *color,
+                            dash_pattern: None,
+                        });
+                    }
+                    _ => {}
+                }
+                elements.extend(render_shape_text(text, cell_geometry, rect, media));
+            }
+        }
+    }
+}
+
 fn render_table_row(
     row: &crate::table::TableRow,
     _col_widths: &[f64],
@@ -2557,14 +2630,25 @@ fn render_table_row(
     let num_cells = row.cells.len();
 
     for (cell_idx, cell) in row.cells.iter().enumerate() {
+        // A merge-starting cell paints shading/side borders over its whole
+        // span; continue cells suppress top borders (and bottom while the
+        // merge keeps going) so no line crosses the merged region.
+        let draw_height = if cell.starts_vmerge {
+            cell.merged_height
+        } else {
+            cell.height
+        };
+
         // Render cell shading
-        if let Some(ref shading) = cell.shading {
+        if !cell.is_vmerge_continue
+            && let Some(ref shading) = cell.shading
+        {
             elements.push(PositionedElement::FilledRect {
                 rect: Rect {
                     x: cell_x,
                     y: row_y,
                     width: cell.width,
-                    height: cell.height,
+                    height: draw_height,
                 },
                 color: *shading,
             });
@@ -2575,13 +2659,15 @@ fn render_table_row(
             cell_x,
             row_y,
             cell.width,
-            cell.height,
+            draw_height,
             &cell.borders,
             table_borders,
             cell_idx,
             num_cells,
             cell.is_first_row,
             cell.is_last_row,
+            cell.is_vmerge_continue,
+            cell.merge_with_below,
             elements,
         );
 
@@ -2590,27 +2676,69 @@ fn render_table_row(
             let cell_margin_top = cell.margin_top;
             let cell_margin_left = cell.margin_left;
 
-            // Compute vertical alignment offset
-            let content_height: f64 = cell.paragraphs.iter().map(|p| p.total_height()).sum();
+            // Compute vertical alignment offset (over the merged span for
+            // a merge-starting cell).
+            let content_height: f64 = cell.paragraphs.iter().map(|p| p.total_height()).sum::<f64>()
+                + cell
+                    .nested
+                    .iter()
+                    .map(|(_, t)| t.total_height())
+                    .sum::<f64>();
             let v_offset = match cell.v_align {
                 Some(rdocx_oxml::table::ST_VerticalJc::Center) => {
-                    ((cell.height - cell_margin_top - content_height) / 2.0).max(0.0)
+                    ((draw_height - cell_margin_top - content_height) / 2.0).max(0.0)
                 }
                 Some(rdocx_oxml::table::ST_VerticalJc::Bottom) => {
-                    (cell.height - cell_margin_top - content_height).max(0.0)
+                    (draw_height - cell_margin_top - content_height).max(0.0)
                 }
                 _ => 0.0, // Top or unspecified
             };
 
+            // Paragraphs and nested tables interleave in document order:
+            // a nested entry at position i renders before paragraphs[i].
             let mut para_y = row_y - geometry.margin_top + cell_margin_top + v_offset;
-            for para in &cell.paragraphs {
+            let mut render_nested_at = |pos: usize, para_y: &mut f64, elements: &mut Vec<PositionedElement>| {
+                for (at, block) in &cell.nested {
+                    if *at != pos {
+                        continue;
+                    }
+                    let mut nested_row_y = geometry.margin_top + *para_y;
+                    for nested_row in &block.rows {
+                        render_table_row(
+                            nested_row,
+                            &block.col_widths,
+                            cell_x + cell_margin_left + block.table_indent,
+                            nested_row_y,
+                            geometry,
+                            page_number,
+                            block.borders.as_ref(),
+                            elements,
+                            media,
+                        );
+                        nested_row_y += nested_row.height;
+                    }
+                    *para_y += block.total_height();
+                }
+            };
+            for (i, para) in cell.paragraphs.iter().enumerate() {
+                render_nested_at(i, &mut para_y, elements);
+                let cell_geometry = PageGeometry {
+                    margin_left: cell_x + cell_margin_left,
+                    ..*geometry
+                };
+                if !para.anchored.is_empty() {
+                    place_cell_anchored(
+                        &para.anchored,
+                        &cell_geometry,
+                        geometry.margin_top + para_y,
+                        elements,
+                        media,
+                    );
+                }
                 render_paragraph_lines(
                     &para.lines,
                     para,
-                    &PageGeometry {
-                        margin_left: cell_x + cell_margin_left,
-                        ..*geometry
-                    },
+                    &cell_geometry,
                     para_y,
                     elements,
                     media,
@@ -2625,6 +2753,7 @@ fn render_table_row(
                 );
                 para_y += para.total_height();
             }
+            render_nested_at(cell.paragraphs.len(), &mut para_y, elements);
         }
         cell_x += cell.width;
     }
@@ -2642,6 +2771,8 @@ fn render_cell_borders(
     num_cells: usize,
     is_first_row: bool,
     is_last_row: bool,
+    suppress_top: bool,
+    suppress_bottom: bool,
     elements: &mut Vec<PositionedElement>,
 ) {
     // Determine effective border for each edge (cell overrides table)
@@ -2672,7 +2803,9 @@ fn render_cell_borders(
         }
     });
     let cell_top = cell_borders.as_ref().and_then(|b| b.top.as_ref());
-    if let Some((thickness, color, dash_pattern)) = get_edge(cell_top, table_top) {
+    if let Some((thickness, color, dash_pattern)) = get_edge(cell_top, table_top)
+        && !suppress_top
+    {
         elements.push(PositionedElement::Line {
             start: Point { x, y },
             end: Point { x: x + w, y },
@@ -2691,7 +2824,9 @@ fn render_cell_borders(
         }
     });
     let cell_bottom = cell_borders.as_ref().and_then(|b| b.bottom.as_ref());
-    if let Some((thickness, color, dash_pattern)) = get_edge(cell_bottom, table_bottom) {
+    if let Some((thickness, color, dash_pattern)) = get_edge(cell_bottom, table_bottom)
+        && !suppress_bottom
+    {
         elements.push(PositionedElement::Line {
             start: Point { x, y: y + h },
             end: Point { x: x + w, y: y + h },

--- a/crates/rdocx-layout/src/style_resolver.rs
+++ b/crates/rdocx-layout/src/style_resolver.rs
@@ -87,12 +87,30 @@ impl NumberingState {
 
 /// Resolve paragraph properties by walking the style inheritance chain.
 pub fn resolve_paragraph_properties(style_id: Option<&str>, styles: &CT_Styles) -> CT_PPr {
+    resolve_paragraph_properties_in_table(style_id, styles, None)
+}
+
+/// Like [`resolve_paragraph_properties`], with an optional table-style
+/// paragraph-property layer. OOXML cascades docDefaults → table style →
+/// paragraph style → direct formatting for paragraphs inside a table;
+/// table styles routinely carry `spacing after=0`, and skipping this layer
+/// doubles every row of a dense form.
+pub fn resolve_paragraph_properties_in_table(
+    style_id: Option<&str>,
+    styles: &CT_Styles,
+    table_ppr: Option<&CT_PPr>,
+) -> CT_PPr {
     let mut effective = CT_PPr::default();
 
     // 1. Start from docDefaults
     if let Some(ref defaults) = styles.doc_defaults
         && let Some(ref ppr) = defaults.ppr
     {
+        effective.merge_from(ppr);
+    }
+
+    // 1.5 Table-style paragraph properties (for paragraphs inside a table)
+    if let Some(ppr) = table_ppr {
         effective.merge_from(ppr);
     }
 
@@ -340,6 +358,8 @@ mod tests {
                 color: Some("2E74B5".to_string()),
                 ..Default::default()
             }),
+                    tbl_pr_xml: None,
+            table_borders: None,
         });
         styles
     }

--- a/crates/rdocx-layout/src/table.rs
+++ b/crates/rdocx-layout/src/table.rs
@@ -55,6 +55,10 @@ pub struct TableRow {
 pub struct TableCell {
     /// Cell content (paragraph blocks).
     pub paragraphs: Vec<ParagraphBlock>,
+    /// Nested tables laid out inside this cell, as
+    /// `(paragraph position, block)`: the block renders after that many of
+    /// `paragraphs` (document order is preserved for mixed content).
+    pub nested: Vec<(usize, TableBlock)>,
     /// Cell width in points (may span multiple grid columns).
     pub width: f64,
     /// Cell height in points (set to row height).
@@ -63,6 +67,16 @@ pub struct TableCell {
     pub grid_span: u32,
     /// Whether this cell is part of a vertical merge continuation (render no content).
     pub is_vmerge_continue: bool,
+    /// Whether this cell starts a vertical merge (vMerge=restart).
+    pub starts_vmerge: bool,
+    /// Total height this cell spans: the sum of the spanned row heights for
+    /// a merge-starting cell, otherwise equal to `height`. The renderer
+    /// draws shading, side borders, and vertically-aligned content over
+    /// this span.
+    pub merged_height: f64,
+    /// The same grid column continues a vertical merge in the next row —
+    /// the renderer suppresses this cell's bottom border.
+    pub merge_with_below: bool,
     /// Column index in the grid.
     pub col_index: usize,
     /// Cell-level borders.
@@ -166,8 +180,51 @@ fn layout_table_inner(
         })
         .unwrap_or(0.0);
 
-    // Table-level borders
-    let table_borders = tbl.properties.as_ref().and_then(|p| p.borders.clone());
+    // Table-level borders: direct properties first, then the referenced
+    // table style (following basedOn up a bounded chain) — receipts and
+    // forms commonly carry all their grid lines in the style.
+    let table_borders = tbl
+        .properties
+        .as_ref()
+        .and_then(|p| p.borders.clone())
+        .or_else(|| {
+            let mut id = tbl.properties.as_ref()?.style_id.as_deref()?;
+            for _ in 0..8 {
+                let style = styles.get_by_id(id)?;
+                if let Some(borders) = &style.table_borders {
+                    return Some(borders.clone());
+                }
+                id = style.based_on.as_deref()?;
+            }
+            None
+        });
+
+    // Table-style paragraph properties, merged base-first along the
+    // basedOn chain: they cascade onto every paragraph inside the table
+    // (styles like Table Grid carry `spacing after=0` here).
+    let table_style_ppr: Option<rdocx_oxml::properties::CT_PPr> = {
+        let mut merged: Option<rdocx_oxml::properties::CT_PPr> = None;
+        if let Some(start) = tbl.properties.as_ref().and_then(|p| p.style_id.as_deref()) {
+            let mut chain = Vec::new();
+            let mut id = start;
+            for _ in 0..8 {
+                let Some(style) = styles.get_by_id(id) else { break };
+                chain.push(style);
+                match style.based_on.as_deref() {
+                    Some(next) => id = next,
+                    None => break,
+                }
+            }
+            for style in chain.iter().rev() {
+                if let Some(ppr) = &style.ppr {
+                    merged
+                        .get_or_insert_with(rdocx_oxml::properties::CT_PPr::default)
+                        .merge_from(ppr);
+                }
+            }
+        }
+        merged
+    };
 
     // Default cell margins
     let default_cell_margin = tbl.properties.as_ref().and_then(|p| p.cell_margin.as_ref());
@@ -191,6 +248,7 @@ fn layout_table_inner(
     let num_rows = tbl.rows.len();
     let mut header_row_indices = Vec::new();
     let mut rows = Vec::new();
+    let mut exact_rows: Vec<bool> = Vec::new();
 
     for (row_idx, row) in tbl.rows.iter().enumerate() {
         let is_header = row
@@ -218,6 +276,12 @@ fn layout_table_inner(
                 .and_then(|p| p.v_merge)
                 .map(|vm| vm == VMerge::Continue)
                 .unwrap_or(false);
+            let starts_vmerge = cell
+                .properties
+                .as_ref()
+                .and_then(|p| p.v_merge)
+                .map(|vm| vm == VMerge::Restart)
+                .unwrap_or(false);
 
             // Cell-level borders and shading
             let cell_borders = cell.properties.as_ref().and_then(|p| p.borders.clone());
@@ -237,8 +301,8 @@ fn layout_table_inner(
             let content_width = (cell_width - cell_margin_left - cell_margin_right).max(0.0);
 
             // Layout cell content (paragraphs and nested tables)
-            let paragraphs = if is_vmerge_continue {
-                Vec::new()
+            let (paragraphs, nested) = if is_vmerge_continue {
+                (Vec::new(), Vec::new())
             } else {
                 layout_cell_content(
                     &cell.content,
@@ -254,10 +318,15 @@ fn layout_table_inner(
                     path,
                     row_idx,
                     cell_index,
+                    table_style_ppr.as_ref(),
                 )?
             };
 
             let content_height: f64 = paragraphs.iter().map(|p| p.total_height()).sum::<f64>()
+                + nested
+                    .iter()
+                    .map(|(_, t)| t.total_height())
+                    .sum::<f64>()
                 + cell_margin_top
                 + cell_margin_bottom;
 
@@ -265,10 +334,14 @@ fn layout_table_inner(
 
             cells.push(TableCell {
                 paragraphs,
+                nested,
                 width: cell_width,
                 height: content_height,
                 grid_span,
                 is_vmerge_continue,
+                starts_vmerge,
+                merged_height: content_height,
+                merge_with_below: false,
                 col_index,
                 borders: cell_borders,
                 shading: cell_shading,
@@ -282,26 +355,98 @@ fn layout_table_inner(
             col_index += grid_span as usize;
         }
 
-        // Row height is max of all cell heights and any specified height
-        let max_cell_height = cells.iter().map(|c| c.height).fold(0.0f64, f64::max);
+        // Row height from cells that do NOT start a vertical merge — a
+        // merge-starting cell's content spans several rows, so counting it
+        // here would balloon this row; its needs are distributed below.
+        let max_cell_height = cells
+            .iter()
+            .filter(|c| !c.starts_vmerge)
+            .map(|c| c.height)
+            .fold(0.0f64, f64::max);
+        let fallback_height = cells.iter().map(|c| c.height).fold(0.0f64, f64::max);
         let specified_height = row
             .properties
             .as_ref()
             .and_then(|p| p.height)
             .map(|h| h.to_pt())
             .unwrap_or(0.0);
-        let row_height = max_cell_height.max(specified_height);
+        // hRule="exact" pins the row height regardless of content (Word
+        // clips overflow) — dense forms rely on it row by row.
+        let exact = row
+            .properties
+            .as_ref()
+            .and_then(|p| p.height_rule.as_deref())
+            == Some("exact");
+        exact_rows.push(exact && specified_height > 0.0);
+        let row_height = if exact && specified_height > 0.0 {
+            specified_height
+        } else if max_cell_height > 0.0 || specified_height > 0.0 {
+            max_cell_height.max(specified_height)
+        } else {
+            // Every cell starts a merge (or the row is empty): fall back so
+            // the row is not zero-height.
+            fallback_height
+        };
 
-        // Set all cell heights to match row height
-        for cell in &mut cells {
-            cell.height = row_height;
-        }
-
+        // Cell heights are frozen after the vertical-merge pass below.
         rows.push(TableRow {
             cells,
             height: row_height,
             is_header,
         });
+    }
+
+    // Vertical merges: find each merge-starting cell's span (continue cells
+    // at the same grid column in the following rows), grow the last spanned
+    // row when the merged content needs more room than the span offers,
+    // then freeze cell heights and the merge geometry for the renderer.
+    let row_count = rows.len();
+    let mut spans: Vec<(usize, usize, usize)> = Vec::new(); // (row, cell, last_row)
+    for r in 0..row_count {
+        for ci in 0..rows[r].cells.len() {
+            if !rows[r].cells[ci].starts_vmerge {
+                continue;
+            }
+            let col = rows[r].cells[ci].col_index;
+            let mut last = r;
+            while last + 1 < row_count
+                && rows[last + 1]
+                    .cells
+                    .iter()
+                    .any(|c| c.col_index == col && c.is_vmerge_continue)
+            {
+                last += 1;
+            }
+            let needed = rows[r].cells[ci].height; // content height, unforced
+            let have: f64 = (r..=last).map(|i| rows[i].height).sum();
+            // Exact-height rows never grow (Word clips merged content too).
+            if needed > have && !exact_rows.get(last).copied().unwrap_or(false) {
+                rows[last].height += needed - have;
+            }
+            spans.push((r, ci, last));
+        }
+    }
+    let heights: Vec<f64> = rows.iter().map(|x| x.height).collect();
+    for r in 0..row_count {
+        let next_continue_cols: Vec<usize> = if r + 1 < row_count {
+            rows[r + 1]
+                .cells
+                .iter()
+                .filter(|c| c.is_vmerge_continue)
+                .map(|c| c.col_index)
+                .collect()
+        } else {
+            Vec::new()
+        };
+        for cell in &mut rows[r].cells {
+            cell.height = heights[r];
+            cell.merged_height = heights[r];
+            cell.merge_with_below =
+                cell.merge_with_below || next_continue_cols.contains(&cell.col_index);
+        }
+    }
+    for &(r, ci, last) in &spans {
+        rows[r].cells[ci].merged_height = heights[r..=last].iter().sum();
     }
 
     Ok(TableBlock {
@@ -379,18 +524,20 @@ fn layout_cell_content(
     table_path: &[usize],
     row_index: usize,
     cell_index: usize,
-) -> Result<Vec<ParagraphBlock>> {
+    table_ppr: Option<&rdocx_oxml::properties::CT_PPr>,
+) -> Result<(Vec<ParagraphBlock>, Vec<(usize, TableBlock)>)> {
     use crate::engine;
     use rdocx_oxml::table::CellContent;
 
     let mut blocks = Vec::new();
+    let mut nested = Vec::new();
     for (content_index, item) in content.iter().enumerate() {
         let mut source_path = table_path.to_vec();
         source_path.extend([row_index, cell_index, content_index]);
         match item {
             CellContent::Paragraph(para) => {
                 let source = sources.and_then(|sources| sources.id(story, &source_path));
-                let block = engine::layout_paragraph_with_source(
+                let block = engine::layout_paragraph_with_source_in_table(
                     para,
                     available_width,
                     styles,
@@ -400,12 +547,16 @@ fn layout_cell_content(
                     num_state,
                     diagnostics,
                     source,
+                    table_ppr,
                 )?;
                 blocks.push(block);
             }
             CellContent::Table(tbl) => {
-                // Recursively lay out the nested table
-                let _nested = layout_table_inner(
+                // Recursively lay out the nested table and keep it as a
+                // block anchored at the current paragraph position, so the
+                // paginator renders real rows, borders, and shading instead
+                // of the old flattened paragraph stream.
+                let block = layout_table_inner(
                     tbl,
                     available_width,
                     styles,
@@ -418,20 +569,12 @@ fn layout_cell_content(
                     story,
                     &source_path,
                 )?;
-                // For now, flatten: render nested table cell content as paragraph blocks
-                // (Full nested table rendering would require the paginator to handle tables within cells)
-                for row in &_nested.rows {
-                    for cell in &row.cells {
-                        if !cell.is_vmerge_continue {
-                            blocks.extend(cell.paragraphs.iter().cloned());
-                        }
-                    }
-                }
+                nested.push((blocks.len(), block));
             }
             CellContent::ContentControl(_) => {}
         }
     }
-    Ok(blocks)
+    Ok((blocks, nested))
 }
 
 #[cfg(test)]
@@ -604,13 +747,18 @@ mod tests {
         assert_eq!(block.rows.len(), 1);
         assert_eq!(block.rows[0].cells.len(), 1);
 
-        // Cell should have paragraphs from both the outer paragraph and flattened nested content
+        // The outer paragraph stays a paragraph block; the nested table is
+        // kept as a real block anchored after it (no more flattening).
         let cell = &block.rows[0].cells[0];
-        // At least: "Before nested" + "N1" + "N2" = 3 paragraph blocks
+        assert_eq!(cell.paragraphs.len(), 1, "outer paragraph only");
+        assert_eq!(cell.nested.len(), 1, "one nested table block");
+        let (pos, nested) = &cell.nested[0];
+        assert_eq!(*pos, 1, "nested table renders after the paragraph");
+        assert_eq!(nested.rows.len(), 1);
+        assert_eq!(nested.rows[0].cells.len(), 2);
         assert!(
-            cell.paragraphs.len() >= 3,
-            "Expected at least 3 paragraph blocks from outer + nested content, got {}",
-            cell.paragraphs.len()
+            cell.height >= cell.paragraphs[0].total_height() + nested.total_height(),
+            "cell height covers paragraph + nested table"
         );
 
         // Table width should match available width

--- a/crates/rdocx-oxml/src/styles.rs
+++ b/crates/rdocx-oxml/src/styles.rs
@@ -51,6 +51,13 @@ pub struct CT_Style {
     pub is_default: bool,
     pub ppr: Option<CT_PPr>,
     pub rpr: Option<CT_RPr>,
+    /// Verbatim `<w:tblPr>` bytes of a table style, written back on save so
+    /// table-style formatting is no longer dropped by the round trip.
+    pub tbl_pr_xml: Option<Vec<u8>>,
+    /// Parsed view of the table style's `w:tblBorders` (from `tbl_pr_xml`),
+    /// used by layout to resolve borders for tables that reference the
+    /// style instead of carrying direct borders.
+    pub table_borders: Option<crate::table::CT_TblBorders>,
 }
 
 #[allow(non_snake_case)]
@@ -87,6 +94,8 @@ impl CT_Style {
         let mut next_style = None;
         let mut ppr = None;
         let mut rpr = None;
+        let mut tbl_pr_xml = None;
+        let mut table_borders = None;
         let mut buf = Vec::new();
 
         loop {
@@ -109,6 +118,10 @@ impl CT_Style {
                         ppr = Some(parse_scoped_ppr(&raw, word_prefixes)?);
                     } else if matches_local_name(ename.as_ref(), b"rPr") {
                         rpr = Some(CT_RPr::from_xml(reader)?);
+                    } else if is_word_element(ename.as_ref(), b"tblPr", &prefixes) {
+                        let raw = capture_element(reader, e)?;
+                        table_borders = parse_style_table_borders(&raw);
+                        tbl_pr_xml = Some(raw);
                     } else {
                         reader.read_to_end_into(ename, &mut Vec::new())?;
                     }
@@ -132,6 +145,8 @@ impl CT_Style {
             is_default,
             ppr,
             rpr,
+            tbl_pr_xml,
+            table_borders,
         })
     }
 
@@ -167,6 +182,9 @@ impl CT_Style {
         }
         if let Some(ref rpr) = self.rpr {
             rpr.to_xml(writer)?;
+        }
+        if let Some(ref raw) = self.tbl_pr_xml {
+            writer.get_mut().write_all(raw)?;
         }
 
         writer.write_event(Event::End(BytesEnd::new("w:style")))?;
@@ -416,6 +434,8 @@ impl CT_Styles {
             is_default: true,
             ppr: None,
             rpr: None,
+            tbl_pr_xml: None,
+            table_borders: None,
         };
 
         let heading1 = CT_Style {
@@ -440,6 +460,8 @@ impl CT_Styles {
                 color: Some("2F5496".to_string()),
                 ..Default::default()
             }),
+            tbl_pr_xml: None,
+            table_borders: None,
         };
 
         let doc_defaults = CT_DocDefaults {
@@ -474,6 +496,24 @@ impl Default for CT_Styles {
 }
 
 /// Extract the `w:val` attribute from an element.
+/// Parse the `w:tblBorders` inside a table style's raw `w:tblPr` bytes.
+fn parse_style_table_borders(raw: &[u8]) -> Option<crate::table::CT_TblBorders> {
+    let mut reader = Reader::from_reader(raw);
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e))
+                if matches_local_name(e.name().as_ref(), b"tblBorders") =>
+            {
+                return crate::table::CT_TblBorders::from_xml(&mut reader).ok();
+            }
+            Ok(Event::Eof) | Err(_) => return None,
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
 fn get_val_attr(e: &BytesStart) -> Result<Option<String>> {
     for attr in e.attributes() {
         let attr = attr?;

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3308,6 +3308,24 @@ impl Document {
         Ok(rdocx_layout::layout_document_with_caller_fonts_and_provenance(&input)?)
     }
 
+    /// SVG PoC patch: like [`Self::layout_with_fonts`], but the injected
+    /// fonts sit on top of the bundled metric-compatible set, so a wasm
+    /// editor that only injects a Korean font still resolves Calibri/Times.
+    /// Separate from the strictly isolated caller-fonts path on purpose.
+    pub fn layout_with_fonts_and_bundled_fallback(
+        &self,
+        font_files: &[(&str, &[u8])],
+    ) -> Result<rdocx_layout::WordLayoutResult> {
+        let mut input = self.build_layout_input();
+        for (family, data) in font_files {
+            input.fonts.push(rdocx_layout::FontFile {
+                family: family.to_string(),
+                data: data.to_vec(),
+            });
+        }
+        Ok(rdocx_layout::layout_document_with_fallback_fonts_and_provenance(&input)?)
+    }
+
     /// Render the document to PDF bytes.
     ///
     /// This performs a full layout pass (font shaping, line breaking, pagination)
@@ -5081,7 +5099,7 @@ mod tests {
                     .find(|font| font.id == run.font_id)
                     .expect("caller-font glyph run should resolve its font id");
                 assert_eq!(font.family, family);
-                assert_eq!(font.data, bytes);
+                assert_eq!(font.data.as_ref(), bytes.as_slice());
                 let source = run
                     .source
                     .expect("caller-font text should retain source provenance");
@@ -6142,7 +6160,7 @@ mod tests {
             assert!(
                 bundled_fonts
                     .iter()
-                    .any(|(_family, data)| *data == font.data.as_slice()),
+                    .any(|(_family, data)| *data == font.data.as_ref()),
                 "resolved font '{}' did not come from the bundled font set",
                 font.family
             );

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -115,6 +115,9 @@ pub struct Document {
     normal_layout_engine: Mutex<Option<rdocx_layout::engine::Engine>>,
     /// Bundled-font-only layout used by deterministic rendering.
     deterministic_layout_cache: Mutex<Option<Arc<rdocx_layout::WordLayoutResult>>>,
+    /// SVG PoC patch: reusable engine for the bundled-fallback caller-fonts
+    /// path (wasm editors), kept across edits like `normal_layout_engine`.
+    fallback_layout_engine: Mutex<Option<rdocx_layout::engine::Engine>>,
 }
 
 enum ChartPackageSource<'a> {
@@ -445,6 +448,7 @@ impl Document {
             layout_cache: Mutex::new(None),
             normal_layout_engine: Mutex::new(None),
             deterministic_layout_cache: Mutex::new(None),
+            fallback_layout_engine: Mutex::new(None),
         }
     }
 
@@ -476,6 +480,7 @@ impl Document {
             layout_cache: Mutex::new(None),
             normal_layout_engine: Mutex::new(None),
             deterministic_layout_cache: Mutex::new(None),
+            fallback_layout_engine: Mutex::new(None),
         }
     }
 
@@ -625,6 +630,7 @@ impl Document {
             layout_cache: Mutex::new(None),
             normal_layout_engine: Mutex::new(None),
             deterministic_layout_cache: Mutex::new(None),
+            fallback_layout_engine: Mutex::new(None),
         })
     }
 
@@ -3323,7 +3329,39 @@ impl Document {
                 data: data.to_vec(),
             });
         }
-        Ok(rdocx_layout::layout_document_with_fallback_fonts_and_provenance(&input)?)
+        let mut engine = self
+            .fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let engine = match engine.as_mut() {
+            Some(engine) => engine,
+            None => {
+                *engine = Some(rdocx_layout::engine::Engine::new_deterministic()?);
+                engine.as_mut().expect("just inserted")
+            }
+        };
+        Ok(rdocx_layout::layout_document_with_fallback_fonts_engine(
+            engine, &input,
+        )?)
+    }
+
+    /// SVG PoC patch: hand the bundled-fallback engine (and its content-keyed
+    /// relayout caches) to a caller restoring an undo snapshot, so the
+    /// rebuilt Document does not go cache-cold. Interim shape until the
+    /// upstream F-X039 session/handle design lands.
+    pub fn take_layout_engine(&self) -> Option<rdocx_layout::engine::Engine> {
+        self.fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
+
+    /// SVG PoC patch: counterpart of [`Self::take_layout_engine`].
+    pub fn set_layout_engine(&self, engine: rdocx_layout::engine::Engine) {
+        *self
+            .fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(engine);
     }
 
     /// Render the document to PDF bytes.

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3541,7 +3541,10 @@ impl Document {
     /// Return a cloned positioned page from the cached normal-font layout.
     ///
     /// `page_index` is zero-based. An index beyond the document returns `None`.
-    pub fn layout_page(&self, page_index: usize) -> Result<Option<oxml_layout::PageFrame>> {
+    pub fn layout_page(
+        &self,
+        page_index: usize,
+    ) -> Result<Option<std::sync::Arc<oxml_layout::PageFrame>>> {
         self.layout_page_with_options(page_index, RenderOptions::default())
     }
 
@@ -3550,7 +3553,7 @@ impl Document {
         &self,
         page_index: usize,
         options: RenderOptions,
-    ) -> Result<Option<oxml_layout::PageFrame>> {
+    ) -> Result<Option<std::sync::Arc<oxml_layout::PageFrame>>> {
         let layout = self.layout_with_options(options)?;
         Ok(layout.layout.pages.get(page_index).cloned())
     }

--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -167,6 +167,24 @@ impl<'a> Paragraph<'a> {
         }
     }
 
+    /// SVG PoC patch: append a text run that inherits the paragraph mark's
+    /// run properties (pPr/rPr) — what Word gives to text typed into an
+    /// empty paragraph, so a form cell designed at 7pt does not sprout
+    /// default-sized text.
+    pub fn add_run_inheriting_mark(&mut self, text: &str) -> Run<'_> {
+        let props = self
+            .inner
+            .properties
+            .as_ref()
+            .and_then(|p| p.rpr.clone());
+        let mut r = CT_R::new(text);
+        r.properties = props;
+        self.inner.runs.push(r);
+        Run {
+            inner: self.inner.runs.last_mut().unwrap(),
+        }
+    }
+
     /// Add a line break in its own run.
     pub fn add_line_break(&mut self) {
         let mut run = CT_R::new("");

--- a/crates/rdocx/src/style.rs
+++ b/crates/rdocx/src/style.rs
@@ -48,6 +48,8 @@ impl StyleBuilder {
                 is_default: false,
                 ppr: None,
                 rpr: None,
+                tbl_pr_xml: None,
+                table_borders: None,
             },
         }
     }
@@ -64,6 +66,8 @@ impl StyleBuilder {
                 is_default: false,
                 ppr: None,
                 rpr: None,
+                tbl_pr_xml: None,
+                table_borders: None,
             },
         }
     }
@@ -219,6 +223,8 @@ mod tests {
                 color: Some("2E74B5".to_string()),
                 ..Default::default()
             }),
+            tbl_pr_xml: None,
+            table_borders: None,
         });
 
         styles


### PR DESCRIPTION
Fixes the seven defects described in #42, one review-sized commit per concern, stacked on #41 because the empty-paragraph metrics fix extends the zero-width segment introduced there:

- `83f761a` styles: preserve a table style's `<w:tblPr>` verbatim (round-trip fidelity) and parse its `tblBorders` into a typed view.
- `bf488f4` layout: keep nested tables as recursively rendered blocks; distribute vMerge spans with merged-span painting and crossing-border suppression; honour `hRule="exact"`; cascade table-style borders (basedOn chain) and table-style pPr between docDefaults and the paragraph style; give empty paragraphs real line metrics from the paragraph mark's rPr.
- `699ca61` borders: at the table's outer boundary a cell border of none/nil yields to the table-level border (Word behavior; interior edges keep spec suppression). Flagged in #42 for a fidelity decision.
- `8f7e142` anchors: render drawings anchored to cell paragraphs; behindDoc ones compose into the page's behind layer.
- `3ce76f9` api: `Paragraph::add_run_inheriting_mark` — text typed into an empty paragraph takes the paragraph mark's run properties, as Word does.

Tests: rdocx-layout 147 green (nested-table dimensions test updated to the new model), rdocx-oxml 275 green. Validated against a real hospital receipt (4 broken pages → Word's exact 1 page) and a 22-document corpus with reference-PDF page-count parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
