### PR TITLE
Expose unsupported XML reader facts

### DIFF
--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -42,6 +42,7 @@ use crate::paragraph::{Paragraph, ParagraphRef};
 use crate::revision::RevisionRef;
 use crate::style::{self, Style, StyleBuilder};
 use crate::table::{Table, TableRef};
+use crate::unsupported_xml::{UnsupportedXmlRef, WORD_NAMESPACE};
 
 /// Options that select a native document render projection.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -60,6 +61,16 @@ pub enum BodyItemRef<'a> {
     ContentControl(ContentControlRef<'a>),
     /// A preserved body child that rdocx does not model.
     UnsupportedXml(&'a [u8]),
+}
+
+/// One body child exposed through the compatibility reader facade.
+pub enum BodyContentRef<'a> {
+    /// A body paragraph.
+    Paragraph(ParagraphRef<'a>),
+    /// A body table.
+    Table(TableRef<'a>),
+    /// Content that the compatibility facade does not model.
+    UnsupportedXml(UnsupportedXmlRef<'a>),
 }
 
 /// A Word document (.docx file).
@@ -1084,6 +1095,24 @@ impl Document {
                 BodyItemRef::ContentControl(ContentControlRef { inner: control })
             }
             BodyContent::RawXml(raw) => BodyItemRef::UnsupportedXml(raw),
+        })
+    }
+
+    /// Iterate over paragraphs, tables, and unsupported content in body order.
+    ///
+    /// This compatibility facade deliberately reports content controls as an
+    /// unsupported WordprocessingML fact. It therefore cannot silently erase a
+    /// construct that older readers did not model.
+    pub fn body_content(&self) -> impl Iterator<Item = BodyContentRef<'_>> {
+        self.document.body.content.iter().map(|item| match item {
+            BodyContent::Paragraph(paragraph) => {
+                BodyContentRef::Paragraph(ParagraphRef { inner: paragraph })
+            }
+            BodyContent::Table(table) => BodyContentRef::Table(TableRef { inner: table }),
+            BodyContent::ContentControl(_) => {
+                BodyContentRef::UnsupportedXml(UnsupportedXmlRef::modeled(WORD_NAMESPACE, "sdt"))
+            }
+            BodyContent::RawXml(raw) => BodyContentRef::UnsupportedXml(UnsupportedXmlRef::new(raw)),
         })
     }
 
@@ -5397,6 +5426,28 @@ mod tests {
                 "table",
                 "raw:<w:custom/>",
                 "control:inside",
+                "paragraph:last",
+            ]
+        );
+
+        let compatibility_items = doc
+            .body_content()
+            .map(|item| match item {
+                BodyContentRef::Paragraph(paragraph) => format!("paragraph:{}", paragraph.text()),
+                BodyContentRef::Table(_) => "table".to_owned(),
+                BodyContentRef::UnsupportedXml(xml) => {
+                    format!("unsupported:{}", xml.local_name())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            compatibility_items,
+            [
+                "paragraph:first",
+                "table",
+                "unsupported:custom",
+                "unsupported:sdt",
                 "paragraph:last",
             ]
         );

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -35,13 +35,14 @@ pub mod run;
 pub mod style;
 pub mod table;
 mod template;
+mod unsupported_xml;
 
 pub use comments::{BookmarkRef, CommentRef, RunPosition, RunRange};
 pub use comparison::ComparisonDiagnostic;
 pub use content_control::ContentControlRef;
 pub use document::{
-    AccessibilityIssue, BodyItemRef, Document, ImageInfo, IssueSeverity, LinkInfo, ListLevel,
-    ListNumberFormat, OutlineNode, RenderOptions,
+    AccessibilityIssue, BodyContentRef, BodyItemRef, Document, ImageInfo, IssueSeverity, LinkInfo,
+    ListLevel, ListNumberFormat, OutlineNode, RenderOptions,
 };
 pub use error::{Error, Result};
 pub use field::{FieldDateTime, FieldEvaluation, FieldEvaluationContext, FieldOutcome};
@@ -67,6 +68,7 @@ pub use rtf::{RtfDiagnostic, RtfReadResult, RtfWriteResult};
 pub use run::{Run, RunRef, UnderlineStyle};
 pub use style::{Style, StyleBuilder};
 pub use table::{Cell, CellRef, Row, RowRef, Table, TableRef, VerticalAlignment};
+pub use unsupported_xml::UnsupportedXmlRef;
 
 #[cfg(test)]
 mod tests {

--- a/crates/rdocx/src/unsupported_xml.rs
+++ b/crates/rdocx/src/unsupported_xml.rs
@@ -1,0 +1,194 @@
+//! Borrowed access to XML the high-level facade does not expose semantically.
+
+use std::ops::Deref;
+
+/// WordprocessingML namespace URI.
+pub(crate) const WORD_NAMESPACE: &str =
+    "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+enum UnsupportedXmlSource<'a> {
+    Raw(&'a [u8]),
+    Modeled {
+        namespace_uri: &'static str,
+        local_name: &'static str,
+    },
+}
+
+/// A preserved XML subtree, or a modeled construct retained as an unsupported
+/// reader fact for a compatibility iterator.
+pub struct UnsupportedXmlRef<'a> {
+    source: UnsupportedXmlSource<'a>,
+}
+
+impl<'a> UnsupportedXmlRef<'a> {
+    pub(crate) fn new(raw: &'a [u8]) -> Self {
+        Self {
+            source: UnsupportedXmlSource::Raw(raw),
+        }
+    }
+
+    pub(crate) fn modeled(namespace_uri: &'static str, local_name: &'static str) -> Self {
+        Self {
+            source: UnsupportedXmlSource::Modeled {
+                namespace_uri,
+                local_name,
+            },
+        }
+    }
+
+    /// Original subtree bytes.
+    ///
+    /// Modeled compatibility facts have no preserved raw subtree and return an
+    /// empty slice. Consumers should use [`Self::local_name`] and
+    /// [`Self::namespace_uri`] to classify those facts.
+    pub fn bytes(&self) -> &'a [u8] {
+        match self.source {
+            UnsupportedXmlSource::Raw(raw) => raw,
+            UnsupportedXmlSource::Modeled { .. } => &[],
+        }
+    }
+
+    /// Qualified element name as it appears in preserved XML.
+    ///
+    /// Modeled compatibility facts return their local name.
+    pub fn qualified_name(&self) -> &str {
+        match self.source {
+            UnsupportedXmlSource::Raw(raw) => first_element_name(raw),
+            UnsupportedXmlSource::Modeled { local_name, .. } => local_name,
+        }
+    }
+
+    /// Local element name.
+    pub fn local_name(&self) -> &str {
+        match self.source {
+            UnsupportedXmlSource::Raw(raw) => first_element_name(raw)
+                .rsplit_once(':')
+                .map(|(_, local)| local)
+                .unwrap_or_else(|| first_element_name(raw)),
+            UnsupportedXmlSource::Modeled { local_name, .. } => local_name,
+        }
+    }
+
+    /// Namespace URI declared on the preserved subtree's root element.
+    ///
+    /// A captured subtree cannot retain declarations inherited from its parent,
+    /// so this returns `None` when that declaration is outside the subtree.
+    /// Callers must treat that as unclassified content rather than assuming a
+    /// namespace.
+    pub fn namespace_uri(&self) -> Option<&str> {
+        match self.source {
+            UnsupportedXmlSource::Raw(raw) => {
+                let name = first_element_name(raw);
+                let prefix = name.split_once(':').map_or("", |(prefix, _)| prefix);
+                namespace_declaration(raw, prefix)
+            }
+            UnsupportedXmlSource::Modeled { namespace_uri, .. } => Some(namespace_uri),
+        }
+    }
+
+    /// Whether the preserved element has nested elements or non-whitespace text.
+    pub fn has_child_content(&self) -> bool {
+        match self.source {
+            UnsupportedXmlSource::Raw(raw) => {
+                let Some(start_end) = raw.iter().position(|byte| *byte == b'>') else {
+                    return false;
+                };
+                let content = &raw[start_end + 1..];
+                content.starts_with(b"<") && !content.starts_with(b"</")
+                    || content
+                        .iter()
+                        .any(|byte| !byte.is_ascii_whitespace() && *byte != b'<')
+            }
+            UnsupportedXmlSource::Modeled { .. } => true,
+        }
+    }
+}
+
+impl AsRef<[u8]> for UnsupportedXmlRef<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes()
+    }
+}
+
+impl Deref for UnsupportedXmlRef<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.bytes()
+    }
+}
+
+fn first_element_name(raw: &[u8]) -> &str {
+    let start = raw
+        .iter()
+        .position(|byte| *byte == b'<')
+        .map_or(0, |index| index + 1);
+    let end = raw[start..]
+        .iter()
+        .position(|byte| byte.is_ascii_whitespace() || matches!(*byte, b'/' | b'>'))
+        .map_or(raw.len(), |index| start + index);
+    std::str::from_utf8(&raw[start..end]).unwrap_or("")
+}
+
+fn namespace_declaration<'a>(raw: &'a [u8], prefix: &str) -> Option<&'a str> {
+    let start_end = raw.iter().position(|byte| *byte == b'>')?;
+    let declaration = if prefix.is_empty() {
+        "xmlns".to_owned()
+    } else {
+        format!("xmlns:{prefix}")
+    };
+    let bytes = declaration.as_bytes();
+    let mut index = 0;
+    while index + bytes.len() < start_end {
+        let found = raw[index..start_end]
+            .windows(bytes.len())
+            .position(|candidate| candidate == bytes)?;
+        let name_start = index + found;
+        let name_end = name_start + bytes.len();
+        let valid_before = name_start == 0 || raw[name_start - 1].is_ascii_whitespace();
+        let valid_after =
+            name_end < start_end && (raw[name_end].is_ascii_whitespace() || raw[name_end] == b'=');
+        if valid_before && valid_after {
+            let equals = raw[name_end..start_end]
+                .iter()
+                .position(|byte| *byte == b'=')
+                .map(|offset| name_end + offset)?;
+            let quote = *raw.get(equals + 1)?;
+            if !matches!(quote, b'\'' | b'\"') {
+                return None;
+            }
+            let value_start = equals + 2;
+            let value_end = raw[value_start..start_end]
+                .iter()
+                .position(|byte| *byte == quote)
+                .map(|offset| value_start + offset)?;
+            return std::str::from_utf8(&raw[value_start..value_end]).ok();
+        }
+        index = name_end;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_fact_reports_its_declared_name_and_namespace() {
+        let fact = UnsupportedXmlRef::new(br#"<x:item xmlns:x="urn:example"><x:child/></x:item>"#);
+
+        assert_eq!(fact.qualified_name(), "x:item");
+        assert_eq!(fact.local_name(), "item");
+        assert_eq!(fact.namespace_uri(), Some("urn:example"));
+        assert!(fact.has_child_content());
+    }
+
+    #[test]
+    fn modeled_fact_has_identity_without_fabricating_xml() {
+        let fact = UnsupportedXmlRef::modeled(WORD_NAMESPACE, "sdt");
+
+        assert_eq!(fact.bytes(), b"");
+        assert_eq!(fact.local_name(), "sdt");
+        assert_eq!(fact.namespace_uri(), Some(WORD_NAMESPACE));
+    }
+}


### PR DESCRIPTION
## Summary

- add `UnsupportedXmlRef`, which exposes preserved raw XML with qualified name, local name, namespace, and child-content facts
- add `Document::body_content()` for compatibility consumers that need body order and explicit unsupported content
- preserve the existing `body_items()` API unchanged
- cover raw XML and content-control classification in a public body-order regression

This allows fail-closed readers to classify content they cannot model without dropping it silently.

## Semver

Additive public API only.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rdocx body_items_preserve_paragraph_table_control_and_raw_order`
- `cargo test -p rdocx unsupported_xml`
- `cargo clippy -p rdocx --all-targets --all-features -- -D warnings`