### PR TITLE
Expose document and table reader completeness facts

### DIFF
--- a/crates/rdocx-layout/src/paginator.rs
+++ b/crates/rdocx-layout/src/paginator.rs
@@ -5626,6 +5626,7 @@ mod tests {
             right: Some(visible.clone()),
             inside_h: Some(visible.clone()),
             inside_v: Some(visible),
+            extra_xml: Vec::new(),
         };
         let cell = Some(CT_TblBorders {
             top: Some(nil.clone()),
@@ -5634,6 +5635,7 @@ mod tests {
             right: Some(nil),
             inside_h: None,
             inside_v: None,
+            extra_xml: Vec::new(),
         });
 
         let mut outer = Vec::new();

--- a/crates/rdocx-oxml/src/content_control.rs
+++ b/crates/rdocx-oxml/src/content_control.rs
@@ -572,9 +572,14 @@ fn parse_content(
                         reader, &prefixes,
                     )?));
                 } else if is_word_element(child.name().as_ref(), b"tr", &prefixes) {
-                    content.push(SdtContent::Row(CT_Row::from_xml_with_prefixes(
-                        reader, &prefixes,
-                    )?));
+                    let owner_bindings = local_namespace_overrides(&child, inherited)?;
+                    content.push(SdtContent::Row(
+                        CT_Row::from_xml_with_prefixes_and_owner_bindings(
+                            reader,
+                            &prefixes,
+                            &owner_bindings,
+                        )?,
+                    ));
                 } else if is_word_element(child.name().as_ref(), b"tc", &prefixes) {
                     let owner_bindings = local_namespace_overrides(&child, inherited)?;
                     content.push(SdtContent::Cell(

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -984,6 +984,20 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        if let Some(grid_before) = self.grid_before {
+            let mut buffer = itoa::Buffer::new();
+            let mut e = BytesStart::new("w:gridBefore");
+            e.push_attribute(("w:val", buffer.format(grid_before)));
+            writer.write_event(Event::Empty(e))?;
+        }
+
+        if let Some(grid_after) = self.grid_after {
+            let mut buffer = itoa::Buffer::new();
+            let mut e = BytesStart::new("w:gridAfter");
+            e.push_attribute(("w:val", buffer.format(grid_after)));
+            writer.write_event(Event::Empty(e))?;
+        }
+
         if let Some(ref cant_split) = self.cant_split
             && *cant_split
         {
@@ -1007,20 +1021,6 @@ impl CT_TrPr {
         if let Some(jc) = self.jc {
             let mut e = BytesStart::new("w:jc");
             e.push_attribute(("w:val", jc.to_str()));
-            writer.write_event(Event::Empty(e))?;
-        }
-
-        if let Some(grid_before) = self.grid_before {
-            let mut buffer = itoa::Buffer::new();
-            let mut e = BytesStart::new("w:gridBefore");
-            e.push_attribute(("w:val", buffer.format(grid_before)));
-            writer.write_event(Event::Empty(e))?;
-        }
-
-        if let Some(grid_after) = self.grid_after {
-            let mut buffer = itoa::Buffer::new();
-            let mut e = BytesStart::new("w:gridAfter");
-            e.push_attribute(("w:val", buffer.format(grid_after)));
             writer.write_event(Event::Empty(e))?;
         }
 
@@ -2761,6 +2761,37 @@ mod tests {
         assert_eq!(tr_pr.header, Some(true));
         assert_eq!(tr_pr.grid_before, Some(1));
         assert_eq!(tr_pr.grid_after, Some(2));
+    }
+
+    #[test]
+    fn row_properties_write_grid_offsets_in_schema_order() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr>
+                 <w:trPr>
+                   <w:gridBefore w:val="1"/>
+                   <w:gridAfter w:val="2"/>
+                   <w:cantSplit/>
+                   <w:trHeight w:val="720" w:hRule="exact"/>
+                   <w:tblHeader/>
+                   <w:jc w:val="center"/>
+                 </w:trPr>
+                 <w:tc><w:p/></w:tc>
+               </w:tr>"#,
+        );
+
+        let xml = table_to_xml(&table);
+        let children = [
+            "<w:gridBefore",
+            "<w:gridAfter",
+            "<w:cantSplit",
+            "<w:trHeight",
+            "<w:tblHeader",
+            "<w:jc",
+        ];
+        let positions = children.map(|child| xml.find(child).expect("row property writes"));
+
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{xml}");
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -939,8 +939,8 @@ pub struct CT_TrPr {
     pub cnf_style: Option<String>,
     /// Contextual row insertion and deletion markers in schema order.
     pub revision_markers: Vec<CT_Revision>,
-    /// Malformed row markers retained at their insertion or deletion schema slot.
-    pub revision_xml: Vec<(usize, Vec<u8>)>,
+    /// Malformed row markers retained verbatim.
+    pub revision_xml: Vec<Vec<u8>>,
     /// Other row properties retained at their schema insertion slots.
     pub extra_xml: Vec<(usize, Vec<u8>)>,
 }
@@ -1012,18 +1012,16 @@ impl CT_TrPr {
                         if let Some(revision) = CT_Revision::from_raw(raw.clone(), &prefixes) {
                             pr.revision_markers.push(revision);
                         } else {
-                            pr.revision_xml.push((at, raw));
+                            pr.revision_xml.push(raw);
                         }
                     } else if matches_local_name(name.as_ref(), b"ins")
                         || matches_local_name(name.as_ref(), b"del")
                     {
-                        pr.revision_xml.push((
-                            row_revision_boundary(name.as_ref()),
-                            crate::text::raw_with_external_bindings(
+                        pr.revision_xml
+                            .push(crate::text::raw_with_external_bindings(
                                 &capture_empty_element(e)?,
                                 owner_bindings,
-                            )?,
-                        ));
+                            )?);
                     } else {
                         pr.extra_xml.push((
                             at,
@@ -1048,18 +1046,16 @@ impl CT_TrPr {
                         if let Some(revision) = CT_Revision::from_raw(raw.clone(), &prefixes) {
                             pr.revision_markers.push(revision);
                         } else {
-                            pr.revision_xml.push((at, raw));
+                            pr.revision_xml.push(raw);
                         }
                     } else if matches_local_name(e.name().as_ref(), b"ins")
                         || matches_local_name(e.name().as_ref(), b"del")
                     {
-                        pr.revision_xml.push((
-                            row_revision_boundary(e.name().as_ref()),
-                            crate::text::raw_with_external_bindings(
+                        pr.revision_xml
+                            .push(crate::text::raw_with_external_bindings(
                                 &capture_element(reader, e)?,
                                 owner_bindings,
-                            )?,
-                        ));
+                            )?);
                     } else {
                         pr.extra_xml.push((
                             at,
@@ -1178,8 +1174,10 @@ impl CT_TrPr {
         {
             revision.write_xml(writer)?;
         }
-        for (_, raw) in self.revision_xml.iter().filter(|(at, _)| *at == boundary) {
-            writer.get_mut().write_all(raw)?;
+        for raw in &self.revision_xml {
+            if row_revision_raw_boundary(raw)? == boundary {
+                writer.get_mut().write_all(raw)?;
+            }
         }
         Ok(())
     }
@@ -1198,11 +1196,24 @@ impl CT_TrPr {
     }
 }
 
-fn row_revision_boundary(name: &[u8]) -> usize {
-    if matches_local_name(name, b"ins") {
-        12
-    } else {
-        13
+fn row_revision_raw_boundary(raw: &[u8]) -> Result<usize> {
+    let mut reader = Reader::from_reader(raw);
+    let mut buffer = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buffer)? {
+            Event::Start(element) | Event::Empty(element) => {
+                return Ok(if matches_local_name(element.name().as_ref(), b"ins") {
+                    12
+                } else {
+                    13
+                });
+            }
+            Event::Eof => {
+                return Err(OxmlError::MissingElement("row revision marker".to_owned()));
+            }
+            _ => {}
+        }
+        buffer.clear();
     }
 }
 
@@ -3132,7 +3143,7 @@ mod tests {
         let properties = table.rows[0].properties.as_ref().unwrap();
         assert_eq!(
             properties.revision_xml,
-            vec![(12, br#"<w:ins w:id="1"/>"#.to_vec())]
+            vec![br#"<w:ins w:id="1"/>"#.to_vec()]
         );
         assert_eq!(properties.revision_markers.len(), 1);
         assert_eq!(

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -401,8 +401,9 @@ pub struct CT_TblPr {
     pub change: Option<CT_Revision>,
     /// Malformed table property changes retained verbatim.
     pub revision_xml: Vec<Vec<u8>>,
-    /// Other table properties retained verbatim.
-    pub extra_xml: Vec<Vec<u8>>,
+    /// Unmodelled property children retained at their schema insertion slots.
+    #[doc(hidden)]
+    pub extra_xml: Vec<(usize, Vec<u8>)>,
 }
 
 /// `w:tblLook` — which parts of a table style's conditional formatting apply.
@@ -534,6 +535,7 @@ impl CT_TblPr {
     ) -> Result<Self> {
         let mut pr = CT_TblPr::default();
         let mut change_raw_index = 0usize;
+        let mut boundary = 0usize;
         let mut buf = Vec::new();
 
         loop {
@@ -541,6 +543,7 @@ impl CT_TblPr {
                 Ok(Event::Empty(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let (at, next) = tbl_pr_raw_boundary(name.as_ref(), boundary, &prefixes);
                     if is_word_element(name.as_ref(), b"tblStyle", &prefixes) {
                         pr.style_id = get_word_val_attr(e, &prefixes)?;
                     } else if is_word_element(name.as_ref(), b"tblW", &prefixes) {
@@ -585,15 +588,20 @@ impl CT_TblPr {
                                 owner_bindings,
                             )?);
                     } else {
-                        pr.extra_xml.push(crate::text::raw_with_external_bindings(
-                            &capture_empty_element(e)?,
-                            owner_bindings,
-                        )?);
+                        pr.extra_xml.push((
+                            at,
+                            crate::text::raw_with_external_bindings(
+                                &capture_empty_element(e)?,
+                                owner_bindings,
+                            )?,
+                        ));
                     }
+                    boundary = next;
                 }
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let (at, next) = tbl_pr_raw_boundary(name.as_ref(), boundary, &prefixes);
                     if is_word_element(name.as_ref(), b"tblBorders", &prefixes) {
                         pr.borders =
                             Some(CT_TblBorders::from_xml_with_prefixes(reader, &prefixes)?);
@@ -621,11 +629,15 @@ impl CT_TblPr {
                                 owner_bindings,
                             )?);
                     } else {
-                        pr.extra_xml.push(crate::text::raw_with_external_bindings(
-                            &capture_element(reader, e)?,
-                            owner_bindings,
-                        )?);
+                        pr.extra_xml.push((
+                            at,
+                            crate::text::raw_with_external_bindings(
+                                &capture_element(reader, e)?,
+                                owner_bindings,
+                            )?,
+                        ));
                     }
+                    boundary = next;
                 }
                 Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"tblPr") => {
                     break;
@@ -643,63 +655,103 @@ impl CT_TblPr {
     pub fn to_xml<W: std::io::Write>(&self, writer: &mut Writer<W>) -> Result<()> {
         writer.write_event(Event::Start(BytesStart::new("w:tblPr")))?;
 
+        write_extras_at(writer, &self.extra_xml, 0)?;
         if let Some(ref style_id) = self.style_id {
             let mut e = BytesStart::new("w:tblStyle");
             e.push_attribute(("w:val", style_id.as_str()));
             writer.write_event(Event::Empty(e))?;
         }
 
+        for boundary in 1..=6 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
         if let Some(ref width) = self.width {
             width.write_xml(writer, "w:tblW")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 7)?;
         if let Some(jc) = self.jc {
             let mut e = BytesStart::new("w:jc");
             e.push_attribute(("w:val", jc.to_str()));
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 8)?;
+        write_extras_at(writer, &self.extra_xml, 9)?;
         if let Some(ref indent) = self.indent {
             indent.write_xml(writer, "w:tblInd")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 10)?;
         if let Some(ref borders) = self.borders
             && !borders.is_empty()
         {
             borders.to_xml(writer, "w:tblBorders")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 11)?;
         if let Some(ref shd) = self.shading {
             shd.write_xml(writer, "w:shd")?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 12)?;
         if let Some(ref layout) = self.layout {
             let mut e = BytesStart::new("w:tblLayout");
             e.push_attribute(("w:type", layout.as_str()));
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 13)?;
         if let Some(ref cell_margin) = self.cell_margin {
             cell_margin.to_xml(writer)?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 14)?;
         if let Some(ref look) = self.look {
             look.to_xml(writer)?;
         }
 
+        for boundary in 15..=18 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
         for raw in &self.revision_xml {
             writer.get_mut().write_all(raw)?;
         }
         if let Some(change) = &self.change {
             change.write_xml(writer)?;
         }
-        for raw in &self.extra_xml {
-            writer.get_mut().write_all(raw)?;
-        }
 
         writer.write_event(Event::End(BytesEnd::new("w:tblPr")))?;
         Ok(())
     }
+}
+
+fn tbl_pr_raw_boundary(name: &[u8], current: usize, word_prefixes: &[String]) -> (usize, usize) {
+    let schema_children = [
+        b"tblStyle".as_slice(),
+        b"tblpPr".as_slice(),
+        b"tblOverlap".as_slice(),
+        b"bidiVisual".as_slice(),
+        b"tblStyleRowBandSize".as_slice(),
+        b"tblStyleColBandSize".as_slice(),
+        b"tblW".as_slice(),
+        b"jc".as_slice(),
+        b"tblCellSpacing".as_slice(),
+        b"tblInd".as_slice(),
+        b"tblBorders".as_slice(),
+        b"shd".as_slice(),
+        b"tblLayout".as_slice(),
+        b"tblCellMar".as_slice(),
+        b"tblLook".as_slice(),
+        b"tblCaption".as_slice(),
+        b"tblDescription".as_slice(),
+        b"tblPrChange".as_slice(),
+    ];
+
+    schema_children
+        .iter()
+        .position(|child| is_word_element(name, child, word_prefixes))
+        .map_or((current, current), |index| (index, index + 1))
 }
 
 // ---- Table grid ----
@@ -2849,6 +2901,48 @@ mod tests {
                 .extra_xml
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn unmodelled_table_properties_keep_schema_slots_before_change() {
+        let table = parse_table(
+            r#"<w:tblPr>
+                 <w:tblOverlap w:val="never"/>
+                 <w:tblW w:w="5000" w:type="dxa"/>
+                 <ext:between xmlns:ext="urn:producer"/>
+                 <w:jc w:val="center"/>
+                 <w:tblCaption w:val="caption"/>
+                 <w:tblPrChange/>
+               </w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>"#,
+        );
+
+        let properties = table.properties.as_ref().expect("table properties parse");
+        assert_eq!(
+            properties.extra_xml,
+            vec![
+                (2, br#"<w:tblOverlap w:val="never"/>"#.to_vec()),
+                (7, br#"<ext:between xmlns:ext="urn:producer"/>"#.to_vec(),),
+                (15, br#"<w:tblCaption w:val="caption"/>"#.to_vec()),
+            ]
+        );
+
+        let xml = table_to_xml(&table);
+        let overlap = xml.find("<w:tblOverlap").expect("overlap writes");
+        let width = xml.find("<w:tblW").expect("width writes");
+        let extension = xml.find("<ext:between").expect("extension writes");
+        let alignment = xml.find("<w:jc").expect("alignment writes");
+        let caption = xml.find("<w:tblCaption").expect("caption writes");
+        let change = xml.find("<w:tblPrChange").expect("change writes");
+
+        assert!(
+            overlap < width
+                && width < extension
+                && extension < alignment
+                && alignment < caption
+                && caption < change,
+            "{xml}"
         );
     }
 

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -82,6 +82,8 @@ pub struct CT_TblBorders {
     pub right: Option<CT_BorderEdge>,
     pub inside_h: Option<CT_BorderEdge>,
     pub inside_v: Option<CT_BorderEdge>,
+    /// Other border edges retained verbatim.
+    pub extra_xml: Vec<Vec<u8>>,
 }
 
 impl CT_TblBorders {
@@ -123,8 +125,11 @@ impl CT_TblBorders {
                     } else if is_word_element(name.as_ref(), b"insideV", &prefixes) {
                         borders.inside_v =
                             Some(CT_BorderEdge::from_xml_attrs_with_prefixes(e, &prefixes)?);
+                    } else {
+                        borders.extra_xml.push(capture_empty_element(e)?);
                     }
                 }
+                Ok(Event::Start(ref e)) => borders.extra_xml.push(capture_element(reader, e)?),
                 Ok(Event::End(ref e))
                     if matches_local_name(e.name().as_ref(), b"tblBorders")
                         || matches_local_name(e.name().as_ref(), b"tcBorders") =>
@@ -161,6 +166,9 @@ impl CT_TblBorders {
         if let Some(ref e) = self.inside_v {
             e.to_xml(writer, "w:insideV")?;
         }
+        for raw in &self.extra_xml {
+            writer.get_mut().write_all(raw)?;
+        }
         writer.write_event(Event::End(BytesEnd::new(tag)))?;
         Ok(())
     }
@@ -172,6 +180,7 @@ impl CT_TblBorders {
             && self.right.is_none()
             && self.inside_h.is_none()
             && self.inside_v.is_none()
+            && self.extra_xml.is_empty()
     }
 }
 
@@ -392,6 +401,8 @@ pub struct CT_TblPr {
     pub change: Option<CT_Revision>,
     /// Malformed table property changes retained verbatim.
     pub revision_xml: Vec<Vec<u8>>,
+    /// Other table properties retained verbatim.
+    pub extra_xml: Vec<Vec<u8>>,
 }
 
 /// `w:tblLook` — which parts of a table style's conditional formatting apply.
@@ -573,6 +584,11 @@ impl CT_TblPr {
                                 &capture_empty_element(e)?,
                                 owner_bindings,
                             )?);
+                    } else {
+                        pr.extra_xml.push(crate::text::raw_with_external_bindings(
+                            &capture_empty_element(e)?,
+                            owner_bindings,
+                        )?);
                     }
                 }
                 Ok(Event::Start(ref e)) => {
@@ -605,7 +621,10 @@ impl CT_TblPr {
                                 owner_bindings,
                             )?);
                     } else {
-                        reader.read_to_end_into(name, &mut Vec::new())?;
+                        pr.extra_xml.push(crate::text::raw_with_external_bindings(
+                            &capture_element(reader, e)?,
+                            owner_bindings,
+                        )?);
                     }
                 }
                 Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"tblPr") => {
@@ -673,6 +692,9 @@ impl CT_TblPr {
         }
         if let Some(change) = &self.change {
             change.write_xml(writer)?;
+        }
+        for raw in &self.extra_xml {
+            writer.get_mut().write_all(raw)?;
         }
 
         writer.write_event(Event::End(BytesEnd::new("w:tblPr")))?;
@@ -837,6 +859,10 @@ pub struct CT_TrPr {
     pub header: Option<bool>,
     /// Row alignment
     pub jc: Option<ST_Jc>,
+    /// Number of grid columns omitted before the first cell.
+    pub grid_before: Option<u32>,
+    /// Number of grid columns omitted after the final cell.
+    pub grid_after: Option<u32>,
     /// Allow row to break across pages
     pub cant_split: Option<bool>,
     /// `w:cnfStyle` — which conditional parts of the table style this row is.
@@ -848,6 +874,8 @@ pub struct CT_TrPr {
     pub revision_markers: Vec<CT_Revision>,
     /// Malformed row markers retained verbatim.
     pub revision_xml: Vec<Vec<u8>>,
+    /// Other row properties retained verbatim.
+    pub extra_xml: Vec<Vec<u8>>,
 }
 
 #[allow(non_snake_case)]
@@ -885,6 +913,10 @@ impl CT_TrPr {
                         if let Some(val) = get_val_attr(e)? {
                             pr.jc = ST_Jc::from_str(&val).ok();
                         }
+                    } else if matches_local_name(name.as_ref(), b"gridBefore") {
+                        pr.grid_before = get_val_attr(e)?.map(|value| value.parse()).transpose()?;
+                    } else if matches_local_name(name.as_ref(), b"gridAfter") {
+                        pr.grid_after = get_val_attr(e)?.map(|value| value.parse()).transpose()?;
                     } else if matches_local_name(name.as_ref(), b"cnfStyle") {
                         pr.cnf_style = get_val_attr(e)?;
                     } else if matches_local_name(name.as_ref(), b"cantSplit") {
@@ -902,6 +934,8 @@ impl CT_TrPr {
                         || matches_local_name(name.as_ref(), b"del")
                     {
                         pr.revision_xml.push(capture_empty_element(e)?);
+                    } else {
+                        pr.extra_xml.push(capture_empty_element(e)?);
                     }
                 }
                 Ok(Event::Start(ref e)) => {
@@ -920,7 +954,7 @@ impl CT_TrPr {
                     {
                         pr.revision_xml.push(capture_element(reader, e)?);
                     } else {
-                        reader.read_to_end_into(e.name(), &mut Vec::new())?;
+                        pr.extra_xml.push(capture_element(reader, e)?);
                     }
                 }
                 Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"trPr") => {
@@ -976,10 +1010,27 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        if let Some(grid_before) = self.grid_before {
+            let mut buffer = itoa::Buffer::new();
+            let mut e = BytesStart::new("w:gridBefore");
+            e.push_attribute(("w:val", buffer.format(grid_before)));
+            writer.write_event(Event::Empty(e))?;
+        }
+
+        if let Some(grid_after) = self.grid_after {
+            let mut buffer = itoa::Buffer::new();
+            let mut e = BytesStart::new("w:gridAfter");
+            e.push_attribute(("w:val", buffer.format(grid_after)));
+            writer.write_event(Event::Empty(e))?;
+        }
+
         for revision in &self.revision_markers {
             revision.write_xml(writer)?;
         }
         for raw in &self.revision_xml {
+            writer.get_mut().write_all(raw)?;
+        }
+        for raw in &self.extra_xml {
             writer.get_mut().write_all(raw)?;
         }
 
@@ -993,8 +1044,11 @@ impl CT_TrPr {
             && self.jc.is_none()
             && self.cant_split.is_none()
             && self.cnf_style.is_none()
+            && self.grid_before.is_none()
+            && self.grid_after.is_none()
             && self.revision_markers.is_empty()
             && self.revision_xml.is_empty()
+            && self.extra_xml.is_empty()
     }
 }
 
@@ -1033,6 +1087,8 @@ pub struct CT_TcPr {
     pub width: Option<CT_TblWidth>,
     /// Horizontal merge (number of grid columns spanned)
     pub grid_span: Option<u32>,
+    /// Legacy horizontal merge state.
+    pub h_merge: Option<String>,
     /// Vertical merge
     pub v_merge: Option<VMerge>,
     /// Cell borders
@@ -1145,6 +1201,8 @@ impl CT_TcPr {
                 }
                 pr.grid_span = Some(span);
             }
+        } else if is_word_element(name.as_ref(), b"hMerge", word_prefixes) {
+            pr.h_merge = Some(get_word_val_attr(e, word_prefixes)?.unwrap_or_default());
         } else if is_word_element(name.as_ref(), b"vMerge", word_prefixes) {
             pr.v_merge = Some(match get_word_val_attr(e, word_prefixes)?.as_deref() {
                 Some("restart") => VMerge::Restart,
@@ -1206,6 +1264,13 @@ impl CT_TcPr {
 
         // Unmodelled w:hMerge is preserved at boundary 3.
         write_extras_at(writer, &self.extra_xml, 3)?;
+        if let Some(h_merge) = &self.h_merge {
+            let mut e = BytesStart::new("w:hMerge");
+            if !h_merge.is_empty() {
+                e.push_attribute(("w:val", h_merge.as_str()));
+            }
+            writer.write_event(Event::Empty(e))?;
+        }
         write_extras_at(writer, &self.extra_xml, 4)?;
         if let Some(ref vm) = self.v_merge {
             let mut e = BytesStart::new("w:vMerge");
@@ -1263,6 +1328,7 @@ impl CT_TcPr {
     fn is_empty(&self) -> bool {
         self.width.is_none()
             && self.grid_span.is_none()
+            && self.h_merge.is_none()
             && self.v_merge.is_none()
             && self.borders.is_none()
             && self.shading.is_none()
@@ -2530,10 +2596,10 @@ mod tests {
             .properties
             .as_ref()
             .expect("cell properties parse");
+        assert_eq!(properties.h_merge.as_deref(), Some(""));
         assert_eq!(
             properties.extra_xml,
             vec![
-                (3, br#"<w:hMerge/>"#.to_vec()),
                 (8, br#"<w:tcMar/>"#.to_vec()),
                 (12, br#"<w:hideMark/>"#.to_vec()),
                 (13, br#"<w:headers/>"#.to_vec()),
@@ -2660,6 +2726,8 @@ mod tests {
                  <w:trPr>
                    <w:trHeight w:val="720" w:hRule="exact"/>
                    <w:tblHeader/>
+                   <w:gridBefore w:val="1"/>
+                   <w:gridAfter w:val="2"/>
                  </w:trPr>
                  <w:tc><w:p/></w:tc>
                </w:tr>"#,
@@ -2669,6 +2737,45 @@ mod tests {
         assert_eq!(tr_pr.height, Some(Twips(720)));
         assert_eq!(tr_pr.height_rule, Some("exact".to_string()));
         assert_eq!(tr_pr.header, Some(true));
+        assert_eq!(tr_pr.grid_before, Some(1));
+        assert_eq!(tr_pr.grid_after, Some(2));
+    }
+
+    #[test]
+    fn unmodelled_table_property_groups_are_retained() {
+        let table = parse_table(
+            r#"<w:tblPr><w:bidiVisual/><w:tblBorders><w:diagonalDown/></w:tblBorders></w:tblPr><w:tblGrid><w:gridCol w:w="100"/></w:tblGrid><w:tr><w:trPr><w:tblCellSpacing/></w:trPr><w:tc><w:tcPr><w:fitText/></w:tcPr><w:p/></w:tc></w:tr>"#,
+        );
+
+        let table_properties = table.properties.as_ref().expect("table properties parse");
+        assert_eq!(table_properties.extra_xml.len(), 1);
+        assert_eq!(
+            table_properties
+                .borders
+                .as_ref()
+                .expect("table borders parse")
+                .extra_xml
+                .len(),
+            1
+        );
+        assert_eq!(
+            table.rows[0]
+                .properties
+                .as_ref()
+                .expect("row properties parse")
+                .extra_xml
+                .len(),
+            1
+        );
+        assert_eq!(
+            table.rows[0].cells[0]
+                .properties
+                .as_ref()
+                .expect("cell properties parse")
+                .extra_xml
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -926,8 +926,8 @@ pub struct CT_TrPr {
     pub revision_markers: Vec<CT_Revision>,
     /// Malformed row markers retained verbatim.
     pub revision_xml: Vec<Vec<u8>>,
-    /// Other row properties retained verbatim.
-    pub extra_xml: Vec<Vec<u8>>,
+    /// Other row properties retained at their schema insertion slots.
+    pub extra_xml: Vec<(usize, Vec<u8>)>,
 }
 
 #[allow(non_snake_case)]
@@ -941,6 +941,7 @@ impl CT_TrPr {
         word_prefixes: &[String],
     ) -> Result<Self> {
         let mut pr = CT_TrPr::default();
+        let mut boundary = 0usize;
         let mut buf = Vec::new();
 
         loop {
@@ -948,6 +949,7 @@ impl CT_TrPr {
                 Ok(Event::Empty(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let (at, next) = tr_pr_raw_boundary(name.as_ref(), boundary, &prefixes);
                     if matches_local_name(name.as_ref(), b"trHeight") {
                         for attr in e.attributes() {
                             let attr = attr?;
@@ -987,11 +989,13 @@ impl CT_TrPr {
                     {
                         pr.revision_xml.push(capture_empty_element(e)?);
                     } else {
-                        pr.extra_xml.push(capture_empty_element(e)?);
+                        pr.extra_xml.push((at, capture_empty_element(e)?));
                     }
+                    boundary = next;
                 }
                 Ok(Event::Start(ref e)) => {
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let (at, next) = tr_pr_raw_boundary(e.name().as_ref(), boundary, &prefixes);
                     if is_word_element(e.name().as_ref(), b"ins", &prefixes)
                         || is_word_element(e.name().as_ref(), b"del", &prefixes)
                     {
@@ -1006,8 +1010,9 @@ impl CT_TrPr {
                     {
                         pr.revision_xml.push(capture_element(reader, e)?);
                     } else {
-                        pr.extra_xml.push(capture_element(reader, e)?);
+                        pr.extra_xml.push((at, capture_element(reader, e)?));
                     }
+                    boundary = next;
                 }
                 Ok(Event::End(ref e)) if matches_local_name(e.name().as_ref(), b"trPr") => {
                     break;
@@ -1029,6 +1034,7 @@ impl CT_TrPr {
 
         writer.write_event(Event::Start(BytesStart::new("w:trPr")))?;
 
+        write_extras_at(writer, &self.extra_xml, 0)?;
         // cnfStyle comes first in the schema sequence for both trPr and tcPr.
         if let Some(ref cnf) = self.cnf_style {
             let mut e = BytesStart::new("w:cnfStyle");
@@ -1036,6 +1042,9 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        for boundary in 1..=2 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
         if let Some(grid_before) = self.grid_before {
             let mut buffer = itoa::Buffer::new();
             let mut e = BytesStart::new("w:gridBefore");
@@ -1043,6 +1052,7 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 3)?;
         if let Some(grid_after) = self.grid_after {
             let mut buffer = itoa::Buffer::new();
             let mut e = BytesStart::new("w:gridAfter");
@@ -1050,12 +1060,16 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        for boundary in 4..=6 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
         if let Some(ref cant_split) = self.cant_split
             && *cant_split
         {
             writer.write_event(Event::Empty(BytesStart::new("w:cantSplit")))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 7)?;
         if let Some(height) = self.height {
             let mut buf = itoa::Buffer::new();
             let mut e = BytesStart::new("w:trHeight");
@@ -1066,24 +1080,31 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
+        write_extras_at(writer, &self.extra_xml, 8)?;
         if let Some(true) = self.header {
             writer.write_event(Event::Empty(BytesStart::new("w:tblHeader")))?;
         }
 
+        for boundary in 9..=10 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
         if let Some(jc) = self.jc {
             let mut e = BytesStart::new("w:jc");
             e.push_attribute(("w:val", jc.to_str()));
             writer.write_event(Event::Empty(e))?;
         }
 
+        for boundary in 11..=13 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
+        }
         for revision in &self.revision_markers {
             revision.write_xml(writer)?;
         }
         for raw in &self.revision_xml {
             writer.get_mut().write_all(raw)?;
         }
-        for raw in &self.extra_xml {
-            writer.get_mut().write_all(raw)?;
+        for boundary in 14..=15 {
+            write_extras_at(writer, &self.extra_xml, boundary)?;
         }
 
         writer.write_event(Event::End(BytesEnd::new("w:trPr")))?;
@@ -1102,6 +1123,31 @@ impl CT_TrPr {
             && self.revision_xml.is_empty()
             && self.extra_xml.is_empty()
     }
+}
+
+fn tr_pr_raw_boundary(name: &[u8], current: usize, word_prefixes: &[String]) -> (usize, usize) {
+    let schema_children = [
+        b"cnfStyle".as_slice(),
+        b"divId".as_slice(),
+        b"gridBefore".as_slice(),
+        b"gridAfter".as_slice(),
+        b"wBefore".as_slice(),
+        b"wAfter".as_slice(),
+        b"cantSplit".as_slice(),
+        b"trHeight".as_slice(),
+        b"tblHeader".as_slice(),
+        b"tblCellSpacing".as_slice(),
+        b"jc".as_slice(),
+        b"hidden".as_slice(),
+        b"ins".as_slice(),
+        b"del".as_slice(),
+        b"trPrChange".as_slice(),
+    ];
+
+    schema_children
+        .iter()
+        .position(|child| is_word_element(name, child, word_prefixes))
+        .map_or((current, current), |index| (index, index + 1))
 }
 
 // ---- Cell properties ----
@@ -2844,6 +2890,44 @@ mod tests {
         let positions = children.map(|child| xml.find(child).expect("row property writes"));
 
         assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{xml}");
+    }
+
+    #[test]
+    fn retained_row_properties_write_at_schema_boundaries() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr>
+                 <w:trPr>
+                   <w:gridBefore w:val="1"/>
+                   <w:tblCellSpacing w:w="120" w:type="dxa"/>
+                   <w:jc w:val="center"/>
+                   <w:ins w:id="1" w:author="Ada"/>
+                   <w:trPrChange w:id="2" w:author="Ada"/>
+                 </w:trPr>
+                 <w:tc><w:p/></w:tc>
+               </w:tr>"#,
+        );
+
+        let properties = table.rows[0].properties.as_ref().unwrap();
+        assert_eq!(
+            properties.extra_xml,
+            vec![
+                (9, br#"<w:tblCellSpacing w:w="120" w:type="dxa"/>"#.to_vec()),
+                (14, br#"<w:trPrChange w:id="2" w:author="Ada"/>"#.to_vec()),
+            ]
+        );
+
+        let xml = table_to_xml(&table);
+        let grid = xml.find("<w:gridBefore").unwrap();
+        let spacing = xml.find("<w:tblCellSpacing").unwrap();
+        let alignment = xml.find("<w:jc").unwrap();
+        let insertion = xml.find("<w:ins").unwrap();
+        let change = xml.find("<w:trPrChange").unwrap();
+
+        assert!(
+            grid < spacing && spacing < alignment && alignment < insertion && insertion < change,
+            "{xml}"
+        );
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -1584,6 +1584,12 @@ impl Default for CT_Tc {
 /// `CT_Row` — A table row containing cells.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CT_Row {
+    /// The optional Word table-property exception for this row.
+    ///
+    /// Its contents affect table presentation only. The complete raw element
+    /// remains the serialization source because the layout model does not
+    /// interpret every table-property variant.
+    pub table_property_exception: Option<Vec<u8>>,
     pub properties: Option<CT_TrPr>,
     pub cells: Vec<CT_Tc>,
     /// Raw XML for children we do not model, tagged with the cell index they
@@ -1597,6 +1603,7 @@ pub struct CT_Row {
 impl CT_Row {
     pub fn new() -> Self {
         CT_Row {
+            table_property_exception: None,
             properties: None,
             cells: Vec::new(),
             extra_xml: Vec::new(),
@@ -1612,6 +1619,7 @@ impl CT_Row {
         reader: &mut Reader<&[u8]>,
         word_prefixes: &[String],
     ) -> Result<Self> {
+        let mut table_property_exception = None;
         let mut properties = None;
         let mut cells = Vec::new();
         let mut extra_xml = Vec::new();
@@ -1623,7 +1631,11 @@ impl CT_Row {
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
-                    if is_word_element(name.as_ref(), b"trPr", &prefixes) {
+                    if is_word_element(name.as_ref(), b"tblPrEx", &prefixes)
+                        && table_property_exception.is_none()
+                    {
+                        table_property_exception = Some(capture_element(reader, e)?);
+                    } else if is_word_element(name.as_ref(), b"trPr", &prefixes) {
                         properties = Some(CT_TrPr::from_xml_with_prefixes(reader, &prefixes)?);
                     } else if is_word_element(name.as_ref(), b"tc", &prefixes) {
                         let owner_bindings = local_namespace_overrides(e, word_prefixes)?;
@@ -1651,7 +1663,12 @@ impl CT_Row {
                 }
                 Ok(Event::Empty(ref e)) => {
                     let name = e.name();
-                    if !matches_local_name(name.as_ref(), b"trPr") {
+                    let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    if is_word_element(name.as_ref(), b"tblPrEx", &prefixes)
+                        && table_property_exception.is_none()
+                    {
+                        table_property_exception = Some(capture_empty_element(e)?);
+                    } else if !is_word_element(name.as_ref(), b"trPr", &prefixes) {
                         extra_xml.push((cells.len(), capture_empty_element(e)?));
                     }
                 }
@@ -1666,6 +1683,7 @@ impl CT_Row {
         }
 
         Ok(CT_Row {
+            table_property_exception,
             properties,
             cells,
             extra_xml,
@@ -1675,6 +1693,10 @@ impl CT_Row {
 
     pub fn to_xml<W: std::io::Write>(&self, writer: &mut Writer<W>) -> Result<()> {
         writer.write_event(Event::Start(BytesStart::new("w:tr")))?;
+
+        if let Some(raw) = &self.table_property_exception {
+            writer.get_mut().write_all(raw)?;
+        }
 
         if let Some(ref props) = self.properties {
             props.to_xml(writer)?;
@@ -2739,6 +2761,27 @@ mod tests {
         assert_eq!(tr_pr.header, Some(true));
         assert_eq!(tr_pr.grid_before, Some(1));
         assert_eq!(tr_pr.grid_after, Some(2));
+    }
+
+    #[test]
+    fn table_property_exception_is_preserved_as_row_formatting() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="100"/></w:tblGrid><w:tr><w:tblPrEx><w:shd w:val="clear" w:color="auto" w:fill="ced7e7"/></w:tblPrEx><w:trPr><w:trHeight w:val="290" w:hRule="atLeast"/></w:trPr><w:tc><w:p/></w:tc></w:tr>"#,
+        );
+        let row = &table.rows[0];
+
+        assert_eq!(
+            row.table_property_exception.as_deref(),
+            Some(
+                br#"<w:tblPrEx><w:shd w:val="clear" w:color="auto" w:fill="ced7e7"/></w:tblPrEx>"#
+                    .as_slice()
+            )
+        );
+
+        let xml = table_to_xml(&table);
+        let exception = xml.find("<w:tblPrEx>").expect("exception writes");
+        let properties = xml.find("<w:trPr>").expect("row properties write");
+        assert!(exception < properties, "tblPrEx must precede trPr: {xml}");
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -967,10 +967,14 @@ impl CT_TrPr {
                         if let Some(val) = get_val_attr(e)? {
                             pr.jc = ST_Jc::from_str(&val).ok();
                         }
-                    } else if matches_local_name(name.as_ref(), b"gridBefore") {
-                        pr.grid_before = get_val_attr(e)?.map(|value| value.parse()).transpose()?;
-                    } else if matches_local_name(name.as_ref(), b"gridAfter") {
-                        pr.grid_after = get_val_attr(e)?.map(|value| value.parse()).transpose()?;
+                    } else if is_word_element(name.as_ref(), b"gridBefore", &prefixes) {
+                        pr.grid_before = get_word_val_attr(e, &prefixes)?
+                            .map(|value| value.parse())
+                            .transpose()?;
+                    } else if is_word_element(name.as_ref(), b"gridAfter", &prefixes) {
+                        pr.grid_after = get_word_val_attr(e, &prefixes)?
+                            .map(|value| value.parse())
+                            .transpose()?;
                     } else if matches_local_name(name.as_ref(), b"cnfStyle") {
                         pr.cnf_style = get_val_attr(e)?;
                     } else if matches_local_name(name.as_ref(), b"cantSplit") {
@@ -2859,6 +2863,28 @@ mod tests {
         assert_eq!(tr_pr.header, Some(true));
         assert_eq!(tr_pr.grid_before, Some(1));
         assert_eq!(tr_pr.grid_after, Some(2));
+    }
+
+    #[test]
+    fn row_grid_offsets_require_the_word_namespace() {
+        let word_namespace = crate::namespace::W_NS;
+        let table = parse_table(&format!(
+            r#"<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr>
+                 <w:trPr>
+                   <ext:gridBefore xmlns:ext="urn:producer" ext:val="7"/>
+                   <q:gridAfter xmlns:q="{word_namespace}" q:val="2"/>
+                 </w:trPr>
+                 <w:tc><w:p/></w:tc>
+               </w:tr>"#,
+        ));
+
+        let properties = table.rows[0].properties.as_ref().unwrap();
+        assert_eq!(properties.grid_before, None);
+        assert_eq!(properties.grid_after, Some(2));
+        assert!(properties.extra_xml.iter().any(|(_, raw)| {
+            raw == br#"<ext:gridBefore xmlns:ext="urn:producer" ext:val="7"/>"#
+        }));
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -14,7 +14,7 @@ use crate::properties::{
     CT_Shd, get_val_attr, get_word_val_attr, is_word_attribute, is_word_element,
 };
 use crate::raw_xml::{capture_element, capture_empty_element};
-use crate::revision::CT_Revision;
+use crate::revision::{CT_Revision, RevisionKind};
 #[cfg(test)]
 use crate::shared::ST_Border;
 use crate::shared::ST_Jc;
@@ -939,8 +939,8 @@ pub struct CT_TrPr {
     pub cnf_style: Option<String>,
     /// Contextual row insertion and deletion markers in schema order.
     pub revision_markers: Vec<CT_Revision>,
-    /// Malformed row markers retained verbatim.
-    pub revision_xml: Vec<Vec<u8>>,
+    /// Malformed row markers retained at their insertion or deletion schema slot.
+    pub revision_xml: Vec<(usize, Vec<u8>)>,
     /// Other row properties retained at their schema insertion slots.
     pub extra_xml: Vec<(usize, Vec<u8>)>,
 }
@@ -1012,16 +1012,18 @@ impl CT_TrPr {
                         if let Some(revision) = CT_Revision::from_raw(raw.clone(), &prefixes) {
                             pr.revision_markers.push(revision);
                         } else {
-                            pr.revision_xml.push(raw);
+                            pr.revision_xml.push((at, raw));
                         }
                     } else if matches_local_name(name.as_ref(), b"ins")
                         || matches_local_name(name.as_ref(), b"del")
                     {
-                        pr.revision_xml
-                            .push(crate::text::raw_with_external_bindings(
+                        pr.revision_xml.push((
+                            row_revision_boundary(name.as_ref()),
+                            crate::text::raw_with_external_bindings(
                                 &capture_empty_element(e)?,
                                 owner_bindings,
-                            )?);
+                            )?,
+                        ));
                     } else {
                         pr.extra_xml.push((
                             at,
@@ -1046,16 +1048,18 @@ impl CT_TrPr {
                         if let Some(revision) = CT_Revision::from_raw(raw.clone(), &prefixes) {
                             pr.revision_markers.push(revision);
                         } else {
-                            pr.revision_xml.push(raw);
+                            pr.revision_xml.push((at, raw));
                         }
                     } else if matches_local_name(e.name().as_ref(), b"ins")
                         || matches_local_name(e.name().as_ref(), b"del")
                     {
-                        pr.revision_xml
-                            .push(crate::text::raw_with_external_bindings(
+                        pr.revision_xml.push((
+                            row_revision_boundary(e.name().as_ref()),
+                            crate::text::raw_with_external_bindings(
                                 &capture_element(reader, e)?,
                                 owner_bindings,
-                            )?);
+                            )?,
+                        ));
                     } else {
                         pr.extra_xml.push((
                             at,
@@ -1147,20 +1151,36 @@ impl CT_TrPr {
             writer.write_event(Event::Empty(e))?;
         }
 
-        for boundary in 11..=13 {
+        for boundary in 11..=12 {
             write_extras_at(writer, &self.extra_xml, boundary)?;
         }
-        for revision in &self.revision_markers {
-            revision.write_xml(writer)?;
-        }
-        for raw in &self.revision_xml {
-            writer.get_mut().write_all(raw)?;
-        }
+        self.write_revisions_at(writer, RevisionKind::Insertion, 12)?;
+        write_extras_at(writer, &self.extra_xml, 13)?;
+        self.write_revisions_at(writer, RevisionKind::Deletion, 13)?;
         for boundary in 14..=15 {
             write_extras_at(writer, &self.extra_xml, boundary)?;
         }
 
         writer.write_event(Event::End(BytesEnd::new("w:trPr")))?;
+        Ok(())
+    }
+
+    fn write_revisions_at<W: std::io::Write>(
+        &self,
+        writer: &mut Writer<W>,
+        kind: RevisionKind,
+        boundary: usize,
+    ) -> Result<()> {
+        for revision in self
+            .revision_markers
+            .iter()
+            .filter(|revision| revision.kind() == kind)
+        {
+            revision.write_xml(writer)?;
+        }
+        for (_, raw) in self.revision_xml.iter().filter(|(at, _)| *at == boundary) {
+            writer.get_mut().write_all(raw)?;
+        }
         Ok(())
     }
 
@@ -1175,6 +1195,14 @@ impl CT_TrPr {
             && self.revision_markers.is_empty()
             && self.revision_xml.is_empty()
             && self.extra_xml.is_empty()
+    }
+}
+
+fn row_revision_boundary(name: &[u8]) -> usize {
+    if matches_local_name(name, b"ins") {
+        12
+    } else {
+        13
     }
 }
 
@@ -3086,6 +3114,39 @@ mod tests {
         let reparsed = parse_scoped_table(&first_xml).expect("serialized table reparses");
         let second_xml = table_to_xml(&reparsed);
         assert_eq!(second_xml, first_xml);
+    }
+
+    #[test]
+    fn malformed_row_insertions_stay_before_typed_deletions() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr>
+                 <w:trPr>
+                   <w:ins w:id="1"/>
+                   <w:del w:id="2" w:author="Ada"/>
+                 </w:trPr>
+                 <w:tc><w:p/></w:tc>
+               </w:tr>"#,
+        );
+
+        let properties = table.rows[0].properties.as_ref().unwrap();
+        assert_eq!(
+            properties.revision_xml,
+            vec![(12, br#"<w:ins w:id="1"/>"#.to_vec())]
+        );
+        assert_eq!(properties.revision_markers.len(), 1);
+        assert_eq!(
+            properties.revision_markers[0].kind(),
+            RevisionKind::Deletion
+        );
+
+        let first_xml = table_to_xml(&table);
+        let insertion = first_xml.find("<w:ins").expect("insertion writes");
+        let deletion = first_xml.find("<w:del").expect("deletion writes");
+        assert!(insertion < deletion, "{first_xml}");
+
+        let reparsed = parse_scoped_table(&first_xml).expect("serialized table reparses");
+        assert_eq!(table_to_xml(&reparsed), first_xml);
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -955,6 +955,14 @@ impl CT_TrPr {
         reader: &mut Reader<&[u8]>,
         word_prefixes: &[String],
     ) -> Result<Self> {
+        Self::from_xml_with_prefixes_and_owner_bindings(reader, word_prefixes, &[])
+    }
+
+    pub(crate) fn from_xml_with_prefixes_and_owner_bindings(
+        reader: &mut Reader<&[u8]>,
+        word_prefixes: &[String],
+        owner_bindings: &[(String, String)],
+    ) -> Result<Self> {
         let mut pr = CT_TrPr::default();
         let mut boundary = 0usize;
         let mut buf = Vec::new();
@@ -997,7 +1005,10 @@ impl CT_TrPr {
                     } else if is_word_element(name.as_ref(), b"ins", &prefixes)
                         || is_word_element(name.as_ref(), b"del", &prefixes)
                     {
-                        let raw = capture_empty_element(e)?;
+                        let raw = crate::text::raw_with_external_bindings(
+                            &capture_empty_element(e)?,
+                            owner_bindings,
+                        )?;
                         if let Some(revision) = CT_Revision::from_raw(raw.clone(), &prefixes) {
                             pr.revision_markers.push(revision);
                         } else {
@@ -1006,9 +1017,19 @@ impl CT_TrPr {
                     } else if matches_local_name(name.as_ref(), b"ins")
                         || matches_local_name(name.as_ref(), b"del")
                     {
-                        pr.revision_xml.push(capture_empty_element(e)?);
+                        pr.revision_xml
+                            .push(crate::text::raw_with_external_bindings(
+                                &capture_empty_element(e)?,
+                                owner_bindings,
+                            )?);
                     } else {
-                        pr.extra_xml.push((at, capture_empty_element(e)?));
+                        pr.extra_xml.push((
+                            at,
+                            crate::text::raw_with_external_bindings(
+                                &capture_empty_element(e)?,
+                                owner_bindings,
+                            )?,
+                        ));
                     }
                     boundary = next;
                 }
@@ -1018,7 +1039,10 @@ impl CT_TrPr {
                     if is_word_element(e.name().as_ref(), b"ins", &prefixes)
                         || is_word_element(e.name().as_ref(), b"del", &prefixes)
                     {
-                        let raw = capture_element(reader, e)?;
+                        let raw = crate::text::raw_with_external_bindings(
+                            &capture_element(reader, e)?,
+                            owner_bindings,
+                        )?;
                         if let Some(revision) = CT_Revision::from_raw(raw.clone(), &prefixes) {
                             pr.revision_markers.push(revision);
                         } else {
@@ -1027,9 +1051,19 @@ impl CT_TrPr {
                     } else if matches_local_name(e.name().as_ref(), b"ins")
                         || matches_local_name(e.name().as_ref(), b"del")
                     {
-                        pr.revision_xml.push(capture_element(reader, e)?);
+                        pr.revision_xml
+                            .push(crate::text::raw_with_external_bindings(
+                                &capture_element(reader, e)?,
+                                owner_bindings,
+                            )?);
                     } else {
-                        pr.extra_xml.push((at, capture_element(reader, e)?));
+                        pr.extra_xml.push((
+                            at,
+                            crate::text::raw_with_external_bindings(
+                                &capture_element(reader, e)?,
+                                owner_bindings,
+                            )?,
+                        ));
                     }
                     boundary = next;
                 }
@@ -1736,6 +1770,14 @@ impl CT_Row {
         reader: &mut Reader<&[u8]>,
         word_prefixes: &[String],
     ) -> Result<Self> {
+        Self::from_xml_with_prefixes_and_owner_bindings(reader, word_prefixes, &[])
+    }
+
+    pub(crate) fn from_xml_with_prefixes_and_owner_bindings(
+        reader: &mut Reader<&[u8]>,
+        word_prefixes: &[String],
+        owner_bindings: &[(String, String)],
+    ) -> Result<Self> {
         let mut table_property_exception = None;
         let mut properties = None;
         let mut cells = Vec::new();
@@ -1753,7 +1795,14 @@ impl CT_Row {
                     {
                         table_property_exception = Some(capture_element(reader, e)?);
                     } else if is_word_element(name.as_ref(), b"trPr", &prefixes) {
-                        properties = Some(CT_TrPr::from_xml_with_prefixes(reader, &prefixes)?);
+                        let local_bindings = local_namespace_overrides(e, word_prefixes)?;
+                        let property_bindings =
+                            merged_owner_bindings(owner_bindings, &local_bindings);
+                        properties = Some(CT_TrPr::from_xml_with_prefixes_and_owner_bindings(
+                            reader,
+                            &prefixes,
+                            &property_bindings,
+                        )?);
                     } else if is_word_element(name.as_ref(), b"tc", &prefixes) {
                         let owner_bindings = local_namespace_overrides(e, word_prefixes)?;
                         cells.push(CT_Tc::from_xml_with_prefixes_and_owner_bindings(
@@ -1951,7 +2000,12 @@ impl CT_Tbl {
                     } else if is_word_element(name.as_ref(), b"tblGrid", &prefixes) {
                         grid = Some(CT_TblGrid::from_xml_with_prefixes(reader, &prefixes)?);
                     } else if is_word_element(name.as_ref(), b"tr", &prefixes) {
-                        rows.push(CT_Row::from_xml_with_prefixes(reader, &prefixes)?);
+                        let owner_bindings = local_namespace_overrides(e, word_prefixes)?;
+                        rows.push(CT_Row::from_xml_with_prefixes_and_owner_bindings(
+                            reader,
+                            &prefixes,
+                            &owner_bindings,
+                        )?);
                     } else if is_word_element(name.as_ref(), b"sdt", &prefixes) {
                         let raw = capture_element(reader, e)?;
                         if let Some(sdt) = CT_Sdt::from_raw(&raw, &prefixes) {
@@ -3000,6 +3054,38 @@ mod tests {
             grid < spacing && spacing < alignment && alignment < insertion && insertion < change,
             "{xml}"
         );
+    }
+
+    #[test]
+    fn retained_row_properties_keep_inherited_owner_namespace_bindings() {
+        let table = parse_table(
+            r#"<w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr xmlns:row-ext="urn:row-property">
+                 <w:trPr xmlns:properties-ext="urn:properties-property">
+                   <row-ext:fromRow row-ext:value="kept"/>
+                   <properties-ext:fromProperties properties-ext:value="kept"/>
+                 </w:trPr>
+                 <w:tc><w:p/></w:tc>
+               </w:tr>"#,
+        );
+
+        let first_xml = table_to_xml(&table);
+        assert!(
+            first_xml.contains(
+                r#"<row-ext:fromRow row-ext:value="kept" xmlns:row-ext="urn:row-property"/>"#
+            ),
+            "{first_xml}"
+        );
+        assert!(
+            first_xml.contains(
+                r#"<properties-ext:fromProperties properties-ext:value="kept" xmlns:properties-ext="urn:properties-property"/>"#
+            ),
+            "{first_xml}"
+        );
+
+        let reparsed = parse_scoped_table(&first_xml).expect("serialized table reparses");
+        let second_xml = table_to_xml(&reparsed);
+        assert_eq!(second_xml, first_xml);
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/table.rs
+++ b/crates/rdocx-oxml/src/table.rs
@@ -126,10 +126,25 @@ impl CT_TblBorders {
                         borders.inside_v =
                             Some(CT_BorderEdge::from_xml_attrs_with_prefixes(e, &prefixes)?);
                     } else {
-                        borders.extra_xml.push(capture_empty_element(e)?);
+                        let raw = capture_empty_element(e)?;
+                        borders
+                            .extra_xml
+                            .push(crate::text::raw_with_external_bindings(
+                                &raw,
+                                &preserved_table_raw_bindings(&prefixes),
+                            )?);
                     }
                 }
-                Ok(Event::Start(ref e)) => borders.extra_xml.push(capture_element(reader, e)?),
+                Ok(Event::Start(ref e)) => {
+                    let prefixes = word_prefixes_at(e, word_prefixes)?;
+                    let raw = capture_element(reader, e)?;
+                    borders
+                        .extra_xml
+                        .push(crate::text::raw_with_external_bindings(
+                            &raw,
+                            &preserved_table_raw_bindings(&prefixes),
+                        )?);
+                }
                 Ok(Event::End(ref e))
                     if matches_local_name(e.name().as_ref(), b"tblBorders")
                         || matches_local_name(e.name().as_ref(), b"tcBorders") =>
@@ -2818,6 +2833,37 @@ mod tests {
         assert_eq!(borders.top.unwrap().val, ST_Border::Single);
         assert_eq!(borders.inside_h.unwrap().val, ST_Border::Single);
         assert_eq!(borders.inside_v.unwrap().val, ST_Border::Single);
+    }
+
+    #[test]
+    fn retained_border_children_keep_owner_namespace_bindings() {
+        let table = parse_table(
+            r#"<w:tblPr>
+                 <w:tblBorders xmlns:table-ext="urn:table-border">
+                   <table-ext:diagonal table-ext:value="kept"/>
+                 </w:tblBorders>
+               </w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:tcPr>
+                 <w:tcBorders xmlns:cell-ext="urn:cell-border">
+                   <cell-ext:diagonal cell-ext:value="kept"/>
+                 </w:tcBorders>
+               </w:tcPr><w:p/></w:tc></w:tr>"#,
+        );
+
+        let xml = table_to_xml(&table);
+        assert!(
+            xml.contains(
+                r#"<table-ext:diagonal table-ext:value="kept" xmlns:table-ext="urn:table-border"/>"#
+            ),
+            "{xml}"
+        );
+        assert!(
+            xml.contains(
+                r#"<cell-ext:diagonal cell-ext:value="kept" xmlns:cell-ext="urn:cell-border"/>"#
+            ),
+            "{xml}"
+        );
     }
 
     #[test]

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -2324,6 +2324,28 @@ impl Document {
         })
     }
 
+    /// Whether the document declares a page background that may affect its
+    /// visible appearance.
+    pub fn has_document_background(&self) -> bool {
+        self.document.background_xml.is_some()
+    }
+
+    /// Whether any document section carries layout formatting.
+    ///
+    /// This includes the final body section and sections attached to paragraph
+    /// properties. Callers that cannot preserve page layout can reject such
+    /// documents without treating section XML as ordinary body content.
+    pub fn has_section_layout_formatting(&self) -> bool {
+        self.section_properties_in_order().any(section_has_layout)
+    }
+
+    /// Whether any document section retains XML that the semantic section
+    /// reader does not model.
+    pub fn has_unmodeled_section_properties(&self) -> bool {
+        self.section_properties_in_order()
+            .any(|properties| !properties.extra_xml.is_empty() || properties.change.is_some())
+    }
+
     /// Get immutable references to all paragraphs.
     pub fn paragraphs(&self) -> Vec<ParagraphRef<'_>> {
         self.document
@@ -3658,6 +3680,23 @@ impl Document {
         run_style_id: Option<&str>,
     ) -> CT_RPr {
         style::resolve_run_properties(para_style_id, run_style_id, &self.styles)
+    }
+
+    fn section_properties_in_order(&self) -> impl Iterator<Item = &CT_SectPr> {
+        self.document
+            .body
+            .content
+            .iter()
+            .filter_map(|content| match content {
+                BodyContent::Paragraph(paragraph) => paragraph
+                    .properties
+                    .as_ref()
+                    .and_then(|properties| properties.sect_pr.as_ref()),
+                BodyContent::Table(_) | BodyContent::ContentControl(_) | BodyContent::RawXml(_) => {
+                    None
+                }
+            })
+            .chain(self.document.body.sect_pr.iter())
     }
 
     // ---- Section/Page setup ----
@@ -6082,6 +6121,22 @@ fn relative_target(source_part: &str, target_part: &str) -> String {
     }
 }
 
+fn section_has_layout(properties: &CT_SectPr) -> bool {
+    properties.page_width.is_some()
+        || properties.page_height.is_some()
+        || properties.orientation.is_some()
+        || properties.margin_top.is_some()
+        || properties.margin_right.is_some()
+        || properties.margin_bottom.is_some()
+        || properties.margin_left.is_some()
+        || properties.gutter.is_some()
+        || properties.header_distance.is_some()
+        || properties.footer_distance.is_some()
+        || properties.section_type.is_some()
+        || properties.columns.is_some()
+        || properties.title_pg.is_some()
+}
+
 /// Numbering format for one level of a custom list definition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ListNumberFormat {
@@ -6740,6 +6795,26 @@ mod tests {
                 "paragraph:last",
             ]
         );
+    }
+
+    #[test]
+    fn reader_reports_background_and_section_completeness_facts() {
+        let mut doc = Document::new();
+        assert!(!doc.has_document_background());
+        assert!(doc.has_section_layout_formatting());
+        assert!(!doc.has_unmodeled_section_properties());
+
+        doc.document.background_xml = Some(b"<w:background/>".to_vec());
+        doc.document
+            .body
+            .sect_pr
+            .as_mut()
+            .expect("default section properties")
+            .extra_xml
+            .push(b"<w:printerSettings r:id=\"rId1\"/>".to_vec());
+
+        assert!(doc.has_document_background());
+        assert!(doc.has_unmodeled_section_properties());
     }
 
     #[test]

--- a/crates/rdocx/src/epub.rs
+++ b/crates/rdocx/src/epub.rs
@@ -2468,6 +2468,7 @@ fn render_table_projection(table: &CT_Tbl) -> CT_Tbl {
             .rows
             .iter()
             .map(|row| CT_Row {
+                table_property_exception: None,
                 properties: None,
                 cells: row
                     .cells

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -77,7 +77,9 @@ pub use run::{
 };
 pub use style::{Style, StyleBuilder};
 pub use svg::{SvgDiagnostic, SvgRenderResult};
-pub use table::{Cell, CellItemRef, CellRef, Row, RowRef, Table, TableRef, VerticalAlignment};
+pub use table::{
+    Cell, CellItemRef, CellRef, Row, RowRef, Table, TableRef, VMerge, VerticalAlignment,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -1019,7 +1019,7 @@ mod tests {
             cell_margin: Some(CT_TblCellMar::default()),
             indent: Some(CT_TblWidth::dxa(100)),
             look: Some(CT_TblLook::default()),
-            extra_xml: vec![b"<w:bidiVisual/>".to_vec()],
+            extra_xml: vec![(3, b"<w:bidiVisual/>".to_vec())],
             ..Default::default()
         });
 

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -125,6 +125,7 @@ impl<'a> Table<'a> {
             right: Some(edge.clone()),
             inside_h: Some(edge.clone()),
             inside_v: Some(edge),
+            extra_xml: Vec::new(),
         });
     }
 

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -3,9 +3,10 @@
 use rdocx_oxml::borders::CT_BorderEdge;
 use rdocx_oxml::properties::CT_Shd;
 use rdocx_oxml::shared::ST_Jc;
+pub use rdocx_oxml::table::VMerge;
 use rdocx_oxml::table::{
     CT_Row, CT_Tbl, CT_TblBorders, CT_TblCellMar, CT_TblPr, CT_TblWidth, CT_Tc, CT_TcPr, CT_TrPr,
-    CellContent, ST_VerticalJc, VMerge,
+    CellContent, ST_VerticalJc,
 };
 use rdocx_oxml::text::CT_P;
 
@@ -604,6 +605,28 @@ impl<'a> TableRef<'a> {
             .unwrap_or(0)
     }
 
+    /// Whether the table contains direct content other than rows.
+    pub fn has_unsupported_content(&self) -> bool {
+        !self.inner.extra_xml.is_empty() || !self.inner.content_controls.is_empty()
+    }
+
+    /// Whether table properties retain facts outside the public reader model.
+    pub fn has_unmodeled_properties(&self) -> bool {
+        self.inner.properties.as_ref().is_some_and(|properties| {
+            properties.change.is_some()
+                || !properties.revision_xml.is_empty()
+                || !properties.extra_xml.is_empty()
+                || properties
+                    .borders
+                    .as_ref()
+                    .is_some_and(|borders| !borders.extra_xml.is_empty())
+        }) || self
+            .inner
+            .grid
+            .as_ref()
+            .is_some_and(|grid| !grid.extra_xml.is_empty())
+    }
+
     /// Whether the table preserves a historical grid revision.
     ///
     /// The historical grid is round-trip metadata. Active columns remain the
@@ -657,6 +680,63 @@ impl<'a> TableRef<'a> {
         let width = self.inner.properties.as_ref()?.width.as_ref()?;
         (width.width_type == "dxa").then(|| Length::twips(width.w))
     }
+
+    /// Whether explicit table width is present.
+    pub fn has_width(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.width.is_some())
+    }
+
+    /// Whether explicit table borders are present.
+    pub fn has_borders(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.borders.as_ref())
+            .is_some_and(|borders| !borders.is_empty())
+    }
+
+    /// Whether explicit table shading is present.
+    pub fn has_shading(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.shading.is_some())
+    }
+
+    /// Whether an explicit table layout mode is present.
+    pub fn has_layout(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.layout.is_some())
+    }
+
+    /// Whether default table-cell margins are present.
+    pub fn has_cell_margins(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.cell_margin.is_some())
+    }
+
+    /// Whether an explicit table indentation is present.
+    pub fn has_indent(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.indent.is_some())
+    }
+
+    /// Whether table-style conditional formatting flags are present.
+    pub fn has_style_look(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.look.is_some())
+    }
 }
 
 /// An immutable reference to a table row.
@@ -668,6 +748,36 @@ impl<'a> RowRef<'a> {
     /// Get the number of cells.
     pub fn cell_count(&self) -> usize {
         self.inner.cells.len()
+    }
+
+    /// Whether the row contains direct content other than cells.
+    pub fn has_unsupported_content(&self) -> bool {
+        !self.inner.extra_xml.is_empty() || !self.inner.content_controls.is_empty()
+    }
+
+    /// Whether row properties retain facts outside the public reader model.
+    pub fn has_unmodeled_properties(&self) -> bool {
+        self.inner.properties.as_ref().is_some_and(|properties| {
+            !properties.revision_markers.is_empty()
+                || !properties.revision_xml.is_empty()
+                || !properties.extra_xml.is_empty()
+        })
+    }
+
+    /// Number of table grid columns omitted before the first cell.
+    pub fn grid_before(&self) -> Option<u32> {
+        self.inner
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.grid_before)
+    }
+
+    /// Number of table grid columns omitted after the last cell.
+    pub fn grid_after(&self) -> Option<u32> {
+        self.inner
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.grid_after)
     }
 
     /// Get a cell reference by index.
@@ -682,6 +792,18 @@ impl<'a> RowRef<'a> {
             .as_ref()
             .and_then(|pr| pr.header)
             .unwrap_or(false)
+    }
+
+    /// Whether the row carries explicit presentation formatting.
+    pub fn has_formatting(&self) -> bool {
+        self.inner.table_property_exception.is_some()
+            || self.inner.properties.as_ref().is_some_and(|properties| {
+                properties.height.is_some()
+                    || properties.height_rule.is_some()
+                    || properties.jc.is_some()
+                    || properties.cant_split.is_some()
+                    || properties.cnf_style.is_some()
+            })
     }
 }
 
@@ -704,6 +826,17 @@ pub enum CellItemRef<'a> {
 }
 
 impl<'a> CellRef<'a> {
+    /// Whether cell properties retain facts outside the public reader model.
+    pub fn has_unmodeled_properties(&self) -> bool {
+        self.inner.properties.as_ref().is_some_and(|properties| {
+            !properties.extra_xml.is_empty()
+                || properties
+                    .borders
+                    .as_ref()
+                    .is_some_and(|borders| !borders.extra_xml.is_empty())
+        })
+    }
+
     /// Get the combined text of all paragraphs.
     pub fn text(&self) -> String {
         self.inner.text()
@@ -770,6 +903,14 @@ impl<'a> CellRef<'a> {
         self.inner.properties.as_ref().and_then(|pr| pr.grid_span)
     }
 
+    /// Whether the cell uses the legacy horizontal-merge property.
+    pub fn has_horizontal_merge(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.h_merge.is_some())
+    }
+
     /// Get the vertical merge state, if set.
     pub fn v_merge(&self) -> Option<&VMerge> {
         self.inner
@@ -787,6 +928,55 @@ impl<'a> CellRef<'a> {
             .and_then(|shd| shd.fill.as_deref())
     }
 
+    /// Whether explicit cell width is present.
+    pub fn has_width(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.width.is_some())
+    }
+
+    /// Whether explicit cell borders are present.
+    pub fn has_borders(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.borders.as_ref())
+            .is_some_and(|borders| !borders.is_empty())
+    }
+
+    /// Whether explicit cell shading is present.
+    pub fn has_shading(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.shading.is_some())
+    }
+
+    /// Whether the cell disables wrapping.
+    pub fn has_wrapping_formatting(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.no_wrap.is_some())
+    }
+
+    /// Whether the cell carries an explicit text direction.
+    pub fn has_text_direction(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.text_direction.is_some())
+    }
+
+    /// Whether the cell carries table-style conditional formatting flags.
+    pub fn has_conditional_formatting(&self) -> bool {
+        self.inner
+            .properties
+            .as_ref()
+            .is_some_and(|properties| properties.cnf_style.is_some())
+    }
+
     /// Get the vertical alignment, if set.
     pub fn vertical_alignment(&self) -> Option<VerticalAlignment> {
         self.inner
@@ -800,8 +990,102 @@ impl<'a> CellRef<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdocx_oxml::table::{CT_Row, CT_TblGrid, CT_TblGridCol};
+    use rdocx_oxml::shared::ST_Border;
+    use rdocx_oxml::table::{CT_Row, CT_TblGrid, CT_TblGridCol, CT_TblLook};
     use rdocx_oxml::units::Twips;
+
+    #[test]
+    fn reader_exposes_table_row_and_cell_completeness_facts() {
+        let border = CT_BorderEdge::new(ST_Border::Single);
+        let mut inner = CT_Tbl::new();
+        inner.extra_xml.push((0, b"<w:custom/>".to_vec()));
+        inner.grid = Some(CT_TblGrid {
+            extra_xml: vec![b"<w:customGrid/>".to_vec()],
+            ..Default::default()
+        });
+        inner.properties = Some(CT_TblPr {
+            width: Some(CT_TblWidth::dxa(1_000)),
+            borders: Some(CT_TblBorders {
+                top: Some(border.clone()),
+                extra_xml: vec![b"<w:diagonalDown/>".to_vec()],
+                ..Default::default()
+            }),
+            shading: Some(CT_Shd {
+                val: "clear".to_owned(),
+                color: None,
+                fill: Some("FFFFFF".to_owned()),
+            }),
+            layout: Some("fixed".to_owned()),
+            cell_margin: Some(CT_TblCellMar::default()),
+            indent: Some(CT_TblWidth::dxa(100)),
+            look: Some(CT_TblLook::default()),
+            extra_xml: vec![b"<w:bidiVisual/>".to_vec()],
+            ..Default::default()
+        });
+
+        let mut row = CT_Row::new();
+        row.extra_xml.push((0, b"<w:customRow/>".to_vec()));
+        row.properties = Some(CT_TrPr {
+            height: Some(Twips(240)),
+            grid_before: Some(1),
+            grid_after: Some(2),
+            extra_xml: vec![b"<w:tblCellSpacing/>".to_vec()],
+            ..Default::default()
+        });
+
+        let mut cell = CT_Tc::new();
+        cell.properties = Some(CT_TcPr {
+            width: Some(CT_TblWidth::dxa(1_000)),
+            h_merge: Some("restart".to_owned()),
+            v_merge: Some(VMerge::Restart),
+            borders: Some(CT_TblBorders {
+                top: Some(border),
+                extra_xml: vec![b"<w:diagonalDown/>".to_vec()],
+                ..Default::default()
+            }),
+            shading: Some(CT_Shd {
+                val: "clear".to_owned(),
+                color: None,
+                fill: Some("FFFFFF".to_owned()),
+            }),
+            no_wrap: Some(true),
+            text_direction: Some("btLr".to_owned()),
+            cnf_style: Some("100000000000".to_owned()),
+            extra_xml: vec![(0, b"<w:fitText/>".to_vec())],
+            ..Default::default()
+        });
+        row.cells.push(cell);
+        inner.rows.push(row);
+
+        let table = TableRef { inner: &inner };
+        assert!(table.has_unsupported_content());
+        assert!(table.has_unmodeled_properties());
+        assert!(table.has_width());
+        assert!(table.has_borders());
+        assert!(table.has_shading());
+        assert!(table.has_layout());
+        assert!(table.has_cell_margins());
+        assert!(table.has_indent());
+        assert!(table.has_style_look());
+
+        let row = table.row(0).expect("table row");
+        assert!(row.has_unsupported_content());
+        assert!(row.has_unmodeled_properties());
+        assert!(row.has_formatting());
+        assert_eq!(row.grid_before(), Some(1));
+        assert_eq!(row.grid_after(), Some(2));
+
+        let cell = row.cell(0).expect("table cell");
+        assert!(cell.has_unmodeled_properties());
+        assert!(cell.has_horizontal_merge());
+        assert!(matches!(cell.v_merge(), Some(VMerge::Restart)));
+        assert!(cell.has_width());
+        assert!(cell.has_borders());
+        assert!(cell.has_shading());
+        assert!(cell.has_wrapping_formatting());
+        assert!(cell.has_text_direction());
+        assert!(cell.has_conditional_formatting());
+    }
 
     #[test]
     fn table_ref_reports_preserved_grid_change() {

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -1029,7 +1029,7 @@ mod tests {
             height: Some(Twips(240)),
             grid_before: Some(1),
             grid_after: Some(2),
-            extra_xml: vec![b"<w:tblCellSpacing/>".to_vec()],
+            extra_xml: vec![(9, b"<w:tblCellSpacing/>".to_vec())],
             ..Default::default()
         });
 

--- a/crates/rdocx/src/table.rs
+++ b/crates/rdocx/src/table.rs
@@ -800,7 +800,10 @@ impl<'a> RowRef<'a> {
             || self.inner.properties.as_ref().is_some_and(|properties| {
                 properties.height.is_some()
                     || properties.height_rule.is_some()
+                    || properties.header.is_some()
                     || properties.jc.is_some()
+                    || properties.grid_before.is_some()
+                    || properties.grid_after.is_some()
                     || properties.cant_split.is_some()
                     || properties.cnf_style.is_some()
             })
@@ -1085,6 +1088,32 @@ mod tests {
         assert!(cell.has_wrapping_formatting());
         assert!(cell.has_text_direction());
         assert!(cell.has_conditional_formatting());
+    }
+
+    #[test]
+    fn row_formatting_includes_header_and_grid_offset_properties() {
+        for properties in [
+            CT_TrPr {
+                header: Some(true),
+                ..Default::default()
+            },
+            CT_TrPr {
+                grid_before: Some(1),
+                ..Default::default()
+            },
+            CT_TrPr {
+                grid_after: Some(1),
+                ..Default::default()
+            },
+        ] {
+            let mut inner = CT_Tbl::new();
+            let mut row = CT_Row::new();
+            row.properties = Some(properties);
+            inner.rows.push(row);
+
+            let table = TableRef { inner: &inner };
+            assert!(table.row(0).unwrap().has_formatting());
+        }
     }
 
     #[test]

--- a/crates/rdocx/tests/integration_test.rs
+++ b/crates/rdocx/tests/integration_test.rs
@@ -1353,16 +1353,10 @@ fn rtf_writer_reports_raw_table_cell_property_xml_once() {
 
     assert_eq!(
         messages,
-        [
-            (
-                "body[0]/row[0]/cell[0]/tcPr/raw[3]".to_owned(),
-                "unmodelled table-cell property hMerge was dropped during RTF export".to_owned(),
-            ),
-            (
-                "body[0]/row[0]/cell[0]/tcPr/raw[4]".to_owned(),
-                "unmodelled table-cell property cellProp was dropped during RTF export".to_owned(),
-            ),
-        ]
+        [(
+            "body[0]/row[0]/cell[0]/tcPr/raw[4]".to_owned(),
+            "unmodelled table-cell property cellProp was dropped during RTF export".to_owned(),
+        )]
     );
 }
 


### PR DESCRIPTION
## Summary

- preserve previously dropped table, row, border, and legacy merge properties
- expose document background and section completeness facts
- expose fail-closed table, row, and cell reader facts
- keep the existing ordered `CellItemRef` API and publicly re-export `VMerge`

## Review follow-up

- rebased onto current `main`
- updated table-border test literals for the retained XML field
- write `gridBefore` and `gridAfter` before later row properties in schema order
- retain unmodeled table properties at their schema boundaries before `tblPrChange`
- update the RTF diagnostic expectation now that `hMerge` is modeled
- ready for maintainer F-ID integration

## Validation

- `cargo test -p rdocx-oxml --lib`
- `cargo test -p rdocx-layout --lib`
- focused `rdocx` integration test for table-cell property diagnostics
- `cargo clippy -p rdocx-oxml -p rdocx-layout -p rdocx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/hash_harness.py --check`

The local unfiltered `rdocx` run only reaches the existing environment-dependent `word_and_powerpoint_chart_pixels_are_identical` rasterizer oracle assertion. The failure does not exercise these reader changes.
