### PR TITLE
Prime Word fidelity Cargo dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,8 @@ jobs:
         with:
           toolchain: 1.97.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Fetch locked Cargo dependencies
+        run: cargo fetch --locked
       - name: Install pinned Poppler 26.01.0
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Prime the lockfile dependencies before the Word-fidelity harness runs its intentionally offline `rdocx` build.

The current upstream `main` and PRs #55 through #57 all fail at that build when the Cargo cache is cold, even though the normal test and no-default-features checks pass. Fetching the locked dependency graph once keeps the harness offline and deterministic while allowing a cold runner to proceed.

## Verification

- Reproduced the cold-cache failure locally with `cargo fetch --locked --offline`.
- Confirmed the harness command succeeds when the required dependencies are cached.
- Kept the change limited to the Word-fidelity workflow.