### PR TITLE
Expose tracked table grid changes

### DIFF
--- a/crates/rdocx-layout/src/table.rs
+++ b/crates/rdocx-layout/src/table.rs
@@ -879,6 +879,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(2880) }, // 2 inches = 144pt
                 CT_TblGridCol { width: Twips(2880) },
             ],
+            grid_change_xml: None,
         };
 
         // 288pt total in a 468pt text column: the author asked for a narrow
@@ -898,6 +899,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(7200) }, // 5 inches = 360pt
                 CT_TblGridCol { width: Twips(7200) },
             ],
+            grid_change_xml: None,
         };
 
         // 720pt total will not fit a 468pt column, so scale it down.
@@ -926,6 +928,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(0) },
                 CT_TblGridCol { width: Twips(0) },
             ],
+            grid_change_xml: None,
         };
         let widths = compute_column_widths(Some(&grid), 468.0, &tbl);
         assert_eq!(widths.len(), 3);
@@ -958,6 +961,7 @@ mod tests {
         let mut outer = CT_Tbl::new();
         outer.grid = Some(CT_TblGrid {
             columns: vec![CT_TblGridCol { width: Twips(4680) }], // 3.25"
+            grid_change_xml: None,
         });
 
         let mut outer_row = CT_Row::new();
@@ -971,6 +975,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(2000) },
                 CT_TblGridCol { width: Twips(2000) },
             ],
+            grid_change_xml: None,
         });
         let mut nr = CT_Row::new();
         let mut nc1 = CT_Tc::new();
@@ -1053,6 +1058,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(600) },
                 CT_TblGridCol { width: Twips(600) },
             ],
+            grid_change_xml: None,
         });
 
         let mut exact_row = CT_Row::new();
@@ -1106,6 +1112,7 @@ mod tests {
         let mut minimum_merge = CT_Tbl::new();
         minimum_merge.grid = Some(CT_TblGrid {
             columns: vec![CT_TblGridCol { width: Twips(600) }],
+            grid_change_xml: None,
         });
         let mut restart_row = CT_Row::new();
         let mut restart = CT_Tc::new();
@@ -1162,6 +1169,7 @@ mod tests {
         });
         table.grid = Some(CT_TblGrid {
             columns: vec![CT_TblGridCol { width: Twips(1200) }],
+            grid_change_xml: None,
         });
         for (index, text) in ["header", "body"].into_iter().enumerate() {
             let mut row = CT_Row::new();

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -673,12 +673,18 @@ impl CT_TblPr {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CT_TblGrid {
     pub columns: Vec<CT_TblGridCol>,
+    /// Prior table grid captured by a tracked table-structure revision.
+    ///
+    /// The current `columns` remain the grid that readers should render. The
+    /// revision snapshot is preserved so saving does not discard it.
+    pub grid_change_xml: Option<Vec<u8>>,
 }
 
 #[allow(non_snake_case)]
 impl CT_TblGrid {
     pub fn from_xml(reader: &mut Reader<&[u8]>) -> Result<Self> {
         let mut columns = Vec::new();
+        let mut grid_change_xml = None;
         let mut buf = Vec::new();
 
         loop {
@@ -695,6 +701,15 @@ impl CT_TblGrid {
                         columns.push(CT_TblGridCol { width });
                     }
                 }
+                Ok(Event::Start(ref e))
+                    if matches_local_name(e.name().as_ref(), b"tblGridChange") =>
+                {
+                    if grid_change_xml.is_none() {
+                        grid_change_xml = Some(capture_element(reader, e)?);
+                    } else {
+                        capture_element(reader, e)?;
+                    }
+                }
                 Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"tblGrid") => {
                     break;
                 }
@@ -705,7 +720,10 @@ impl CT_TblGrid {
             buf.clear();
         }
 
-        Ok(CT_TblGrid { columns })
+        Ok(CT_TblGrid {
+            columns,
+            grid_change_xml,
+        })
     }
 
     pub fn to_xml<W: std::io::Write>(&self, writer: &mut Writer<W>) -> Result<()> {
@@ -716,6 +734,9 @@ impl CT_TblGrid {
             let mut e = BytesStart::new("w:gridCol");
             e.push_attribute(("w:w", buf.format(col.width.0)));
             writer.write_event(Event::Empty(e))?;
+        }
+        if let Some(grid_change_xml) = &self.grid_change_xml {
+            writer.get_mut().write_all(grid_change_xml)?;
         }
 
         writer.write_event(Event::End(BytesEnd::new("w:tblGrid")))?;
@@ -1832,6 +1853,26 @@ mod tests {
     }
 
     #[test]
+    fn table_grid_change_is_preserved() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="100"/><w:tblGridChange w:id="0"><w:tblGrid><w:gridCol w:w="80"/></w:tblGrid></w:tblGridChange></w:tblGrid><w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+        );
+        let grid = table.grid.as_ref().unwrap();
+
+        assert_eq!(grid.columns, vec![CT_TblGridCol { width: Twips(100) }]);
+        assert_eq!(
+            grid.grid_change_xml.as_deref(),
+            Some(
+                br#"<w:tblGridChange w:id="0"><w:tblGrid><w:gridCol w:w="80"/></w:tblGrid></w:tblGridChange>"#
+                    .as_slice()
+            )
+        );
+        assert!(table_to_xml(&table).contains(
+            r#"<w:tblGridChange w:id="0"><w:tblGrid><w:gridCol w:w="80"/></w:tblGrid></w:tblGridChange>"#
+        ));
+    }
+
+    #[test]
     fn aliased_table_cell_paragraph_properties_keep_root_scope() {
         let xml = format!(
             r#"<q:tbl xmlns:q="{}" xmlns:ext="urn:producer"><q:tr><q:tc><ext:p><ext:pPr><ext:jc ext:val="right"/></ext:pPr></ext:p><q:p><q:pPr><ext:jc ext:val="right"/><q:jc q:val="center"/></q:pPr><q:r><q:t>Cell</q:t></q:r></q:p></q:tc></q:tr></q:tbl>"#,
@@ -2312,6 +2353,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(4500) },
                 CT_TblGridCol { width: Twips(4500) },
             ],
+            grid_change_xml: None,
         });
 
         let mut row = CT_Row::new();
@@ -2362,6 +2404,7 @@ mod tests {
         let mut nested_tbl = CT_Tbl::new();
         nested_tbl.grid = Some(CT_TblGrid {
             columns: vec![CT_TblGridCol { width: Twips(2000) }],
+            grid_change_xml: None,
         });
         let mut nested_row = CT_Row::new();
         let mut nested_cell = CT_Tc::new();

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -2469,6 +2469,7 @@ impl Document {
             columns: (0..cols)
                 .map(|_| CT_TblGridCol { width: col_width })
                 .collect(),
+            grid_change_xml: None,
         };
 
         let mut tbl = CT_Tbl::new();
@@ -2544,6 +2545,7 @@ impl Document {
             columns: (0..cols)
                 .map(|_| CT_TblGridCol { width: col_width })
                 .collect(),
+            grid_change_xml: None,
         };
 
         let mut tbl = CT_Tbl::new();
@@ -9466,6 +9468,7 @@ mod tests {
                 CT_TblGridCol { width: Twips(1800) },
                 CT_TblGridCol { width: Twips(1800) },
             ],
+            grid_change_xml: None,
         });
         table.rows.push(marker_row("{% for item in items %}"));
         table

--- a/crates/rdocx/src/epub.rs
+++ b/crates/rdocx/src/epub.rs
@@ -4276,6 +4276,7 @@ mod tests {
             columns: (0..=MAX_PROJECTED_NODES)
                 .map(|_| CT_TblGridCol { width: Twips(1) })
                 .collect(),
+            grid_change_xml: None,
         });
         table.rows.push(CT_Row::new());
         grid.document.body.content.push(BodyContent::Table(table));

--- a/crates/rdocx/src/html.rs
+++ b/crates/rdocx/src/html.rs
@@ -904,6 +904,7 @@ impl Importer<'_> {
         });
         output.grid = Some(CT_TblGrid {
             columns: (0..column_count).map(|_| CT_TblGridCol { width }).collect(),
+            grid_change_xml: None,
         });
         for model in models {
             let mut row = CT_Row::new();

--- a/crates/rdocx/src/odt.rs
+++ b/crates/rdocx/src/odt.rs
@@ -3825,6 +3825,7 @@ impl<'a> Importer<'a> {
         });
         tbl.grid = Some(CT_TblGrid {
             columns: (0..columns).map(|_| CT_TblGridCol { width }).collect(),
+            grid_change_xml: None,
         });
         let mut active: Vec<Option<(usize, usize)>> = vec![None; columns];
         for row in rows {

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -551,6 +551,7 @@ impl<'a> Cell<'a> {
             columns: (0..cols)
                 .map(|_| CT_TblGridCol { width: col_width })
                 .collect(),
+            grid_change_xml: None,
         };
 
         let mut tbl = CT_Tbl::new();
@@ -600,6 +601,18 @@ impl<'a> TableRef<'a> {
             .as_ref()
             .map(|g| g.columns.len())
             .unwrap_or(0)
+    }
+
+    /// Whether the table retains a prior grid from a tracked structure change.
+    ///
+    /// The current grid remains the table structure readers should use. This
+    /// reports the preserved historical snapshot separately from the current
+    /// table structure.
+    pub fn has_grid_change(&self) -> bool {
+        self.inner
+            .grid
+            .as_ref()
+            .is_some_and(|grid| grid.grid_change_xml.is_some())
     }
 
     /// Get an immutable row reference.
@@ -791,6 +804,20 @@ mod tests {
     use rdocx_oxml::units::Twips;
 
     #[test]
+    fn table_grid_change_is_a_modeled_historical_snapshot() {
+        let xml = br#"<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:tblGrid><w:gridCol w:w="100"/><w:tblGridChange w:id="0"><w:tblGrid><w:gridCol w:w="80"/></w:tblGrid></w:tblGridChange></w:tblGrid><w:tr><w:tc><w:p/></w:tc></w:tr></w:tbl>"#;
+        let mut reader = quick_xml::Reader::from_reader(xml.as_slice());
+        let mut buffer = Vec::new();
+        let table = match reader.read_event_into(&mut buffer).unwrap() {
+            quick_xml::events::Event::Start(_) => CT_Tbl::from_xml(&mut reader).unwrap(),
+            event => panic!("expected table start, got {event:?}"),
+        };
+        let table = TableRef { inner: &table };
+
+        assert!(table.has_grid_change());
+    }
+
+    #[test]
     fn table_column_width_updates_grid_table_and_spanning_cells() {
         let mut inner = CT_Tbl::new();
         inner.grid = Some(CT_TblGrid {
@@ -805,6 +832,7 @@ mod tests {
                     width: Twips(3_000),
                 },
             ],
+            grid_change_xml: None,
         });
         let mut row = CT_Row::new();
         let mut spanning_cell = CT_Tc::new();
@@ -840,6 +868,7 @@ mod tests {
                     width: Twips(2_000),
                 },
             ],
+            grid_change_xml: None,
         });
         inner.properties = Some(CT_TblPr {
             width: Some(CT_TblWidth::dxa(3_000)),


### PR DESCRIPTION
## Summary

Preserve `w:tblGridChange` as the historical grid snapshot from a tracked table-structure revision. The active `w:tblGrid` remains the one readers use for layout.

The public reader API adds `TableRef::has_grid_change()` so consumers can distinguish this modeled revision metadata from unsupported table structure instead of failing generically or dropping the snapshot on save.

## Tests

- Added OOXML round-trip coverage for `w:tblGridChange`.
- Added reader coverage for the modeled historical snapshot.
- Ran `cargo test -p rdocx-oxml table_grid_change_is_preserved`.
- Ran `cargo test -p rdocx table_grid_change_is_a_modeled_historical_snapshot`.
- Ran `cargo test -p rdocx-layout --lib`.
- Ran `cargo clippy -p rdocx-oxml -p rdocx --all-targets -- -D warnings`.