### PR TITLE
Preserve producer-defined numbering formats

### DIFF
--- a/crates/rdocx-html/src/emitter.rs
+++ b/crates/rdocx-html/src/emitter.rs
@@ -155,7 +155,7 @@ fn detect_list(para: &CT_P, numbering: Option<&CT_Numbering>) -> Option<(bool, u
     let level = abstract_num.levels.iter().find(|l| l.ilvl == ilvl)?;
 
     let is_ordered = !matches!(
-        level.num_fmt,
+        level.num_fmt.as_ref(),
         Some(rdocx_oxml::numbering::ST_NumberFormat::Bullet)
     );
 

--- a/crates/rdocx-html/src/markdown.rs
+++ b/crates/rdocx-html/src/markdown.rs
@@ -86,7 +86,7 @@ fn detect_list(para: &CT_P, numbering: Option<&CT_Numbering>) -> Option<(bool, u
     let level = abstract_num.levels.iter().find(|l| l.ilvl == ilvl)?;
 
     let is_ordered = !matches!(
-        level.num_fmt,
+        level.num_fmt.as_ref(),
         Some(rdocx_oxml::numbering::ST_NumberFormat::Bullet)
     );
 

--- a/crates/rdocx-layout/src/style_resolver.rs
+++ b/crates/rdocx-layout/src/style_resolver.rs
@@ -205,7 +205,7 @@ pub fn generate_marker(
     // sequence at every block, so a two item list rendered as "1." twice.
     let counter_id = abs.abstract_num_id;
 
-    let num_fmt = lvl.num_fmt.unwrap_or(ST_NumberFormat::Decimal);
+    let num_fmt = lvl.num_fmt.clone().unwrap_or(ST_NumberFormat::Decimal);
     let start = lvl.start.unwrap_or(1);
     let lvl_text = lvl.lvl_text.as_deref().unwrap_or("%1.");
 
@@ -253,7 +253,7 @@ fn format_lvl_text(
                 .levels
                 .iter()
                 .find(|l| l.ilvl == lvl_idx)
-                .and_then(|l| l.num_fmt)
+                .and_then(|l| l.num_fmt.clone())
                 .unwrap_or(ST_NumberFormat::Decimal);
             let formatted = format_number(count, fmt);
             result = result.replace(&placeholder, &formatted);
@@ -271,7 +271,9 @@ fn format_number(n: u32, fmt: ST_NumberFormat) -> String {
         ST_NumberFormat::UpperLetter => to_letter(n, true),
         ST_NumberFormat::LowerLetter => to_letter(n, false),
         ST_NumberFormat::Ordinal => format!("{n}"),
-        ST_NumberFormat::Bullet | ST_NumberFormat::None => String::new(),
+        ST_NumberFormat::Bullet | ST_NumberFormat::None | ST_NumberFormat::Other(_) => {
+            String::new()
+        }
     }
 }
 

--- a/crates/rdocx-oxml/src/numbering.rs
+++ b/crates/rdocx-oxml/src/numbering.rs
@@ -2063,7 +2063,7 @@ fn write_level_property<W: std::io::Write>(
 }
 
 /// `ST_NumberFormat` — Numbering format type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ST_NumberFormat {
     Decimal,
     UpperRoman,
@@ -2073,6 +2073,8 @@ pub enum ST_NumberFormat {
     Ordinal,
     Bullet,
     None,
+    /// A producer-defined format value that rdocx does not model.
+    Other(String),
 }
 
 /// The character or layout item that follows a numbering level marker.
@@ -2113,11 +2115,11 @@ impl ST_NumberFormat {
             "ordinal" => Self::Ordinal,
             "bullet" => Self::Bullet,
             "none" => Self::None,
-            _ => Self::Decimal,
+            _ => Self::Other(s.to_owned()),
         }
     }
 
-    pub fn to_str(self) -> &'static str {
+    pub fn to_str(&self) -> &str {
         match self {
             Self::Decimal => "decimal",
             Self::UpperRoman => "upperRoman",
@@ -2127,6 +2129,7 @@ impl ST_NumberFormat {
             Self::Ordinal => "ordinal",
             Self::Bullet => "bullet",
             Self::None => "none",
+            Self::Other(value) => value,
         }
     }
 }
@@ -2350,7 +2353,7 @@ impl CT_Lvl {
         }
 
         write_extras_at(writer, &self.extra_xml, 1)?;
-        if let Some(fmt) = self.num_fmt {
+        if let Some(fmt) = &self.num_fmt {
             let name = qualified(word_prefix, "numFmt");
             let val_name = qualified(word_prefix, "val");
             let mut e = BytesStart::new(name.as_str());
@@ -2961,10 +2964,10 @@ impl CT_Numbering {
         for i in 0..9u32 {
             let (num_fmt, start) = match levels.get(i as usize) {
                 Some((fmt, start)) => {
-                    last_specified = *fmt;
-                    (*fmt, start.unwrap_or(1))
+                    last_specified = fmt.clone();
+                    (fmt.clone(), start.unwrap_or(1))
                 }
-                None => (level_fill_format(last_specified, i), 1),
+                None => (level_fill_format(&last_specified, i), 1),
             };
 
             abs.levels.push(build_level(i, num_fmt, start));
@@ -3076,10 +3079,10 @@ const NUMBERED_FORMATS: [ST_NumberFormat; 9] = [
 /// Template format for an unspecified level, keyed on the last format the
 /// caller did specify: bullets stay bullets; anything numeric continues the
 /// numbered rotation.
-fn level_fill_format(last_specified: ST_NumberFormat, ilvl: u32) -> ST_NumberFormat {
+fn level_fill_format(last_specified: &ST_NumberFormat, ilvl: u32) -> ST_NumberFormat {
     match last_specified {
         ST_NumberFormat::Bullet => ST_NumberFormat::Bullet,
-        _ => NUMBERED_FORMATS[ilvl as usize % NUMBERED_FORMATS.len()],
+        _ => NUMBERED_FORMATS[ilvl as usize % NUMBERED_FORMATS.len()].clone(),
     }
 }
 
@@ -3088,11 +3091,11 @@ fn level_fill_format(last_specified: ST_NumberFormat, ilvl: u32) -> ST_NumberFor
 fn build_level(ilvl: u32, num_fmt: ST_NumberFormat, start: u32) -> CT_Lvl {
     let mut lvl = CT_Lvl::new(ilvl);
     lvl.start = Some(start);
-    lvl.num_fmt = Some(num_fmt);
     lvl.lvl_text = Some(match num_fmt {
         ST_NumberFormat::Bullet => BULLET_CHARS[ilvl as usize % BULLET_CHARS.len()].to_string(),
         _ => format!("%{}.", ilvl + 1),
     });
+    lvl.num_fmt = Some(num_fmt);
     lvl.lvl_jc = Some(ST_Jc::Left);
 
     // Standard indentation: 720tw per level
@@ -3146,6 +3149,23 @@ mod tests {
         assert_eq!(abs.levels[0].num_fmt, Some(ST_NumberFormat::Decimal));
         assert_eq!(abs.levels[0].lvl_text, Some("%1.".to_string()));
         assert_eq!(abs.levels[1].num_fmt, Some(ST_NumberFormat::LowerLetter));
+    }
+
+    #[test]
+    fn producer_defined_number_format_round_trips_without_substitution() {
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:numFmt w:val="chicago"/></w:lvl></w:abstractNum></w:numbering>"#;
+
+        let numbering = CT_Numbering::from_xml(xml).unwrap();
+        assert_eq!(
+            numbering.abstract_nums[0].levels[0].num_fmt,
+            Some(ST_NumberFormat::Other("chicago".to_owned()))
+        );
+
+        let output = String::from_utf8(numbering.to_xml().unwrap()).unwrap();
+        assert!(
+            output.contains(r#"<w:numFmt w:val="chicago"/>"#),
+            "{output}"
+        );
     }
 
     #[test]

--- a/crates/rdocx-py/src/lib.rs
+++ b/crates/rdocx-py/src/lib.rs
@@ -71,7 +71,10 @@ pub(crate) fn rdocx_to_pyerr(py: Python<'_>, error: rdocx::Error) -> PyErr {
         | rdocx::Error::UnavailableImageDimensions { .. } => "PackageError",
         rdocx::Error::Oxml(_) => "XmlError",
         rdocx::Error::Layout(_) | rdocx::Error::Pdf(_) | rdocx::Error::Raster(_) => "LayoutError",
-        rdocx::Error::Rtf { .. } | rdocx::Error::Other(_) => "RdocxError",
+        rdocx::Error::Rtf { .. }
+        | rdocx::Error::Html { .. }
+        | rdocx::Error::Odt { .. }
+        | rdocx::Error::Other(_) => "RdocxError",
     };
     public_error(py, class_name, error.to_string())
 }
@@ -123,6 +126,39 @@ mod tests {
             let raised = rdocx_to_pyerr(py, error);
 
             assert!(raised.get_type(py).is(&expected));
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn import_errors_map_to_the_generic_public_error_class() {
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            let package = PyModule::from_code(
+                py,
+                c_str!("class RdocxError(Exception):\n    pass\n"),
+                c_str!("rdocx_test.py"),
+                c_str!("rdocx"),
+            )?;
+            py.import("sys")?
+                .getattr("modules")?
+                .set_item("rdocx", &package)?;
+            let expected = package.getattr("RdocxError")?.cast_into::<PyType>()?;
+
+            for error in [
+                rdocx::Error::Html {
+                    location: "body[0]".to_string(),
+                    message: "invalid HTML".to_string(),
+                },
+                rdocx::Error::Odt {
+                    part: Some("content.xml".to_string()),
+                    offset: 0,
+                    message: "invalid ODT".to_string(),
+                },
+            ] {
+                assert!(rdocx_to_pyerr(py, error).get_type(py).is(&expected));
+            }
             Ok(())
         })
         .unwrap();

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -1596,7 +1596,7 @@ impl Document {
     pub fn numbering_is_bullet(&self, num_id: u32) -> Option<bool> {
         let numbering = self.numbering.as_ref()?;
         let abstract_num = numbering.get_abstract_num_for(num_id)?;
-        let fmt = abstract_num.levels.first()?.num_fmt?;
+        let fmt = abstract_num.levels.first()?.num_fmt.clone()?;
         Some(fmt == rdocx_oxml::numbering::ST_NumberFormat::Bullet)
     }
 
@@ -2253,8 +2253,8 @@ impl Document {
                 numbering
                     .get_abstract_num_for(n.num_id)
                     .map(|a| {
-                        a.levels.first().and_then(|l| l.num_fmt)
-                            == Some(rdocx_oxml::numbering::ST_NumberFormat::Bullet)
+                        a.levels.first().and_then(|l| l.num_fmt.as_ref())
+                            == Some(&rdocx_oxml::numbering::ST_NumberFormat::Bullet)
                     })
                     .unwrap_or(false)
             });
@@ -2297,8 +2297,8 @@ impl Document {
                 numbering
                     .get_abstract_num_for(n.num_id)
                     .map(|a| {
-                        a.levels.first().and_then(|l| l.num_fmt)
-                            == Some(rdocx_oxml::numbering::ST_NumberFormat::Decimal)
+                        a.levels.first().and_then(|l| l.num_fmt.as_ref())
+                            == Some(&rdocx_oxml::numbering::ST_NumberFormat::Decimal)
                     })
                     .unwrap_or(false)
             });

--- a/crates/rdocx/src/rtf.rs
+++ b/crates/rdocx/src/rtf.rs
@@ -1246,9 +1246,9 @@ impl<'a> RtfWriter<'a> {
                     .iter()
                     .find(|level| level.ilvl == level_index);
                 let format = level
-                    .and_then(|level| level.num_fmt)
+                    .and_then(|level| level.num_fmt.clone())
                     .and_then(public_number_format);
-                if level.and_then(|level| level.num_fmt).is_some() && format.is_none() {
+                if level.and_then(|level| level.num_fmt.as_ref()).is_some() && format.is_none() {
                     self.diagnose(
                         &format!("numbering[numId={num_id}]/level[{level_index}]/numFmt"),
                         "unsupported numbering format was dropped during RTF export",


### PR DESCRIPTION
## Summary

- preserve unknown `w:numFmt/@w:val` values as `ST_NumberFormat::Other(String)` rather than substituting decimal
- round-trip the producer-defined value verbatim
- make layout, HTML, RTF, and public helpers handle the new variant explicitly
- render an unknown list marker as empty rather than inventing a numbering scheme
- rebase onto S55 and map its new HTML and ODT import errors to Python’s generic `RdocxError`, with regression coverage

This prevents silent conversion of a producer-defined list format into decimal numbering and keeps the current upstream merge base buildable.

## API impact

`ST_NumberFormat` gains `Other(String)` and therefore changes from `Copy` to `Clone`. This is an intentional public API change required to preserve the producer value.

## Verification

- `cargo fmt --all --check`
- `cargo check -p rdocx-py --all-targets`
- `cargo test -p rdocx-oxml numbering`
- `cargo test --workspace --all-features --exclude rdocx-py --exclude rpptx-py`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

The workspace test command compiled all affected consumers. Its only local failure is the unrelated Poppler-version visual assertion in `oxml-pdf`.