### PR TITLE
Honor caller-supplied family names for additional fonts (byte-free aliases)

### DIFF
--- a/crates/oxml-layout/src/font.rs
+++ b/crates/oxml-layout/src/font.rs
@@ -211,6 +211,12 @@ pub struct FontManager {
     /// something else -- e.g. an open Korean serif registered as "\uBC14\uD0D5".
     /// Rebuilt together with `additional_fonts`.
     caller_aliases: HashMap<String, String>,
+    /// Caller-declared aliases set via [`Self::set_caller_aliases`], exactly
+    /// as passed (for cheap change detection).
+    explicit_aliases: Vec<(String, String)>,
+    /// Lowercased requested-name -> target-family view of
+    /// `explicit_aliases`, consulted before the label-derived aliases.
+    explicit_alias_map: HashMap<String, String>,
     /// Bounded exact-key shaping results.
     shaping_memo: Mutex<ShapingMemo>,
     /// Exact resolution events for one cache-candidate paragraph.
@@ -280,6 +286,8 @@ impl FontManager {
             coverage_misses: HashSet::new(),
             additional_fonts: Vec::new(),
             caller_aliases: HashMap::new(),
+            explicit_aliases: Vec::new(),
+            explicit_alias_map: HashMap::new(),
             shaping_memo: Mutex::new(ShapingMemo::new()),
             paragraph_font_trace: None,
             layout_fonts: Vec::new(),
@@ -366,6 +374,27 @@ impl FontManager {
         let mut manager = Self::from_base_database(db);
         manager.caller_aliases = aliases;
         manager
+    }
+
+    /// Replace the caller-declared requested-name -> family aliases.
+    ///
+    /// Unlike [`Self::load_additional_fonts`] this carries no font bytes, so
+    /// an arbitrarily large alias set stays cheap to pass on every layout.
+    /// An unchanged set is a no-op; a changed set clears resolution state,
+    /// because names may now resolve to different faces.
+    pub fn set_caller_aliases(&mut self, aliases: &[(String, String)]) -> bool {
+        if self.explicit_aliases == aliases {
+            return false;
+        }
+        self.explicit_aliases = aliases.to_vec();
+        self.explicit_alias_map = aliases
+            .iter()
+            .map(|(requested, target)| (requested.to_lowercase(), target.clone()))
+            .collect();
+        self.cache.clear();
+        self.coverage_fallbacks.clear();
+        self.coverage_misses.clear();
+        true
     }
 
     /// Load one caller-provided font and remember its requested family name
@@ -697,8 +726,13 @@ impl FontManager {
         let mapped = map_font_name(family_name);
 
         // A caller-provided font registered under this name wins right after
-        // the exact match (see `caller_aliases`).
-        let caller_alias = self.caller_aliases.get(&family_name.to_lowercase()).cloned();
+        // the exact match (see `caller_aliases` / `explicit_alias_map`).
+        let requested_key = family_name.to_lowercase();
+        let caller_alias = self
+            .explicit_alias_map
+            .get(&requested_key)
+            .or_else(|| self.caller_aliases.get(&requested_key))
+            .cloned();
 
         // Try the requested font, mapped alternatives, then generic fallbacks
         let mut fallbacks: Vec<&str> = Vec::with_capacity(10);
@@ -1190,6 +1224,20 @@ mod tests {
             data: caladea.to_vec(),
         }]);
         assert!(fm.caller_aliases.is_empty());
+
+        // Explicit aliases carry no bytes and resolve the same way.
+        assert!(fm.set_caller_aliases(&[(
+            "\u{bc14}\u{d0d5}".to_string(),
+            "Caladea".to_string(),
+        )]));
+        let id = fm.resolve_font(Some("\u{bc14}\u{d0d5}"), false, false).unwrap();
+        let idx = fm.index_of(id).unwrap();
+        assert_eq!(fm.fonts[idx].family, "Caladea");
+        // Unchanged set is a no-op.
+        assert!(!fm.set_caller_aliases(&[(
+            "\u{bc14}\u{d0d5}".to_string(),
+            "Caladea".to_string(),
+        )]));
     }
 
     fn font_with_family(source: &[u8], family: &str) -> Vec<u8> {

--- a/crates/oxml-layout/src/font.rs
+++ b/crates/oxml-layout/src/font.rs
@@ -202,6 +202,15 @@ pub struct FontManager {
     coverage_misses: HashSet<char>,
     /// Exact additional font set currently loaded into `db`.
     additional_fonts: Vec<FontFile>,
+    /// Requested-name -> real-family aliases for caller-provided fonts.
+    ///
+    /// Callers hand fonts over as `(family_name, bytes)` pairs, but fontdb
+    /// only knows a face by the family recorded inside the file. Remembering
+    /// the caller's label (lowercased) lets a document that asks for that
+    /// name resolve to the supplied face even though the file calls itself
+    /// something else -- e.g. an open Korean serif registered as "\uBC14\uD0D5".
+    /// Rebuilt together with `additional_fonts`.
+    caller_aliases: HashMap<String, String>,
     /// Bounded exact-key shaping results.
     shaping_memo: Mutex<ShapingMemo>,
     /// Exact resolution events for one cache-candidate paragraph.
@@ -270,6 +279,7 @@ impl FontManager {
             coverage_fallbacks: HashMap::new(),
             coverage_misses: HashSet::new(),
             additional_fonts: Vec::new(),
+            caller_aliases: HashMap::new(),
             shaping_memo: Mutex::new(ShapingMemo::new()),
             paragraph_font_trace: None,
             layout_fonts: Vec::new(),
@@ -317,8 +327,14 @@ impl FontManager {
         }
 
         self.db = self.base_db.clone();
+        self.caller_aliases.clear();
         for font_file in font_files {
-            self.db.load_font_data(font_file.data.clone());
+            Self::load_caller_font(
+                &mut self.db,
+                &mut self.caller_aliases,
+                &font_file.family,
+                font_file.data.clone(),
+            );
         }
         self.cache.clear();
         self.memory_face_data.clear();
@@ -343,10 +359,34 @@ impl FontManager {
     /// where system fonts are not available, such as WASM.
     pub fn new_with_fonts(fonts: Vec<(String, Vec<u8>)>) -> Self {
         let mut db = fontdb::Database::new();
-        for (_name, data) in &fonts {
-            db.load_font_data(data.clone());
+        let mut aliases = HashMap::new();
+        for (name, data) in &fonts {
+            Self::load_caller_font(&mut db, &mut aliases, name, data.clone());
         }
-        Self::from_base_database(db)
+        let mut manager = Self::from_base_database(db);
+        manager.caller_aliases = aliases;
+        manager
+    }
+
+    /// Load one caller-provided font and remember its requested family name
+    /// as an alias when the face's own family differs.
+    fn load_caller_font(
+        db: &mut fontdb::Database,
+        aliases: &mut HashMap<String, String>,
+        family: &str,
+        data: Vec<u8>,
+    ) {
+        let before = db.len();
+        db.load_font_data(data);
+        let real = db
+            .faces()
+            .skip(before)
+            .find_map(|face| face.families.first().map(|(name, _)| name.clone()));
+        if let Some(real) = real {
+            if !real.eq_ignore_ascii_case(family) {
+                aliases.insert(family.to_lowercase(), real);
+            }
+        }
     }
 
     /// Begin one complete layout attempt's exact font-usage trace.
@@ -656,9 +696,18 @@ impl FontManager {
         // Map common Word font names to metric-compatible alternatives
         let mapped = map_font_name(family_name);
 
+        // A caller-provided font registered under this name wins right after
+        // the exact match (see `caller_aliases`).
+        let caller_alias = self.caller_aliases.get(&family_name.to_lowercase()).cloned();
+
         // Try the requested font, mapped alternatives, then generic fallbacks
         let mut fallbacks: Vec<&str> = Vec::with_capacity(10);
         fallbacks.push(family_name);
+        if let Some(alias) = caller_alias.as_deref() {
+            if alias != family_name {
+                fallbacks.push(alias);
+            }
+        }
         for alt in mapped {
             if *alt != family_name {
                 fallbacks.push(alt);
@@ -1115,6 +1164,33 @@ fn map_font_name(name: &str) -> &[&str] {
 mod tests {
     use super::*;
     use crate::bundled_fonts::bundled_font_data;
+
+    #[test]
+    fn caller_font_label_becomes_an_alias() {
+        // A caller registers Caladea bytes under a Korean family name the
+        // face itself does not carry; resolving that name must pick the
+        // supplied face instead of drifting to the generic fallbacks.
+        let mut fm = FontManager::new_deterministic().unwrap();
+        let caladea = bundled_font_data()
+            .into_iter()
+            .find(|(family, _)| *family == "Caladea")
+            .expect("Caladea is bundled")
+            .1;
+        fm.load_additional_fonts(&[FontFile {
+            family: "\u{bc14}\u{d0d5}".to_string(), // 바탕
+            data: caladea.to_vec(),
+        }]);
+        let id = fm.resolve_font(Some("\u{bc14}\u{d0d5}"), false, false).unwrap();
+        let idx = fm.index_of(id).unwrap();
+        assert_eq!(fm.fonts[idx].family, "Caladea");
+
+        // A label matching the face's own family stores no alias.
+        fm.load_additional_fonts(&[FontFile {
+            family: "Caladea".to_string(),
+            data: caladea.to_vec(),
+        }]);
+        assert!(fm.caller_aliases.is_empty());
+    }
 
     fn font_with_family(source: &[u8], family: &str) -> Vec<u8> {
         assert_eq!(family.len(), 7);

--- a/crates/rdocx-layout/src/engine.rs
+++ b/crates/rdocx-layout/src/engine.rs
@@ -404,6 +404,9 @@ pub struct Engine {
     #[cfg(test)]
     pending_paragraph_cache_peak_bytes: usize,
     paragraph_cache_reads_enabled: bool,
+    /// Requested-name -> family aliases forwarded to the font manager on
+    /// every layout (no bytes; see FontManager::set_caller_aliases).
+    caller_font_aliases: Vec<(String, String)>,
     table_cache: VecDeque<TableCacheEntry>,
     table_cache_bytes: usize,
     table_cache_hits: usize,
@@ -633,6 +636,7 @@ impl Engine {
             #[cfg(test)]
             pending_paragraph_cache_peak_bytes: 0,
             paragraph_cache_reads_enabled: false,
+            caller_font_aliases: Vec::new(),
             table_cache: VecDeque::new(),
             table_cache_bytes: 0,
             table_cache_hits: 0,
@@ -658,6 +662,14 @@ impl Engine {
             #[cfg(test)]
             last_rebuilt_page_range: None,
         }
+    }
+
+    /// Set the requested-name -> family font aliases consulted during
+    /// resolution. Carries no font bytes, so passing a large mapping every
+    /// layout is cheap; a change invalidates font-derived caches on the
+    /// next layout.
+    pub fn set_caller_font_aliases(&mut self, aliases: Vec<(String, String)>) {
+        self.caller_font_aliases = aliases;
     }
 
     pub fn new() -> Self {
@@ -710,7 +722,10 @@ impl Engine {
     ) -> Result<LayoutResult> {
         // Load user-provided / DOCX-embedded fonts (highest priority). An exact
         // unchanged set is a no-op in a reusable engine.
-        let fonts_changed = self.font_manager.load_additional_fonts(&input.fonts);
+        let fonts_changed = self.font_manager.load_additional_fonts(&input.fonts)
+            | self
+                .font_manager
+                .set_caller_aliases(&self.caller_font_aliases);
         self.font_manager.begin_layout();
 
         let paragraph_context = ReusableEngineContext::for_input(input);

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3456,6 +3456,38 @@ impl Document {
         )?)
     }
 
+    /// Like [`Self::layout_with_fonts_and_bundled_fallback`], plus
+    /// requested-name -> family font aliases. Aliases carry no font bytes:
+    /// a caller can register one open font and point many document-facing
+    /// family names (e.g. 바탕, 굴림) at it without duplicating data on
+    /// every layout.
+    pub fn layout_with_fonts_aliases_and_bundled_fallback(
+        &self,
+        font_files: &[(&str, &[u8])],
+        font_aliases: &[(&str, &str)],
+    ) -> Result<rdocx_layout::WordLayoutResult> {
+        let input = self.build_layout_input_with_fonts(font_files, RenderOptions::default());
+        #[cfg(test)]
+        record_layout_invocation();
+        let mut engine = self
+            .bundled_fallback_layout_engine
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let engine = match engine.as_mut() {
+            Some(engine) => engine,
+            None => engine.insert(rdocx_layout::engine::Engine::new_deterministic()?),
+        };
+        engine.set_caller_font_aliases(
+            font_aliases
+                .iter()
+                .map(|(requested, target)| (requested.to_string(), target.to_string()))
+                .collect(),
+        );
+        Ok(rdocx_layout::layout_document_with_reusable_engine(
+            engine, &input,
+        )?)
+    }
+
     fn build_layout_input_with_fonts(
         &self,
         font_files: &[(&str, &[u8])],


### PR DESCRIPTION
Closes #44.

Two commits, as offered in the issue, rebased onto current `main` (post-S52):

1. **Honor the caller-supplied family name for additional fonts** — `load_additional_fonts` now remembers requested-name → real-family aliases for caller fonts and tries the alias in `resolve_font` right after the exact name, before `map_font_name` and the generic fallbacks. A label equal to the face's own family stores nothing, so existing callers are unaffected. Includes the unit test from the issue's repro (바탕 label on bundled Caladea resolves to Caladea, not Carlito).

2. **Pass caller font aliases without duplicating font bytes** — expressing one open font under many document-facing names by repeating `FontFile` entries clones the font bytes per alias (~100MB per relayout with a realistic Korean alias set; editor keystrokes regressed 70ms → ~200ms). Adds byte-free `FontManager::set_caller_aliases(&[(String, String)])` (unchanged set = no-op; a change invalidates resolution state and folds into the existing `fonts_changed` cache boundary), `Engine::set_caller_font_aliases`, and `Document::layout_with_fonts_aliases_and_bundled_fallback`.

Adaptation notes for this base: the Engine struct fields sit alongside the S52 table/header-footer caches, and the new `Document` method follows the bundled-fallback engine path (mutex + `layout_document_with_reusable_engine`) that `layout_with_fonts_and_bundled_fallback_and_options` uses.

Tests on this branch: oxml-layout 78 passed, rdocx-layout 153 passed, rdocx 161 passed (3 pre-existing failures on my machine are the shasum-dependent chart/comment recording tests — missing external `shasum` binary, unrelated to this change).

Both commits run in production in the [rdoc online demo](https://emptinessform.github.io/rdoc/) (Pretendard + NanumMyeongjo served under Korean family names this way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)