### PR TITLE
Expose hyperlink and drawing reader safety facts

### DIFF
--- a/crates/rdocx-html/tests/injection_test.rs
+++ b/crates/rdocx-html/tests/injection_test.rs
@@ -28,6 +28,8 @@ fn linked_paragraph(url: &str) -> HtmlInput {
     p.hyperlinks.push(HyperlinkSpan {
         rel_id: Some("rId7".to_string()),
         anchor: None,
+        tooltip: None,
+        doc_location: None,
         run_start: 0,
         run_end: 1,
         extra_attributes: Vec::new(),

--- a/crates/rdocx-oxml/src/drawing.rs
+++ b/crates/rdocx-oxml/src/drawing.rs
@@ -251,6 +251,8 @@ pub struct CT_Anchor {
     pub wrap: WrapType,
     /// Relationship ID referencing the image part.
     pub embed_id: String,
+    /// Relationship ID referencing an externally linked image.
+    pub link_id: Option<String>,
     /// Relationship ID referencing a ChartML part.
     pub chart_rel_id: Option<String>,
     /// Z-order relative height.
@@ -424,6 +426,7 @@ impl CT_Anchor {
             dist_r: Emu(0),
             wrap: WrapType::None,
             embed_id: embed_id.to_string(),
+            link_id: None,
             chart_rel_id: None,
             relative_height: 0,
             description: Some("Background".to_string()),
@@ -481,6 +484,7 @@ impl CT_Anchor {
         let mut extent_cx = Emu(0);
         let mut extent_cy = Emu(0);
         let mut embed_id = String::new();
+        let mut link_id = None;
         let mut shape: Option<CT_Shape> = None;
         let mut description = None;
         let mut name = None;
@@ -519,6 +523,8 @@ impl CT_Anchor {
                             let val = std::str::from_utf8(&attr.value)?;
                             if matches_local_name(key, b"embed") {
                                 embed_id = val.to_string();
+                            } else if matches_local_name(key, b"link") {
+                                link_id = Some(val.to_string());
                             }
                         }
                     } else if matches_local_name(ename.as_ref(), b"simplePos") {
@@ -654,6 +660,8 @@ impl CT_Anchor {
                             let val = std::str::from_utf8(&attr.value)?;
                             if matches_local_name(key, b"embed") {
                                 embed_id = val.to_string();
+                            } else if matches_local_name(key, b"link") {
+                                link_id = Some(val.to_string());
                             }
                         }
                         reader.read_to_end_into(ename, &mut Vec::new())?;
@@ -699,6 +707,7 @@ impl CT_Anchor {
             dist_r,
             wrap,
             embed_id,
+            link_id,
             chart_rel_id: None,
             relative_height,
             description,
@@ -827,6 +836,8 @@ pub struct CT_Inline {
     pub extent_cy: Emu,
     /// Relationship ID referencing the image part
     pub embed_id: String,
+    /// Relationship ID referencing an externally linked image.
+    pub link_id: Option<String>,
     /// Relationship ID referencing a ChartML part.
     pub chart_rel_id: Option<String>,
     /// Optional description/alt text
@@ -844,6 +855,7 @@ impl CT_Inline {
             extent_cx: Emu(width_emu),
             extent_cy: Emu(height_emu),
             embed_id: embed_id.to_string(),
+            link_id: None,
             chart_rel_id: None,
             description: None,
             name: None,
@@ -857,6 +869,7 @@ impl CT_Inline {
             extent_cx: Emu(width_emu),
             extent_cy: Emu(height_emu),
             embed_id: String::new(),
+            link_id: None,
             chart_rel_id: Some(chart_rel_id.to_owned()),
             description: None,
             name: Some("Chart".to_owned()),
@@ -868,6 +881,7 @@ impl CT_Inline {
         let mut cx = Emu(0);
         let mut cy = Emu(0);
         let mut embed_id = String::new();
+        let mut link_id = None;
         let mut description = None;
         let mut name = None;
         let mut buf = Vec::new();
@@ -905,6 +919,8 @@ impl CT_Inline {
                             let val = std::str::from_utf8(&attr.value)?;
                             if matches_local_name(key, b"embed") {
                                 embed_id = val.to_string();
+                            } else if matches_local_name(key, b"link") {
+                                link_id = Some(val.to_string());
                             }
                         }
                     }
@@ -918,6 +934,8 @@ impl CT_Inline {
                             let val = std::str::from_utf8(&attr.value)?;
                             if matches_local_name(key, b"embed") {
                                 embed_id = val.to_string();
+                            } else if matches_local_name(key, b"link") {
+                                link_id = Some(val.to_string());
                             }
                         }
                         reader.read_to_end_into(ename, &mut Vec::new())?;
@@ -951,6 +969,7 @@ impl CT_Inline {
             extent_cx: cx,
             extent_cy: cy,
             embed_id,
+            link_id,
             chart_rel_id: None,
             description,
             name,
@@ -1335,6 +1354,7 @@ mod tests {
             extent_cx: Emu(914400), // 1 inch
             extent_cy: Emu(457200), // 0.5 inch
             embed_id: "rId5".to_string(),
+            link_id: None,
             chart_rel_id: None,
             description: Some("A test image".to_string()),
             name: Some("TestPic".to_string()),
@@ -1353,6 +1373,27 @@ mod tests {
         assert_eq!(inl.extent_cx, Emu(914400));
         assert_eq!(inl.extent_cy, Emu(457200));
         assert_eq!(inl.embed_id, "rId5");
+    }
+
+    #[test]
+    fn linked_image_relationships_are_retained_for_inline_and_anchor_drawings() {
+        let inline = parse_drawing(concat!(
+            r#"<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" "#,
+            r#"xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" "#,
+            r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" "#,
+            r#"xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">"#,
+            r#"<wp:inline><wp:extent cx="10" cy="20"/><a:blip r:link="rId7"/></wp:inline></w:drawing>"#,
+        ));
+        assert_eq!(inline.inline.unwrap().link_id.as_deref(), Some("rId7"));
+
+        let anchor = parse_drawing(concat!(
+            r#"<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" "#,
+            r#"xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" "#,
+            r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" "#,
+            r#"xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">"#,
+            r#"<wp:anchor><wp:extent cx="10" cy="20"/><a:blip r:link="rId8"/></wp:anchor></w:drawing>"#,
+        ));
+        assert_eq!(anchor.anchor.unwrap().link_id.as_deref(), Some("rId8"));
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/drawing.rs
+++ b/crates/rdocx-oxml/src/drawing.rs
@@ -7,6 +7,7 @@ use quick_xml::{Reader, Writer};
 
 use crate::error::Result;
 use crate::namespace::matches_local_name;
+use crate::numbering::namespace_bindings;
 use crate::raw_xml::capture_element;
 use crate::units::Emu;
 
@@ -1098,6 +1099,39 @@ fn chart_relationship_id(xml: &[u8]) -> Result<Option<String>> {
     }
 }
 
+fn image_relationship_ids(xml: &[u8]) -> Result<(String, Option<String>)> {
+    let mut reader = NsReader::from_reader(xml);
+    let mut buffer = Vec::new();
+    let mut embed_id = String::new();
+    let mut link_id = None;
+    loop {
+        let (namespace, event) = reader.read_resolved_event_into(&mut buffer)?;
+        match event {
+            Event::Start(ref element) | Event::Empty(ref element)
+                if namespace_matches(&namespace, drawing_ns::A, b"a")
+                    && matches_local_name(element.name().as_ref(), b"blip") =>
+            {
+                for attribute in element.attributes() {
+                    let attribute = attribute?;
+                    let (namespace, local) = reader.resolver().resolve_attribute(attribute.key);
+                    if !namespace_matches(&namespace, drawing_ns::R, b"r") {
+                        continue;
+                    }
+                    let value = std::str::from_utf8(&attribute.value)?.to_owned();
+                    match local.as_ref() {
+                        b"embed" => embed_id = value,
+                        b"link" => link_id = Some(value),
+                        _ => {}
+                    }
+                }
+            }
+            Event::Eof => return Ok((embed_id, link_id)),
+            _ => {}
+        }
+        buffer.clear();
+    }
+}
+
 fn graphic_data_uri_is_chart(element: &BytesStart<'_>) -> Result<bool> {
     for attribute in element.attributes() {
         let attribute = attribute?;
@@ -1240,6 +1274,13 @@ impl CT_Drawing {
     }
 
     pub fn from_xml(reader: &mut Reader<&[u8]>) -> Result<Self> {
+        Self::from_xml_with_prefixes(reader, &[format!("\0r\0{}", drawing_ns::R)])
+    }
+
+    pub(crate) fn from_xml_with_prefixes(
+        reader: &mut Reader<&[u8]>,
+        prefixes: &[String],
+    ) -> Result<Self> {
         let mut inline = None;
         let mut anchor = None;
         let mut buf = Vec::new();
@@ -1251,7 +1292,11 @@ impl CT_Drawing {
                     if matches_local_name(name.as_ref(), b"inline") {
                         // Capture full raw XML, then re-parse for structured fields
                         let raw = capture_element(reader, e)?;
-                        let mut re_reader = Reader::from_reader(raw.as_slice());
+                        let scoped_raw = crate::text::raw_with_external_bindings(
+                            &raw,
+                            &namespace_bindings(prefixes),
+                        )?;
+                        let mut re_reader = Reader::from_reader(scoped_raw.as_slice());
                         re_reader.config_mut().trim_text(true);
                         // Skip to the <wp:inline> start
                         let mut rbuf = Vec::new();
@@ -1261,7 +1306,9 @@ impl CT_Drawing {
                                     if matches_local_name(ie.name().as_ref(), b"inline") =>
                                 {
                                     let mut inl = CT_Inline::from_xml(&mut re_reader)?;
-                                    inl.chart_rel_id = chart_relationship_id(&raw)?;
+                                    (inl.embed_id, inl.link_id) =
+                                        image_relationship_ids(&scoped_raw)?;
+                                    inl.chart_rel_id = chart_relationship_id(&scoped_raw)?;
                                     inl.raw_xml = Some(raw);
                                     inline = Some(inl);
                                     break;
@@ -1275,7 +1322,11 @@ impl CT_Drawing {
                     } else if matches_local_name(name.as_ref(), b"anchor") {
                         // Capture full raw XML, then re-parse for structured fields
                         let raw = capture_element(reader, e)?;
-                        let mut re_reader = Reader::from_reader(raw.as_slice());
+                        let scoped_raw = crate::text::raw_with_external_bindings(
+                            &raw,
+                            &namespace_bindings(prefixes),
+                        )?;
+                        let mut re_reader = Reader::from_reader(scoped_raw.as_slice());
                         re_reader.config_mut().trim_text(true);
                         let mut rbuf = Vec::new();
                         loop {
@@ -1284,7 +1335,9 @@ impl CT_Drawing {
                                     if matches_local_name(ie.name().as_ref(), b"anchor") =>
                                 {
                                     let mut anc = CT_Anchor::from_xml(&mut re_reader, ie)?;
-                                    anc.chart_rel_id = chart_relationship_id(&raw)?;
+                                    (anc.embed_id, anc.link_id) =
+                                        image_relationship_ids(&scoped_raw)?;
+                                    anc.chart_rel_id = chart_relationship_id(&scoped_raw)?;
                                     anc.raw_xml = Some(raw);
                                     anchor = Some(anc);
                                     break;
@@ -1394,6 +1447,25 @@ mod tests {
             r#"<wp:anchor><wp:extent cx="10" cy="20"/><a:blip r:link="rId8"/></wp:anchor></w:drawing>"#,
         ));
         assert_eq!(anchor.anchor.unwrap().link_id.as_deref(), Some("rId8"));
+    }
+
+    #[test]
+    fn linked_image_relationships_require_the_office_relationship_namespace() {
+        let foreign = parse_drawing(concat!(
+            r#"<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" "#,
+            r#"xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" "#,
+            r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">"#,
+            r#"<wp:inline><a:blip xmlns:x="urn:producer" x:link="rIdBad"/></wp:inline></w:drawing>"#,
+        ));
+        assert!(foreign.inline.unwrap().link_id.is_none());
+
+        let aliased = parse_drawing(concat!(
+            r#"<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" "#,
+            r#"xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" "#,
+            r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">"#,
+            r#"<wp:inline><a:blip xmlns:q="http://schemas.openxmlformats.org/officeDocument/2006/relationships" q:link="rId9"/></wp:inline></w:drawing>"#,
+        ));
+        assert_eq!(aliased.inline.unwrap().link_id.as_deref(), Some("rId9"));
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/text.rs
+++ b/crates/rdocx-oxml/src/text.rs
@@ -1045,6 +1045,10 @@ pub struct HyperlinkSpan {
     pub rel_id: Option<String>,
     /// Optional anchor within the document (for internal links).
     pub anchor: Option<String>,
+    /// Optional user-facing hover text.
+    pub tooltip: Option<String>,
+    /// Optional location in the hyperlink target document.
+    pub doc_location: Option<String>,
     /// Index of the first run in the hyperlink (inclusive).
     pub run_start: usize,
     /// Index of the last run in the hyperlink (exclusive).
@@ -1077,7 +1081,13 @@ pub struct ComplexFieldHyperlink {
     pub target: String,
 }
 
-type ParsedHyperlinkAttributes = (Option<String>, Option<String>, Vec<(String, String)>);
+type ParsedHyperlinkAttributes = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Vec<(String, String)>,
+);
 
 pub(crate) fn hyperlink_revision_slot(hyperlink_index: usize) -> usize {
     HYPERLINK_REVISION_FLAG | hyperlink_index
@@ -1852,6 +1862,8 @@ impl CT_P {
                 let suffix = HyperlinkSpan {
                     rel_id: hyperlink.rel_id.clone(),
                     anchor: hyperlink.anchor.clone(),
+                    tooltip: hyperlink.tooltip.clone(),
+                    doc_location: hyperlink.doc_location.clone(),
                     run_start: run_index + 1,
                     run_end: hyperlink.run_end + 1,
                     extra_attributes: hyperlink.extra_attributes.clone(),
@@ -2228,7 +2240,7 @@ impl CT_P {
                             extra_xml.push((runs.len(), raw));
                         }
                     } else if is_word_element(name.as_ref(), b"hyperlink", &prefixes) {
-                        let (rel_id, anchor, extra_attributes) =
+                        let (rel_id, anchor, tooltip, doc_location, extra_attributes) =
                             parse_hyperlink_attributes(e, &prefixes)?;
                         let raw = capture_element(reader, e)?;
                         let parsed = parse_hyperlink_children(&raw, &prefixes)?;
@@ -2247,6 +2259,8 @@ impl CT_P {
                             hyperlinks.push(HyperlinkSpan {
                                 rel_id,
                                 anchor,
+                                tooltip,
+                                doc_location,
                                 run_start,
                                 run_end,
                                 extra_attributes,
@@ -4087,6 +4101,8 @@ fn parse_hyperlink_attributes(
 ) -> Result<ParsedHyperlinkAttributes> {
     let mut rel_id = None;
     let mut anchor = None;
+    let mut tooltip = None;
+    let mut doc_location = None;
     let mut extra = Vec::new();
     for attribute in element.attributes() {
         let attribute = attribute?;
@@ -4098,11 +4114,15 @@ fn parse_hyperlink_attributes(
             rel_id = Some(value);
         } else if attribute_in_namespace(name, b"anchor", crate::namespace::W_NS, scope) {
             anchor = Some(value);
+        } else if attribute_in_namespace(name, b"tooltip", crate::namespace::W_NS, scope) {
+            tooltip = Some(value);
+        } else if attribute_in_namespace(name, b"docLocation", crate::namespace::W_NS, scope) {
+            doc_location = Some(value);
         } else {
             extra.push((std::str::from_utf8(name)?.to_owned(), value));
         }
     }
-    Ok((rel_id, anchor, extra))
+    Ok((rel_id, anchor, tooltip, doc_location, extra))
 }
 
 fn attribute_in_namespace(name: &[u8], local: &[u8], namespace: &str, scope: &[String]) -> bool {
@@ -4304,6 +4324,14 @@ fn write_hyperlink_start<W: std::io::Write>(
     }
     if let Some(anchor) = &hyperlink.anchor {
         element.push_attribute((anchor_name.as_str(), anchor.as_str()));
+    }
+    if let Some(tooltip) = &hyperlink.tooltip {
+        let tooltip_name = format!("{word_prefix}:tooltip");
+        element.push_attribute((tooltip_name.as_str(), tooltip.as_str()));
+    }
+    if let Some(doc_location) = &hyperlink.doc_location {
+        let doc_location_name = format!("{word_prefix}:docLocation");
+        element.push_attribute((doc_location_name.as_str(), doc_location.as_str()));
     }
     for (name, value) in &hyperlink.extra_attributes {
         element.push_attribute((name.as_str(), value.as_str()));
@@ -5129,11 +5157,35 @@ mod tests {
     #[test]
     fn parse_hyperlink_with_anchor() {
         let p = parse_paragraph(
-            r#"<w:hyperlink w:anchor="section1"><w:r><w:t>Go to section</w:t></w:r></w:hyperlink>"#,
+            r#"<w:hyperlink w:anchor="section1" w:tooltip="Jump" w:docLocation="target"><w:r><w:t>Go to section</w:t></w:r></w:hyperlink>"#,
         );
         assert_eq!(p.hyperlinks.len(), 1);
         assert_eq!(p.hyperlinks[0].anchor, Some("section1".to_string()));
+        assert_eq!(p.hyperlinks[0].tooltip.as_deref(), Some("Jump"));
+        assert_eq!(p.hyperlinks[0].doc_location.as_deref(), Some("target"));
         assert!(p.hyperlinks[0].rel_id.is_none());
+    }
+
+    #[test]
+    fn parse_hyperlink_uses_local_namespace_aliases_without_reporting_declarations() {
+        let p = parse_paragraph(concat!(
+            r#"<q:hyperlink xmlns:q="http://schemas.openxmlformats.org/wordprocessingml/2006/main" "#,
+            r#"q:tooltip="Jump" q:docLocation="target" q:history="1">"#,
+            r#"<q:r><q:t>Go</q:t></q:r></q:hyperlink>"#,
+        ));
+        assert_eq!(p.hyperlinks[0].tooltip.as_deref(), Some("Jump"));
+        assert_eq!(p.hyperlinks[0].doc_location.as_deref(), Some("target"));
+        assert!(
+            p.hyperlinks[0]
+                .extra_attributes
+                .contains(&("q:history".to_owned(), "1".to_owned()))
+        );
+        assert!(
+            p.hyperlinks[0]
+                .extra_attributes
+                .iter()
+                .any(|(name, _)| name == "xmlns:q")
+        );
     }
 
     #[test]
@@ -5157,6 +5209,8 @@ mod tests {
         p.hyperlinks.push(HyperlinkSpan {
             rel_id: Some("rId7".to_string()),
             anchor: None,
+            tooltip: None,
+            doc_location: None,
             run_start: 1,
             run_end: 2,
             extra_attributes: Vec::new(),

--- a/crates/rdocx-oxml/src/text.rs
+++ b/crates/rdocx-oxml/src/text.rs
@@ -801,7 +801,9 @@ impl CT_R {
                         }));
                         modeled_children += 1;
                     } else if is_word_element(name.as_ref(), b"drawing", &prefixes) {
-                        content.push(RunContent::Drawing(CT_Drawing::from_xml(reader)?));
+                        content.push(RunContent::Drawing(CT_Drawing::from_xml_with_prefixes(
+                            reader, &prefixes,
+                        )?));
                         modeled_children += 1;
                     } else if is_word_element(name.as_ref(), b"commentReference", &prefixes) {
                         let id = required_word_i32_attribute(e, b"id", &prefixes)?;

--- a/crates/rdocx/src/comments.rs
+++ b/crates/rdocx/src/comments.rs
@@ -1089,6 +1089,8 @@ mod tests {
         paragraph.hyperlinks.push(HyperlinkSpan {
             rel_id: Some("rIdLink".to_owned()),
             anchor: None,
+            tooltip: None,
+            doc_location: None,
             run_start: 0,
             run_end: 2,
             extra_attributes: Vec::new(),

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -4137,6 +4137,8 @@ impl Document {
             p.hyperlinks.push(HyperlinkSpan {
                 rel_id: None,
                 anchor: Some(heading.bookmark_name.clone()),
+                tooltip: None,
+                doc_location: None,
                 run_start: 0,
                 run_end: 1, // Just the text run, not the tab
                 extra_attributes: Vec::new(),
@@ -10553,9 +10555,10 @@ mod tests {
             panic!("expected paragraph");
         };
         assert_eq!(
-            paragraph.hyperlinks[0].extra_attributes,
-            vec![("w:tooltip".to_string(), "Example site".to_string())]
+            paragraph.hyperlinks[0].tooltip.as_deref(),
+            Some("Example site")
         );
+        assert!(paragraph.hyperlinks[0].extra_attributes.is_empty());
         let BodyContent::Table(table) = &reopened.document.body.content[1] else {
             panic!("expected table");
         };
@@ -10763,6 +10766,8 @@ mod hyperlink_span_tests {
         p.hyperlinks.push(HyperlinkSpan {
             rel_id: None,
             anchor: Some("bookmark".to_string()),
+            tooltip: None,
+            doc_location: None,
             run_start: 1,
             run_end: 99,
             extra_attributes: Vec::new(),
@@ -10772,6 +10777,8 @@ mod hyperlink_span_tests {
         p.hyperlinks.push(HyperlinkSpan {
             rel_id: None,
             anchor: Some("inverted".to_string()),
+            tooltip: None,
+            doc_location: None,
             run_start: 5,
             run_end: 1,
             extra_attributes: Vec::new(),

--- a/crates/rdocx/src/epub.rs
+++ b/crates/rdocx/src/epub.rs
@@ -2448,6 +2448,7 @@ fn render_drawing_projection(drawing: &CT_Drawing) -> CT_Drawing {
         extent_cx,
         extent_cy,
         embed_id: embed_id.to_owned(),
+        link_id: None,
         chart_rel_id: chart_rel_id.cloned(),
         description: description.cloned(),
         name: None,

--- a/crates/rdocx/src/epub.rs
+++ b/crates/rdocx/src/epub.rs
@@ -2314,6 +2314,8 @@ fn render_paragraph_projection(paragraph: &CT_P) -> CT_P {
             .map(|hyperlink| HyperlinkSpan {
                 rel_id: hyperlink.rel_id.clone(),
                 anchor: hyperlink.anchor.clone(),
+                tooltip: hyperlink.tooltip.clone(),
+                doc_location: hyperlink.doc_location.clone(),
                 run_start: hyperlink.run_start,
                 run_end: hyperlink.run_end,
                 extra_attributes: Vec::new(),
@@ -4181,6 +4183,8 @@ mod tests {
         paragraph.hyperlinks.push(HyperlinkSpan {
             rel_id: Some("rId1".to_owned()),
             anchor: None,
+            tooltip: None,
+            doc_location: None,
             run_start: 0,
             run_end: usize::MAX,
             extra_attributes: Vec::new(),
@@ -4795,6 +4799,8 @@ mod tests {
         paragraph.inner.hyperlinks.push(HyperlinkSpan {
             rel_id: None,
             anchor: Some("bookmark".to_owned()),
+            tooltip: None,
+            doc_location: None,
             run_start: internal_start,
             run_end: internal_start + 1,
             extra_attributes: Vec::new(),

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -72,8 +72,8 @@ pub use redaction::RedactionReport;
 pub use revision::{RevisionKind, RevisionRef};
 pub use rtf::{RtfDiagnostic, RtfReadResult, RtfWriteResult};
 pub use run::{
-    BreakKind, DrawingRef, FieldRef, LegacyHorizontalRuleRef, Run, RunItemRef, RunRef,
-    UnderlineStyle,
+    BreakKind, DrawingKind, DrawingRef, DrawingRelationshipKind, FieldRef, LegacyHorizontalRuleRef,
+    Run, RunItemRef, RunRef, UnderlineStyle,
 };
 pub use style::{Style, StyleBuilder};
 pub use svg::{SvgDiagnostic, SvgRenderResult};

--- a/crates/rdocx/src/odt.rs
+++ b/crates/rdocx/src/odt.rs
@@ -6839,6 +6839,8 @@ mod tests {
         paragraph.hyperlinks.push(rdocx_oxml::text::HyperlinkSpan {
             rel_id: None,
             anchor: Some("bookmark".to_owned()),
+            tooltip: None,
+            doc_location: None,
             run_start: 0,
             run_end: 1,
             extra_attributes: Vec::new(),

--- a/crates/rdocx/src/paragraph.rs
+++ b/crates/rdocx/src/paragraph.rs
@@ -87,6 +87,24 @@ impl<'a> HyperlinkRef<'a> {
         self.inner().anchor.as_deref()
     }
 
+    /// The optional hyperlink tooltip.
+    pub fn tooltip(&self) -> Option<&'a str> {
+        self.inner().tooltip.as_deref()
+    }
+
+    /// The optional location in the hyperlink target document.
+    pub fn doc_location(&self) -> Option<&'a str> {
+        self.inner().doc_location.as_deref()
+    }
+
+    /// Whether the hyperlink retains attributes outside the modeled reader API.
+    pub fn has_unmodeled_semantic_attributes(&self) -> bool {
+        self.inner()
+            .extra_attributes
+            .iter()
+            .any(|(name, _)| name != "xmlns" && !name.starts_with("xmlns:"))
+    }
+
     /// Get the combined text of the hyperlink runs.
     pub fn text(&self) -> String {
         let hyperlink = self.inner();
@@ -344,11 +362,11 @@ impl<'a> Paragraph<'a> {
         self.inner.hyperlinks.push(HyperlinkSpan {
             rel_id: Some(relationship_id.to_string()),
             anchor: None,
+            tooltip: tooltip.map(str::to_owned),
+            doc_location: None,
             run_start,
             run_end: run_start + 1,
-            extra_attributes: tooltip
-                .map(|tooltip| vec![("w:tooltip".to_string(), tooltip.to_string())])
-                .unwrap_or_default(),
+            extra_attributes: Vec::new(),
             extra_xml: Vec::new(),
             preserved_raw_before: None,
         });
@@ -1252,5 +1270,35 @@ impl<'a> ParagraphRef<'a> {
             .as_ref()
             .and_then(|ppr| ppr.shading.as_ref())
             .and_then(|shd| shd.fill.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hyperlink_reader_exposes_modeled_and_unmodeled_attributes() {
+        let mut paragraph = CT_P::new();
+        paragraph.add_run("linked");
+        paragraph.hyperlinks.push(HyperlinkSpan {
+            rel_id: Some("rId1".to_owned()),
+            anchor: None,
+            tooltip: Some("Open link".to_owned()),
+            doc_location: Some("section-two".to_owned()),
+            run_start: 0,
+            run_end: 1,
+            extra_attributes: vec![("w:history".to_owned(), "1".to_owned())],
+            extra_xml: Vec::new(),
+            preserved_raw_before: None,
+        });
+        let hyperlink = HyperlinkRef {
+            paragraph: &paragraph,
+            index: 0,
+        };
+
+        assert_eq!(hyperlink.tooltip(), Some("Open link"));
+        assert_eq!(hyperlink.doc_location(), Some("section-two"));
+        assert!(hyperlink.has_unmodeled_semantic_attributes());
     }
 }

--- a/crates/rdocx/src/run.rs
+++ b/crates/rdocx/src/run.rs
@@ -19,6 +19,26 @@ pub enum BreakKind {
     Column,
 }
 
+/// Semantic kind of drawing exposed by the reader facade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrawingKind {
+    /// A DrawingML picture with an image relationship.
+    Image,
+    /// An anchored DrawingML shape.
+    Shape,
+    /// Any other drawing construct.
+    Other,
+}
+
+/// How an image relationship obtains its content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrawingRelationshipKind {
+    /// The drawing refers to an image part within the package.
+    Embedded,
+    /// The drawing refers to an external image relationship.
+    Linked,
+}
+
 /// An immutable drawing embedded in a run.
 #[derive(Debug, Clone, Copy)]
 pub struct DrawingRef<'a> {
@@ -26,6 +46,22 @@ pub struct DrawingRef<'a> {
 }
 
 impl DrawingRef<'_> {
+    /// Semantic content kind.
+    pub fn kind(&self) -> DrawingKind {
+        if self.relationship_id().is_some() {
+            DrawingKind::Image
+        } else if self
+            .inner
+            .anchor
+            .as_ref()
+            .is_some_and(|anchor| anchor.shape.is_some())
+        {
+            DrawingKind::Shape
+        } else {
+            DrawingKind::Other
+        }
+    }
+
     /// Whether this drawing is inline with the surrounding text.
     pub fn is_inline(&self) -> bool {
         self.inner.inline.is_some()
@@ -36,19 +72,45 @@ impl DrawingRef<'_> {
         self.inner.anchor.is_some()
     }
 
-    /// The relationship ID for the drawing's embedded image, when present.
+    /// The relationship ID for the drawing's embedded or linked image, when present.
     pub fn relationship_id(&self) -> Option<&str> {
         self.inner
             .inline
             .as_ref()
-            .map(|inline| inline.embed_id.as_str())
+            .and_then(|inline| {
+                (!inline.embed_id.is_empty())
+                    .then_some(inline.embed_id.as_str())
+                    .or(inline.link_id.as_deref())
+            })
+            .or_else(|| {
+                self.inner.anchor.as_ref().and_then(|anchor| {
+                    (!anchor.embed_id.is_empty())
+                        .then_some(anchor.embed_id.as_str())
+                        .or(anchor.link_id.as_deref())
+                })
+            })
+    }
+
+    /// Whether the image relationship is embedded in the package or linked.
+    pub fn relationship_kind(&self) -> Option<DrawingRelationshipKind> {
+        self.inner
+            .inline
+            .as_ref()
+            .map(|inline| inline.embed_id.is_empty() && inline.link_id.is_some())
             .or_else(|| {
                 self.inner
                     .anchor
                     .as_ref()
-                    .map(|anchor| anchor.embed_id.as_str())
+                    .map(|anchor| anchor.embed_id.is_empty() && anchor.link_id.is_some())
             })
-            .filter(|id| !id.is_empty())
+            .filter(|_| self.relationship_id().is_some())
+            .map(|linked| {
+                if linked {
+                    DrawingRelationshipKind::Linked
+                } else {
+                    DrawingRelationshipKind::Embedded
+                }
+            })
     }
 
     /// The drawing description, commonly used as image alternative text.
@@ -835,6 +897,45 @@ mod tests {
             panic!("expected paragraph");
         };
         paragraph.runs.remove(0)
+    }
+
+    #[test]
+    fn drawing_reader_classifies_image_relationships_and_shapes() {
+        let linked_run = run_with_inner_xml(concat!(
+            r#"<w:drawing xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" "#,
+            r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" "#,
+            r#"xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">"#,
+            r#"<wp:inline><wp:extent cx="10" cy="20"/><a:blip r:link="rId7"/></wp:inline></w:drawing>"#,
+        ));
+        let linked_run = RunRef { inner: &linked_run };
+        let linked_items = linked_run.items().collect::<Vec<_>>();
+        let [RunItemRef::Drawing(linked)] = linked_items.as_slice() else {
+            panic!("expected one linked drawing");
+        };
+        assert_eq!(linked.kind(), DrawingKind::Image);
+        assert_eq!(linked.relationship_id(), Some("rId7"));
+        assert_eq!(
+            linked.relationship_kind(),
+            Some(DrawingRelationshipKind::Linked)
+        );
+
+        let embedded = CT_Drawing::inline(rdocx_oxml::drawing::CT_Inline::new("rId8", 10, 20));
+        let embedded = DrawingRef { inner: &embedded };
+        assert_eq!(embedded.kind(), DrawingKind::Image);
+        assert_eq!(
+            embedded.relationship_kind(),
+            Some(DrawingRelationshipKind::Embedded)
+        );
+
+        let mut anchor = rdocx_oxml::drawing::CT_Anchor::background("", 10, 20);
+        anchor.shape = Some(rdocx_oxml::drawing::CT_Shape::default());
+        let shape = CT_Drawing::anchor(anchor);
+        assert_eq!(DrawingRef { inner: &shape }.kind(), DrawingKind::Shape);
+
+        let chart = CT_Drawing::inline(rdocx_oxml::drawing::CT_Inline::new_chart("rId9", 10, 20));
+        let chart = DrawingRef { inner: &chart };
+        assert_eq!(chart.kind(), DrawingKind::Other);
+        assert_eq!(chart.relationship_kind(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain hyperlink tooltip and document-location metadata as typed reader facts
- report unmodeled hyperlink attributes without treating namespace declarations as semantic attributes
- retain external drawing relationship IDs and distinguish linked from embedded images
- classify reader drawings as images, anchored shapes, or other constructs
- require the Office relationships namespace before accepting linked-image relationship attributes

## Review follow-up

- rebased onto current `main`
- added coverage proving a foreign same-local-name `link` attribute is rejected
- retained support for valid aliased Office relationship prefixes
- ready for maintainer F-ID integration

## Validation

- `cargo test -p rdocx-oxml --lib`
- focused `rdocx` hyperlink and drawing reader tests
- `cargo clippy -p rdocx-oxml -p rdocx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/hash_harness.py --check`
- CI Test and MSRV jobs pass

The local unfiltered `rdocx` run only reaches the existing environment-dependent `word_and_powerpoint_chart_pixels_are_identical` rasterizer oracle assertion. The failure does not exercise these reader changes.
