### PR TITLE
Expose ordered table cell items

### DIFF
--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -66,7 +66,7 @@ pub use revision::{RevisionKind, RevisionRef};
 pub use rtf::{RtfDiagnostic, RtfReadResult, RtfWriteResult};
 pub use run::{Run, RunRef, UnderlineStyle};
 pub use style::{Style, StyleBuilder};
-pub use table::{Cell, CellRef, Row, RowRef, Table, TableRef, VerticalAlignment};
+pub use table::{Cell, CellItemRef, CellRef, Row, RowRef, Table, TableRef, VerticalAlignment};
 
 #[cfg(test)]
 mod tests {

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -5,11 +5,12 @@ use rdocx_oxml::properties::CT_Shd;
 use rdocx_oxml::shared::ST_Jc;
 use rdocx_oxml::table::{
     CT_Row, CT_Tbl, CT_TblBorders, CT_TblCellMar, CT_TblPr, CT_TblWidth, CT_Tc, CT_TcPr, CT_TrPr,
-    ST_VerticalJc, VMerge,
+    CellContent, ST_VerticalJc, VMerge,
 };
 use rdocx_oxml::text::CT_P;
 
 use crate::Length;
+use crate::content_control::ContentControlRef;
 use crate::paragraph::{Paragraph, ParagraphRef};
 
 /// Vertical alignment within a table cell.
@@ -676,10 +677,51 @@ pub struct CellRef<'a> {
     pub(crate) inner: &'a CT_Tc,
 }
 
+/// One direct child of a table cell, in source order.
+pub enum CellItemRef<'a> {
+    /// A cell paragraph.
+    Paragraph(ParagraphRef<'a>),
+    /// A nested table.
+    Table(TableRef<'a>),
+    /// A cell-level content control.
+    ContentControl(ContentControlRef<'a>),
+    /// A preserved cell child that rdocx does not model.
+    UnsupportedXml(&'a [u8]),
+}
+
 impl<'a> CellRef<'a> {
     /// Get the combined text of all paragraphs.
     pub fn text(&self) -> String {
         self.inner.text()
+    }
+
+    /// Iterate over direct cell items in source order.
+    ///
+    /// Unlike [`Self::paragraphs`], this retains nested tables, content
+    /// controls, and preserved unmodelled XML at their original boundaries.
+    pub fn items(&self) -> impl Iterator<Item = CellItemRef<'_>> {
+        let mut items = Vec::with_capacity(self.inner.content.len() + self.inner.extra_xml.len());
+        for index in 0..=self.inner.content.len() {
+            items.extend(
+                self.inner
+                    .extra_xml
+                    .iter()
+                    .filter(|(at, _)| *at == index)
+                    .map(|(_, raw)| CellItemRef::UnsupportedXml(raw.as_slice())),
+            );
+            if let Some(content) = self.inner.content.get(index) {
+                items.push(match content {
+                    CellContent::Paragraph(paragraph) => {
+                        CellItemRef::Paragraph(ParagraphRef { inner: paragraph })
+                    }
+                    CellContent::Table(table) => CellItemRef::Table(TableRef { inner: table }),
+                    CellContent::ContentControl(control) => {
+                        CellItemRef::ContentControl(ContentControlRef { inner: control })
+                    }
+                });
+            }
+        }
+        items.into_iter()
     }
 
     /// Get paragraph references.
@@ -746,6 +788,41 @@ mod tests {
     use super::*;
     use rdocx_oxml::table::{CT_Row, CT_TblGrid, CT_TblGridCol};
     use rdocx_oxml::units::Twips;
+
+    #[test]
+    fn cell_items_preserve_paragraph_table_control_and_raw_order() {
+        let xml = br#"<w:tc xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="urn:foreign"><w:p><w:r><w:t>first</w:t></w:r></w:p><x:raw/><w:tbl><w:tr><w:tc><w:p><w:r><w:t>nested</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:sdt><w:sdtContent><w:p><w:r><w:t>inside</w:t></w:r></w:p></w:sdtContent></w:sdt><w:p><w:r><w:t>last</w:t></w:r></w:p></w:tc>"#;
+        let mut reader = quick_xml::Reader::from_reader(xml.as_slice());
+        let mut buffer = Vec::new();
+        let cell = match reader.read_event_into(&mut buffer).unwrap() {
+            quick_xml::events::Event::Start(_) => CT_Tc::from_xml(&mut reader).unwrap(),
+            event => panic!("expected cell start, got {event:?}"),
+        };
+        let cell = CellRef { inner: &cell };
+
+        let items = cell
+            .items()
+            .map(|item| match item {
+                CellItemRef::Paragraph(paragraph) => format!("paragraph:{}", paragraph.text()),
+                CellItemRef::Table(table) => format!("table:{}", table.row_count()),
+                CellItemRef::ContentControl(control) => format!("control:{}", control.text()),
+                CellItemRef::UnsupportedXml(raw) => {
+                    format!("raw:{}", std::str::from_utf8(raw).unwrap())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            items,
+            [
+                "paragraph:first",
+                "raw:<x:raw/>",
+                "table:1",
+                "control:inside",
+                "paragraph:last",
+            ]
+        );
+    }
 
     #[test]
     fn table_column_width_updates_grid_table_and_spanning_cells() {


### PR DESCRIPTION
## Summary

- add the additive `CellRef::items()` reader API and public `CellItemRef` variants
- retain direct cell ordering across paragraphs, nested tables, content controls, and preserved unmodelled XML
- cover the complete interleaving with a regression test

This is the next narrow slice after #36. It does not change parsing or writing behavior.

## Semver

Additive public API only.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rdocx cell_items_preserve_paragraph_table_control_and_raw_order`
- `cargo clippy -p rdocx --all-targets --all-features -- -D warnings`
- `cargo test -p rdocx`

The full suite had 205 passing tests and two expected manual skips. `word_and_powerpoint_chart_pixels_are_identical` is blocked locally because the installed rasterizer differs from the repository-pinned `RASTERIZER` value.