### PR TITLE
Expose numbering and effective formatting reader facts

### DIFF
--- a/crates/rdocx-oxml/src/numbering.rs
+++ b/crates/rdocx-oxml/src/numbering.rs
@@ -2242,10 +2242,14 @@ impl CT_Lvl {
                         reader.read_to_end_into(name, &mut Vec::new())?;
                         boundary = 7;
                     } else if is_word_element(name.as_ref(), b"lvlJc", &prefixes) {
-                        if let Some(value) = word_attribute_value(e, b"val", &prefixes)? {
-                            lvl.lvl_jc = ST_Jc::from_str(&value).ok();
+                        if let Some(value) = word_attribute_value(e, b"val", &prefixes)?
+                            && let Ok(justification) = ST_Jc::from_str(&value)
+                        {
+                            lvl.lvl_jc = Some(justification);
+                            reader.read_to_end_into(name, &mut Vec::new())?;
+                        } else {
+                            lvl.extra_xml.push((9, capture_element(reader, e)?));
                         }
-                        reader.read_to_end_into(name, &mut Vec::new())?;
                         boundary = 10;
                     } else if is_word_element(name.as_ref(), b"pPr", &prefixes) {
                         let raw = capture_element(reader, e)?;
@@ -2299,10 +2303,14 @@ impl CT_Lvl {
                     } else if is_word_element(name.as_ref(), b"lvlText", &prefixes) {
                         lvl.lvl_text = word_attribute_value(e, b"val", &prefixes)?;
                         boundary = 7;
-                    } else if is_word_element(name.as_ref(), b"lvlJc", &prefixes)
-                        && let Some(val) = word_attribute_value(e, b"val", &prefixes)?
-                    {
-                        lvl.lvl_jc = ST_Jc::from_str(&val).ok();
+                    } else if is_word_element(name.as_ref(), b"lvlJc", &prefixes) {
+                        if let Some(value) = word_attribute_value(e, b"val", &prefixes)?
+                            && let Ok(justification) = ST_Jc::from_str(&value)
+                        {
+                            lvl.lvl_jc = Some(justification);
+                        } else {
+                            lvl.extra_xml.push((9, capture_empty_element(e)?));
+                        }
                         boundary = 10;
                     } else if is_word_element(name.as_ref(), b"pPr", &prefixes) {
                         let raw = capture_empty_element(e)?;
@@ -4815,5 +4823,20 @@ mod tests {
             reopened.abstract_nums[0].levels[0].num_fmt,
             Some(ST_NumberFormat::Other("chicago".to_owned()))
         );
+    }
+
+    #[test]
+    fn producer_defined_suffix_and_justification_remain_unmodelled() {
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:suff w:val="producer"/><w:lvlJc w:val="producer"/></w:lvl></w:abstractNum></w:numbering>"#;
+        let numbering = CT_Numbering::from_xml(xml).unwrap();
+        let level = &numbering.abstract_nums[0].levels[0];
+
+        assert_eq!(level.suffix, None);
+        assert_eq!(level.lvl_jc, None);
+        assert_eq!(level.extra_xml.len(), 2);
+
+        let output = String::from_utf8(numbering.to_xml().unwrap()).unwrap();
+        assert!(output.contains(r#"<w:suff w:val="producer"/>"#));
+        assert!(output.contains(r#"<w:lvlJc w:val="producer"/>"#));
     }
 }

--- a/crates/rdocx-oxml/src/numbering.rs
+++ b/crates/rdocx-oxml/src/numbering.rs
@@ -2148,6 +2148,8 @@ pub struct CT_Lvl {
     pub start: Option<u32>,
     /// Number format
     pub num_fmt: Option<ST_NumberFormat>,
+    /// Paragraph style associated with this numbering level.
+    pub p_style: Option<String>,
     /// Item emitted between the marker and the paragraph content.
     pub suffix: Option<ST_LvlSuffix>,
     /// Level text (e.g., "%1.", "%1.%2.", bullet char)
@@ -2175,6 +2177,7 @@ impl CT_Lvl {
             ilvl,
             start: None,
             num_fmt: None,
+            p_style: None,
             suffix: None,
             lvl_text: None,
             lvl_jc: None,
@@ -2217,6 +2220,10 @@ impl CT_Lvl {
                         }
                         reader.read_to_end_into(name, &mut Vec::new())?;
                         boundary = 2;
+                    } else if is_word_element(name.as_ref(), b"pStyle", &prefixes) {
+                        lvl.p_style = word_attribute_value(e, b"val", &prefixes)?;
+                        reader.read_to_end_into(name, &mut Vec::new())?;
+                        boundary = 4;
                     } else if is_word_element(name.as_ref(), b"suff", &prefixes) {
                         if let Some(value) = word_attribute_value(e, b"val", &prefixes)?
                             && let Some(suffix) = ST_LvlSuffix::from_str(&value)
@@ -2275,6 +2282,9 @@ impl CT_Lvl {
                             lvl.num_fmt = Some(ST_NumberFormat::from_str(&val));
                         }
                         boundary = 2;
+                    } else if is_word_element(name.as_ref(), b"pStyle", &prefixes) {
+                        lvl.p_style = word_attribute_value(e, b"val", &prefixes)?;
+                        boundary = 4;
                     } else if is_word_element(name.as_ref(), b"suff", &prefixes) {
                         if let Some(value) = word_attribute_value(e, b"val", &prefixes)?
                             && let Some(suffix) = ST_LvlSuffix::from_str(&value)
@@ -2366,7 +2376,15 @@ impl CT_Lvl {
             writer.write_event(Event::Empty(e))?;
         }
 
-        for boundary in 2..=5 {
+        write_extras_at(writer, &self.extra_xml, 2)?;
+        if let Some(style) = &self.p_style {
+            let name = qualified(word_prefix, "pStyle");
+            let val_name = qualified(word_prefix, "val");
+            let mut element = BytesStart::new(name.as_str());
+            element.push_attribute((val_name.as_str(), style.as_str()));
+            writer.write_event(Event::Empty(element))?;
+        }
+        for boundary in 3..=5 {
             write_extras_at(writer, &self.extra_xml, boundary)?;
         }
         if let Some(suffix) = self.suffix {
@@ -2476,8 +2494,12 @@ impl CT_Lvl {
 pub struct CT_AbstractNum {
     pub abstract_num_id: u32,
     pub levels: Vec<CT_Lvl>,
+    /// Producer identifier for this abstract numbering definition.
+    pub nsid: Option<String>,
     /// Optional multi-level type hint
     pub multi_level_type: Option<String>,
+    /// Producer template identifier for this abstract numbering definition.
+    pub tmpl: Option<String>,
     /// Unmodelled children retained at their modelled-child boundaries.
     pub extra_xml: Vec<(usize, Vec<u8>)>,
     /// Unmodelled attributes and namespace declarations from `w:abstractNum`.
@@ -2490,7 +2512,9 @@ impl CT_AbstractNum {
         CT_AbstractNum {
             abstract_num_id: id,
             levels: Vec::new(),
+            nsid: None,
             multi_level_type: None,
+            tmpl: None,
             extra_xml: Vec::new(),
             extra_attributes: Vec::new(),
         }
@@ -2514,10 +2538,18 @@ impl CT_AbstractNum {
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
-                    if is_word_element(name.as_ref(), b"multiLevelType", &prefixes) {
+                    if is_word_element(name.as_ref(), b"nsid", &prefixes) {
+                        abs.nsid = word_attribute_value(e, b"val", &prefixes)?;
+                        reader.read_to_end_into(name, &mut Vec::new())?;
+                        boundary = 1;
+                    } else if is_word_element(name.as_ref(), b"multiLevelType", &prefixes) {
                         abs.multi_level_type = word_attribute_value(e, b"val", &prefixes)?;
                         reader.read_to_end_into(name, &mut Vec::new())?;
                         boundary = 2;
+                    } else if is_word_element(name.as_ref(), b"tmpl", &prefixes) {
+                        abs.tmpl = word_attribute_value(e, b"val", &prefixes)?;
+                        reader.read_to_end_into(name, &mut Vec::new())?;
+                        boundary = 3;
                     } else if is_word_element(name.as_ref(), b"lvl", &prefixes) {
                         let ilvl = u32_attribute(e, b"ilvl", &prefixes)?;
                         let mut level = CT_Lvl::from_xml_with_prefixes(reader, ilvl, &prefixes)?;
@@ -2534,9 +2566,15 @@ impl CT_AbstractNum {
                 Ok(Event::Empty(ref e)) => {
                     let name = e.name();
                     let prefixes = word_prefixes_at(e, word_prefixes)?;
-                    if is_word_element(name.as_ref(), b"multiLevelType", &prefixes) {
+                    if is_word_element(name.as_ref(), b"nsid", &prefixes) {
+                        abs.nsid = word_attribute_value(e, b"val", &prefixes)?;
+                        boundary = 1;
+                    } else if is_word_element(name.as_ref(), b"multiLevelType", &prefixes) {
                         abs.multi_level_type = word_attribute_value(e, b"val", &prefixes)?;
                         boundary = 2;
+                    } else if is_word_element(name.as_ref(), b"tmpl", &prefixes) {
+                        abs.tmpl = word_attribute_value(e, b"val", &prefixes)?;
+                        boundary = 3;
                     } else if is_word_element(name.as_ref(), b"lvl", &prefixes) {
                         let mut level = CT_Lvl::new(u32_attribute(e, b"ilvl", &prefixes)?);
                         level.extra_attributes =
@@ -2582,6 +2620,13 @@ impl CT_AbstractNum {
         writer.write_event(Event::Start(start))?;
 
         write_extras_at(writer, &self.extra_xml, 0)?;
+        if let Some(nsid) = &self.nsid {
+            let name = qualified(word_prefix, "nsid");
+            let val_name = qualified(word_prefix, "val");
+            let mut element = BytesStart::new(name.as_str());
+            element.push_attribute((val_name.as_str(), nsid.as_str()));
+            writer.write_event(Event::Empty(element))?;
+        }
         write_extras_at(writer, &self.extra_xml, 1)?;
         if let Some(ref mlt) = self.multi_level_type {
             let name = qualified(word_prefix, "multiLevelType");
@@ -2591,7 +2636,15 @@ impl CT_AbstractNum {
             writer.write_event(Event::Empty(e))?;
         }
 
-        for boundary in 2..=6 {
+        write_extras_at(writer, &self.extra_xml, 2)?;
+        if let Some(tmpl) = &self.tmpl {
+            let name = qualified(word_prefix, "tmpl");
+            let val_name = qualified(word_prefix, "val");
+            let mut element = BytesStart::new(name.as_str());
+            element.push_attribute((val_name.as_str(), tmpl.as_str()));
+            writer.write_event(Event::Empty(element))?;
+        }
+        for boundary in 3..=6 {
             write_extras_at(writer, &self.extra_xml, boundary)?;
         }
         for (index, lvl) in self.levels.iter().enumerate() {
@@ -3228,10 +3281,13 @@ mod tests {
         let xml = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:abstractNum w:abstractNumId="0">
+    <w:nsid w:val="FFFFFF7C"/>
     <w:multiLevelType w:val="hybridMultilevel"/>
+    <w:tmpl w:val="C310EC42"/>
     <w:lvl w:ilvl="0">
       <w:start w:val="1"/>
       <w:numFmt w:val="decimal"/>
+      <w:pStyle w:val="ListNumber"/>
       <w:lvlText w:val="%1."/>
       <w:lvlJc w:val="left"/>
       <w:pPr>
@@ -3256,10 +3312,13 @@ mod tests {
 
         let abs = &numbering.abstract_nums[0];
         assert_eq!(abs.abstract_num_id, 0);
+        assert_eq!(abs.nsid.as_deref(), Some("FFFFFF7C"));
         assert_eq!(abs.multi_level_type, Some("hybridMultilevel".to_string()));
+        assert_eq!(abs.tmpl.as_deref(), Some("C310EC42"));
         assert_eq!(abs.levels.len(), 2);
         assert_eq!(abs.levels[0].start, Some(1));
         assert_eq!(abs.levels[0].num_fmt, Some(ST_NumberFormat::Decimal));
+        assert_eq!(abs.levels[0].p_style.as_deref(), Some("ListNumber"));
         assert_eq!(abs.levels[0].lvl_text, Some("%1.".to_string()));
         assert_eq!(
             abs.levels[0].ppr.as_ref().unwrap().ind_left,
@@ -4703,6 +4762,7 @@ mod tests {
             ilvl: 0,
             start: Some(1),
             num_fmt: Some(ST_NumberFormat::Decimal),
+            p_style: None,
             suffix: None,
             lvl_text: Some("%1.".to_string()),
             lvl_jc: Some(ST_Jc::Left),
@@ -4723,7 +4783,9 @@ mod tests {
             abstract_nums: vec![CT_AbstractNum {
                 abstract_num_id: 0,
                 levels: vec![level.clone()],
+                nsid: None,
                 multi_level_type: None,
+                tmpl: None,
                 extra_xml: Vec::new(),
                 extra_attributes: Vec::new(),
             }],

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3750,8 +3750,8 @@ impl Document {
         style::resolve_run_properties(para_style_id, run_style_id, &self.styles)
     }
 
-    /// Resolve inherited, numbering-level, paragraph-mark, and direct
-    /// properties for one concrete run.
+    /// Resolve inherited, paragraph-mark, and direct properties for one
+    /// concrete body run.
     pub fn effective_run_properties(
         &self,
         paragraph: &ParagraphRef<'_>,
@@ -3764,14 +3764,6 @@ impl Document {
             direct.and_then(|properties| properties.style_id.as_deref()),
             &self.styles,
         );
-        let effective_paragraph = self.effective_paragraph_properties(paragraph);
-
-        if let Some((num_id, level)) = effective_paragraph.num_id.zip(effective_paragraph.num_ilvl)
-            && let Some(definition) = self.numbering_definition(num_id, level)
-            && let Some(properties) = &definition.rpr
-        {
-            effective.merge_from(properties);
-        }
         if let Some(properties) =
             paragraph_properties.and_then(|properties| properties.rpr.as_ref())
         {
@@ -11010,9 +11002,14 @@ mod tests {
         assert_eq!(paragraph_properties.keep_next, Some(true));
         assert_eq!(paragraph_properties.ind_left, Some(Twips(720)));
         assert_eq!(run_properties.italic, Some(true));
-        assert_eq!(run_properties.bold, Some(true));
+        assert_eq!(run_properties.bold, None);
         assert_eq!(run_properties.strike, Some(true));
         assert_eq!(run_properties.vanish, Some(true));
+        assert!(
+            doc.numbering_level(num_id, 0)
+                .expect("numbering level")
+                .has_marker_presentation
+        );
     }
 
     #[test]

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -2846,9 +2846,9 @@ impl Document {
 
     /// Resolve the public reader projection for one numbering level.
     ///
-    /// `has_unmodeled_properties` reports retained XML or attributes attached
-    /// to this numbering instance, definition, or level. Modeled producer
-    /// metadata that this projection does not expose is not reported here.
+    /// `has_unmodeled_properties` reports extra XML or attributes attached to
+    /// this numbering instance, definition, or level. Modeled producer metadata
+    /// and raw preservation overlays for level properties are not reported.
     pub fn numbering_level(&self, num_id: u32, level: u32) -> Option<NumberingLevel<'_>> {
         if num_id == 0 {
             return None;
@@ -2881,9 +2881,7 @@ impl Document {
                 || !definition.extra_xml.is_empty()
                 || !definition.extra_attributes.is_empty()
                 || !level.extra_xml.is_empty()
-                || !level.extra_attributes.is_empty()
-                || level.ppr_raw.is_some()
-                || level.rpr_raw.is_some(),
+                || !level.extra_attributes.is_empty(),
             has_paragraph_presentation: level.ppr.as_ref().is_some_and(|properties| {
                 Self::has_list_paragraph_presentation(level.ilvl, properties)
             }),
@@ -10954,17 +10952,17 @@ mod tests {
     }
 
     #[test]
-    fn numbering_level_distinguishes_modeled_metadata_from_retained_raw_facts() {
+    fn numbering_level_unmodeled_fact_contract_is_limited_to_extras() {
         let mut doc = Document::new();
         let definition_metadata_id = doc.add_list_definition(&[ListLevel::decimal()]);
-        let raw_level_properties_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        let retained_extra_id = doc.add_list_definition(&[ListLevel::decimal()]);
 
         let definition = &mut doc.numbering.as_mut().unwrap().abstract_nums[0];
         definition.nsid = Some("12345678".to_owned());
         definition.tmpl = Some("87654321".to_owned());
         definition.multi_level_type = Some("hybridMultilevel".to_owned());
 
-        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[1].levels[0];
+        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0];
         level.ppr_raw = Some((
             CT_PPr::default(),
             b"<w:pPr><producer:property/></w:pPr>".to_vec(),
@@ -10975,6 +10973,9 @@ mod tests {
             b"<w:rPr><producer:property/></w:rPr>".to_vec(),
             vec!["producer".to_owned()],
         ));
+        doc.numbering.as_mut().unwrap().abstract_nums[1].levels[0]
+            .extra_xml
+            .push((0, b"<w:lvlRestart w:val=\"0\"/>".to_vec()));
 
         assert!(
             !doc.numbering_level(definition_metadata_id, 0)
@@ -10982,8 +10983,8 @@ mod tests {
                 .has_unmodeled_properties
         );
         assert!(
-            doc.numbering_level(raw_level_properties_id, 0)
-                .expect("raw properties level")
+            doc.numbering_level(retained_extra_id, 0)
+                .expect("retained extra level")
                 .has_unmodeled_properties
         );
     }

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -26,10 +26,10 @@ use rdocx_oxml::header_footer::{
     CT_HdrFtr, HdrFtrRef, HdrFtrType, VmlWatermark, replace_authored_watermark,
 };
 use rdocx_oxml::namespace::matches_local_name;
-use rdocx_oxml::numbering::{CT_Numbering, ST_NumberFormat};
+use rdocx_oxml::numbering::{CT_Numbering, ST_LvlSuffix, ST_NumberFormat};
 use rdocx_oxml::properties::{CT_PPr, CT_RPr};
 use rdocx_oxml::settings::{CT_Settings, DocumentProtection};
-use rdocx_oxml::shared::{ST_PageOrientation, ST_SectionType};
+use rdocx_oxml::shared::{ST_Jc, ST_PageOrientation, ST_SectionType};
 use rdocx_oxml::styles::CT_Styles;
 use rdocx_oxml::table::{CT_Row, CT_Tbl, CT_Tc, CellContent};
 use rdocx_oxml::text::{CT_P, CT_R, RunContent};
@@ -2841,6 +2841,65 @@ impl Document {
             rdocx_oxml::numbering::ST_NumberFormat::Other(_) => None,
             _ => Some(false),
         }
+    }
+
+    /// Resolve the public reader projection for one numbering level.
+    ///
+    /// `has_unmodeled_properties` reports retained facts attached to this
+    /// numbering instance, definition, or level that this projection does not
+    /// otherwise expose.
+    pub fn numbering_level(&self, num_id: u32, level: u32) -> Option<NumberingLevel<'_>> {
+        if num_id == 0 {
+            return None;
+        }
+        let numbering = self.numbering.as_ref()?;
+        let instance = numbering.nums.iter().find(|item| item.num_id == num_id)?;
+        let definition = numbering
+            .abstract_nums
+            .iter()
+            .find(|item| item.abstract_num_id == instance.abstract_num_id)?;
+        let level = definition.levels.iter().find(|item| item.ilvl == level)?;
+        let format = level.num_fmt.as_ref();
+
+        Some(NumberingLevel {
+            level: level.ilvl,
+            format: format
+                .map(NumberingFormat::from_st)
+                .unwrap_or(NumberingFormat::Decimal),
+            format_name: format.map(ST_NumberFormat::to_str).unwrap_or("decimal"),
+            start: level.start.unwrap_or(1),
+            suffix: level
+                .suffix
+                .map(ListLevelSuffix::from_st)
+                .unwrap_or(ListLevelSuffix::Tab),
+            level_text: level.lvl_text.as_deref(),
+            alignment: level.lvl_jc.map(list_level_alignment),
+            paragraph_style: level.p_style.as_deref(),
+            has_unmodeled_properties: !instance.extra_xml.is_empty()
+                || !instance.extra_attributes.is_empty()
+                || !definition.extra_xml.is_empty()
+                || !definition.extra_attributes.is_empty()
+                || !level.extra_xml.is_empty()
+                || !level.extra_attributes.is_empty(),
+            has_paragraph_presentation: level.ppr.as_ref().is_some_and(|properties| {
+                Self::has_list_paragraph_presentation(level.ilvl, properties)
+            }),
+            has_marker_presentation: level
+                .rpr
+                .as_ref()
+                .is_some_and(|properties| properties != &CT_RPr::default()),
+        })
+    }
+
+    fn has_list_paragraph_presentation(level: u32, properties: &CT_PPr) -> bool {
+        let standard = CT_PPr {
+            ind_left: Some(rdocx_oxml::units::Twips(
+                (level.saturating_add(1) * 720) as i32,
+            )),
+            ind_hanging: Some(rdocx_oxml::units::Twips(360)),
+            ..CT_PPr::default()
+        };
+        properties != &standard
     }
 
     /// Append an external hyperlink to the last paragraph (creating one if
@@ -6105,6 +6164,91 @@ impl ListNumberFormat {
             Self::UpperRoman => ST_NumberFormat::UpperRoman,
             Self::Ordinal => ST_NumberFormat::Ordinal,
         }
+    }
+}
+
+/// The numbering format reported by the read-only numbering projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumberingFormat<'a> {
+    Bullet,
+    Decimal,
+    LowerLetter,
+    UpperLetter,
+    LowerRoman,
+    UpperRoman,
+    Ordinal,
+    None,
+    /// A producer-defined format value retained by rdocx.
+    Other(&'a str),
+}
+
+impl<'a> NumberingFormat<'a> {
+    fn from_st(value: &'a ST_NumberFormat) -> Self {
+        match value {
+            ST_NumberFormat::Bullet => Self::Bullet,
+            ST_NumberFormat::Decimal => Self::Decimal,
+            ST_NumberFormat::LowerLetter => Self::LowerLetter,
+            ST_NumberFormat::UpperLetter => Self::UpperLetter,
+            ST_NumberFormat::LowerRoman => Self::LowerRoman,
+            ST_NumberFormat::UpperRoman => Self::UpperRoman,
+            ST_NumberFormat::Ordinal => Self::Ordinal,
+            ST_NumberFormat::None => Self::None,
+            ST_NumberFormat::Other(value) => Self::Other(value),
+        }
+    }
+}
+
+/// The layout item emitted between a list marker and paragraph content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListLevelSuffix {
+    Tab,
+    Space,
+    Nothing,
+}
+
+impl ListLevelSuffix {
+    fn from_st(value: ST_LvlSuffix) -> Self {
+        match value {
+            ST_LvlSuffix::Tab => Self::Tab,
+            ST_LvlSuffix::Space => Self::Space,
+            ST_LvlSuffix::Nothing => Self::Nothing,
+        }
+    }
+}
+
+/// Resolved reader metadata for one numbering definition level.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NumberingLevel<'a> {
+    /// The zero-based list level.
+    pub level: u32,
+    /// The marker format at this level.
+    pub format: NumberingFormat<'a>,
+    /// The exact OOXML format name, including producer-defined values.
+    pub format_name: &'a str,
+    /// The first marker value, defaulting to one when Word omits it.
+    pub start: u32,
+    /// The item emitted between the marker and paragraph content.
+    pub suffix: ListLevelSuffix,
+    /// The Word level-text template or bullet glyph.
+    pub level_text: Option<&'a str>,
+    /// The marker alignment, when explicitly configured.
+    pub alignment: Option<crate::paragraph::Alignment>,
+    /// The paragraph style associated with this numbering level.
+    pub paragraph_style: Option<&'a str>,
+    /// Whether this level retains semantic facts this projection does not model.
+    pub has_unmodeled_properties: bool,
+    /// Whether the list item has nonstandard paragraph-level presentation.
+    pub has_paragraph_presentation: bool,
+    /// Whether the marker has run-level presentation properties.
+    pub has_marker_presentation: bool,
+}
+
+fn list_level_alignment(value: ST_Jc) -> crate::paragraph::Alignment {
+    match value {
+        ST_Jc::Center => crate::paragraph::Alignment::Center,
+        ST_Jc::Right | ST_Jc::End => crate::paragraph::Alignment::Right,
+        ST_Jc::Both | ST_Jc::Distribute => crate::paragraph::Alignment::Justify,
+        _ => crate::paragraph::Alignment::Left,
     }
 }
 
@@ -10665,6 +10809,55 @@ mod tests {
         assert_eq!(
             paragraph.inner.properties.as_ref().unwrap().num_ilvl,
             Some(8)
+        );
+    }
+
+    #[test]
+    fn reader_exposes_complete_numbering_level_facts() {
+        let mut doc = Document::new();
+        let num_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0];
+        level.num_fmt = Some(ST_NumberFormat::Other("chicago".to_owned()));
+        level.start = Some(4);
+        level.suffix = Some(ST_LvlSuffix::Space);
+        level.lvl_jc = Some(ST_Jc::Center);
+        level.p_style = Some("ListNumber".to_owned());
+
+        let level = doc.numbering_level(num_id, 0).expect("numbering level");
+        assert_eq!(level.format, NumberingFormat::Other("chicago"));
+        assert_eq!(level.format_name, "chicago");
+        assert_eq!(level.start, 4);
+        assert_eq!(level.suffix, ListLevelSuffix::Space);
+        assert_eq!(level.alignment, Some(Alignment::Center));
+        assert_eq!(level.paragraph_style, Some("ListNumber"));
+        assert!(!level.has_unmodeled_properties);
+        assert!(!level.has_paragraph_presentation);
+        assert!(!level.has_marker_presentation);
+
+        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0];
+        level.ppr = Some(CT_PPr {
+            ind_left: Some(Twips(360)),
+            ..Default::default()
+        });
+        level.rpr = Some(CT_RPr {
+            bold: Some(true),
+            ..Default::default()
+        });
+        level.extra_xml.push((0, b"<w:unknown/>".to_vec()));
+
+        let level = doc.numbering_level(num_id, 0).expect("numbering level");
+        assert!(level.has_unmodeled_properties);
+        assert!(level.has_paragraph_presentation);
+        assert!(level.has_marker_presentation);
+
+        let none_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        doc.numbering.as_mut().unwrap().abstract_nums[1].levels[0].num_fmt =
+            Some(ST_NumberFormat::None);
+        assert_eq!(
+            doc.numbering_level(none_id, 0)
+                .expect("no-numbering level")
+                .format,
+            NumberingFormat::None
         );
     }
 

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -30,7 +30,7 @@ use rdocx_oxml::numbering::{CT_Numbering, ST_LvlSuffix, ST_NumberFormat};
 use rdocx_oxml::properties::{CT_PPr, CT_RPr};
 use rdocx_oxml::settings::{CT_Settings, DocumentProtection};
 use rdocx_oxml::shared::{ST_Jc, ST_PageOrientation, ST_SectionType};
-use rdocx_oxml::styles::CT_Styles;
+use rdocx_oxml::styles::{CT_Styles, StyleType};
 use rdocx_oxml::table::{CT_Row, CT_Tbl, CT_Tc, CellContent};
 use rdocx_oxml::text::{CT_P, CT_R, RunContent};
 
@@ -3714,7 +3714,7 @@ impl Document {
     /// concrete paragraph.
     pub fn effective_paragraph_properties(&self, paragraph: &ParagraphRef<'_>) -> CT_PPr {
         let direct = paragraph.inner.properties.as_ref();
-        let style_id = direct.and_then(|properties| properties.style_id.as_deref());
+        let style_id = self.effective_paragraph_style_id(direct);
         let mut effective = style::resolve_paragraph_properties(style_id, &self.styles);
 
         effective.num_id = direct
@@ -3740,6 +3740,16 @@ impl Document {
             effective.merge_from(properties);
         }
         effective
+    }
+
+    fn effective_paragraph_style_id<'a>(&'a self, direct: Option<&'a CT_PPr>) -> Option<&'a str> {
+        direct
+            .and_then(|properties| properties.style_id.as_deref())
+            .or_else(|| {
+                self.styles
+                    .get_default(StyleType::Paragraph)
+                    .map(|style| style.style_id.as_str())
+            })
     }
 
     /// Resolve the effective run properties for the given paragraph and character styles,
@@ -11099,6 +11109,52 @@ mod tests {
         assert_eq!(disabled.num_id, Some(0));
         assert_eq!(disabled.keep_next, None);
         assert_eq!(disabled.keep_lines, None);
+    }
+
+    #[test]
+    fn effective_paragraph_properties_use_default_style_for_numbering_level_association() {
+        let mut doc = Document::new();
+        let num_id = doc.add_list_definition(&[
+            ListLevel::decimal(),
+            ListLevel::decimal(),
+            ListLevel::decimal(),
+        ]);
+        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[2];
+        level.p_style = Some("Normal".to_owned());
+        level.ppr = Some(CT_PPr {
+            keep_next: Some(true),
+            ..Default::default()
+        });
+        let default_style = doc
+            .styles
+            .styles
+            .iter_mut()
+            .find(|style| style.style_type == StyleType::Paragraph && style.is_default)
+            .expect("default paragraph style");
+        default_style.ppr = Some(CT_PPr {
+            num_id: Some(num_id),
+            ..Default::default()
+        });
+
+        doc.add_paragraph("without properties");
+        doc.add_paragraph("without a paragraph style");
+        let BodyContent::Paragraph(paragraph) = &mut doc.document.body.content[1] else {
+            panic!("expected paragraph");
+        };
+        paragraph.properties = Some(CT_PPr {
+            ind_left: Some(Twips(720)),
+            ..Default::default()
+        });
+
+        for index in 0..2 {
+            let properties =
+                doc.effective_paragraph_properties(&doc.paragraph(index).expect("paragraph"));
+            assert_eq!(properties.num_id, Some(num_id));
+            assert_eq!(properties.num_ilvl, Some(2));
+            assert_eq!(properties.keep_next, Some(true));
+        }
+        let direct = doc.effective_paragraph_properties(&doc.paragraph(1).expect("paragraph"));
+        assert_eq!(direct.ind_left, Some(Twips(720)));
     }
 
     #[test]

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -2880,8 +2880,13 @@ impl Document {
                 || !instance.extra_attributes.is_empty()
                 || !definition.extra_xml.is_empty()
                 || !definition.extra_attributes.is_empty()
+                || definition.nsid.is_some()
+                || definition.tmpl.is_some()
+                || definition.multi_level_type.is_some()
                 || !level.extra_xml.is_empty()
-                || !level.extra_attributes.is_empty(),
+                || !level.extra_attributes.is_empty()
+                || level.ppr_raw.is_some()
+                || level.rpr_raw.is_some(),
             has_paragraph_presentation: level.ppr.as_ref().is_some_and(|properties| {
                 Self::has_list_paragraph_presentation(level.ilvl, properties)
             }),
@@ -10906,6 +10911,10 @@ mod tests {
     fn reader_exposes_complete_numbering_level_facts() {
         let mut doc = Document::new();
         let num_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        let definition = &mut doc.numbering.as_mut().unwrap().abstract_nums[0];
+        definition.nsid = None;
+        definition.tmpl = None;
+        definition.multi_level_type = None;
         let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0];
         level.num_fmt = Some(ST_NumberFormat::Other("chicago".to_owned()));
         level.start = Some(4);
@@ -10948,6 +10957,41 @@ mod tests {
                 .expect("no-numbering level")
                 .format,
             NumberingFormat::None
+        );
+    }
+
+    #[test]
+    fn numbering_level_reports_unexposed_definition_and_level_facts() {
+        let mut doc = Document::new();
+        let definition_metadata_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        let raw_level_properties_id = doc.add_list_definition(&[ListLevel::decimal()]);
+
+        let definition = &mut doc.numbering.as_mut().unwrap().abstract_nums[0];
+        definition.nsid = Some("12345678".to_owned());
+        definition.tmpl = Some("87654321".to_owned());
+        definition.multi_level_type = Some("hybridMultilevel".to_owned());
+
+        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[1].levels[0];
+        level.ppr_raw = Some((
+            CT_PPr::default(),
+            b"<w:pPr><producer:property/></w:pPr>".to_vec(),
+            vec!["producer".to_owned()],
+        ));
+        level.rpr_raw = Some((
+            CT_RPr::default(),
+            b"<w:rPr><producer:property/></w:rPr>".to_vec(),
+            vec!["producer".to_owned()],
+        ));
+
+        assert!(
+            doc.numbering_level(definition_metadata_id, 0)
+                .expect("definition metadata level")
+                .has_unmodeled_properties
+        );
+        assert!(
+            doc.numbering_level(raw_level_properties_id, 0)
+                .expect("raw properties level")
+                .has_unmodeled_properties
         );
     }
 

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -2846,9 +2846,9 @@ impl Document {
 
     /// Resolve the public reader projection for one numbering level.
     ///
-    /// `has_unmodeled_properties` reports retained facts attached to this
-    /// numbering instance, definition, or level that this projection does not
-    /// otherwise expose.
+    /// `has_unmodeled_properties` reports retained XML or attributes attached
+    /// to this numbering instance, definition, or level. Modeled producer
+    /// metadata that this projection does not expose is not reported here.
     pub fn numbering_level(&self, num_id: u32, level: u32) -> Option<NumberingLevel<'_>> {
         if num_id == 0 {
             return None;
@@ -2880,9 +2880,6 @@ impl Document {
                 || !instance.extra_attributes.is_empty()
                 || !definition.extra_xml.is_empty()
                 || !definition.extra_attributes.is_empty()
-                || definition.nsid.is_some()
-                || definition.tmpl.is_some()
-                || definition.multi_level_type.is_some()
                 || !level.extra_xml.is_empty()
                 || !level.extra_attributes.is_empty()
                 || level.ppr_raw.is_some()
@@ -10911,10 +10908,6 @@ mod tests {
     fn reader_exposes_complete_numbering_level_facts() {
         let mut doc = Document::new();
         let num_id = doc.add_list_definition(&[ListLevel::decimal()]);
-        let definition = &mut doc.numbering.as_mut().unwrap().abstract_nums[0];
-        definition.nsid = None;
-        definition.tmpl = None;
-        definition.multi_level_type = None;
         let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0];
         level.num_fmt = Some(ST_NumberFormat::Other("chicago".to_owned()));
         level.start = Some(4);
@@ -10961,7 +10954,7 @@ mod tests {
     }
 
     #[test]
-    fn numbering_level_reports_unexposed_definition_and_level_facts() {
+    fn numbering_level_distinguishes_modeled_metadata_from_retained_raw_facts() {
         let mut doc = Document::new();
         let definition_metadata_id = doc.add_list_definition(&[ListLevel::decimal()]);
         let raw_level_properties_id = doc.add_list_definition(&[ListLevel::decimal()]);
@@ -10984,7 +10977,7 @@ mod tests {
         ));
 
         assert!(
-            doc.numbering_level(definition_metadata_id, 0)
+            !doc.numbering_level(definition_metadata_id, 0)
                 .expect("definition metadata level")
                 .has_unmodeled_properties
         );

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -42,6 +42,7 @@ use crate::content_control::ContentControlRef;
 use crate::error::{Error, Result};
 use crate::paragraph::{Paragraph, ParagraphRef};
 use crate::revision::RevisionRef;
+use crate::run::RunRef;
 use crate::style::{self, Style, StyleBuilder};
 use crate::table::{Table, TableRef};
 
@@ -3709,6 +3710,36 @@ impl Document {
         style::resolve_paragraph_properties(style_id, &self.styles)
     }
 
+    /// Resolve inherited, numbering-level, and direct properties for a
+    /// concrete paragraph.
+    pub fn effective_paragraph_properties(&self, paragraph: &ParagraphRef<'_>) -> CT_PPr {
+        let direct = paragraph.inner.properties.as_ref();
+        let mut effective = style::resolve_paragraph_properties(
+            direct.and_then(|properties| properties.style_id.as_deref()),
+            &self.styles,
+        );
+
+        if let Some(num_id) = effective.num_id {
+            effective.num_ilvl = effective.num_ilvl.or_else(|| {
+                self.numbering_level_for_style(
+                    num_id,
+                    direct.and_then(|properties| properties.style_id.as_deref()),
+                )
+            });
+        }
+
+        if let Some((num_id, level)) = effective.num_id.zip(effective.num_ilvl)
+            && let Some(definition) = self.numbering_definition(num_id, level)
+            && let Some(properties) = &definition.ppr
+        {
+            effective.merge_from(properties);
+        }
+        if let Some(properties) = direct {
+            effective.merge_from(properties);
+        }
+        effective
+    }
+
     /// Resolve the effective run properties for the given paragraph and character styles,
     /// walking the full inheritance chain.
     pub fn resolve_run_properties(
@@ -3717,6 +3748,71 @@ impl Document {
         run_style_id: Option<&str>,
     ) -> CT_RPr {
         style::resolve_run_properties(para_style_id, run_style_id, &self.styles)
+    }
+
+    /// Resolve inherited, numbering-level, paragraph-mark, and direct
+    /// properties for one concrete run.
+    pub fn effective_run_properties(
+        &self,
+        paragraph: &ParagraphRef<'_>,
+        run: &RunRef<'_>,
+    ) -> CT_RPr {
+        let paragraph_properties = paragraph.inner.properties.as_ref();
+        let direct = run.inner.properties.as_ref();
+        let mut effective = style::resolve_run_properties(
+            paragraph_properties.and_then(|properties| properties.style_id.as_deref()),
+            direct.and_then(|properties| properties.style_id.as_deref()),
+            &self.styles,
+        );
+        let effective_paragraph = self.effective_paragraph_properties(paragraph);
+
+        if let Some((num_id, level)) = effective_paragraph.num_id.zip(effective_paragraph.num_ilvl)
+            && let Some(definition) = self.numbering_definition(num_id, level)
+            && let Some(properties) = &definition.rpr
+        {
+            effective.merge_from(properties);
+        }
+        if let Some(properties) =
+            paragraph_properties.and_then(|properties| properties.rpr.as_ref())
+        {
+            effective.merge_from(properties);
+        }
+        if let Some(properties) = direct {
+            effective.merge_from(properties);
+        }
+        effective
+    }
+
+    fn numbering_definition(
+        &self,
+        num_id: u32,
+        level: u32,
+    ) -> Option<&rdocx_oxml::numbering::CT_Lvl> {
+        if num_id == 0 {
+            return None;
+        }
+        self.numbering
+            .as_ref()?
+            .get_abstract_num_for(num_id)?
+            .levels
+            .iter()
+            .find(|definition| definition.ilvl == level)
+    }
+
+    fn numbering_level_for_style(&self, num_id: u32, style_id: Option<&str>) -> Option<u32> {
+        let definition = self.numbering.as_ref()?.get_abstract_num_for(num_id)?;
+        let mut style_id = style_id?;
+        for _ in 0..self.styles.styles.len() {
+            if let Some(level) = definition
+                .levels
+                .iter()
+                .find(|level| level.p_style.as_deref() == Some(style_id))
+            {
+                return Some(level.ilvl);
+            }
+            style_id = self.styles.get_by_id(style_id)?.based_on.as_deref()?;
+        }
+        None
     }
 
     // ---- Section/Page setup ----
@@ -10859,6 +10955,64 @@ mod tests {
                 .format,
             NumberingFormat::None
         );
+    }
+
+    #[test]
+    fn reader_resolves_concrete_paragraph_and_run_properties() {
+        let mut doc = Document::new();
+        let num_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        let level = &mut doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0];
+        level.p_style = Some("ListBase".to_owned());
+        level.ppr = Some(CT_PPr {
+            keep_next: Some(true),
+            ..Default::default()
+        });
+        level.rpr = Some(CT_RPr {
+            bold: Some(true),
+            ..Default::default()
+        });
+
+        doc.add_style(
+            StyleBuilder::paragraph("ListBase", "List Base")
+                .paragraph_properties(CT_PPr {
+                    num_id: Some(num_id),
+                    ..Default::default()
+                })
+                .run_properties(CT_RPr {
+                    italic: Some(true),
+                    ..Default::default()
+                }),
+        );
+        doc.add_style(StyleBuilder::paragraph("ListChild", "List Child").based_on("ListBase"));
+        doc.add_paragraph("text").style("ListChild");
+
+        let BodyContent::Paragraph(paragraph) = &mut doc.document.body.content[0] else {
+            panic!("expected paragraph");
+        };
+        let properties = paragraph.properties.as_mut().expect("paragraph style");
+        properties.ind_left = Some(Twips(720));
+        properties.rpr = Some(CT_RPr {
+            strike: Some(true),
+            ..Default::default()
+        });
+        paragraph.runs[0].properties = Some(CT_RPr {
+            vanish: Some(true),
+            ..Default::default()
+        });
+
+        let paragraph = doc.paragraph(0).expect("paragraph");
+        let run = paragraph.runs().next().expect("run");
+        let paragraph_properties = doc.effective_paragraph_properties(&paragraph);
+        let run_properties = doc.effective_run_properties(&paragraph, &run);
+
+        assert_eq!(paragraph_properties.num_id, Some(num_id));
+        assert_eq!(paragraph_properties.num_ilvl, Some(0));
+        assert_eq!(paragraph_properties.keep_next, Some(true));
+        assert_eq!(paragraph_properties.ind_left, Some(Twips(720)));
+        assert_eq!(run_properties.italic, Some(true));
+        assert_eq!(run_properties.bold, Some(true));
+        assert_eq!(run_properties.strike, Some(true));
+        assert_eq!(run_properties.vanish, Some(true));
     }
 
     #[test]

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -3714,18 +3714,20 @@ impl Document {
     /// concrete paragraph.
     pub fn effective_paragraph_properties(&self, paragraph: &ParagraphRef<'_>) -> CT_PPr {
         let direct = paragraph.inner.properties.as_ref();
-        let mut effective = style::resolve_paragraph_properties(
-            direct.and_then(|properties| properties.style_id.as_deref()),
-            &self.styles,
-        );
+        let style_id = direct.and_then(|properties| properties.style_id.as_deref());
+        let mut effective = style::resolve_paragraph_properties(style_id, &self.styles);
+
+        effective.num_id = direct
+            .and_then(|properties| properties.num_id)
+            .or(effective.num_id);
+        effective.num_ilvl = direct
+            .and_then(|properties| properties.num_ilvl)
+            .or(effective.num_ilvl);
 
         if let Some(num_id) = effective.num_id {
-            effective.num_ilvl = effective.num_ilvl.or_else(|| {
-                self.numbering_level_for_style(
-                    num_id,
-                    direct.and_then(|properties| properties.style_id.as_deref()),
-                )
-            });
+            effective.num_ilvl = effective
+                .num_ilvl
+                .or_else(|| self.numbering_level_for_style(num_id, style_id));
         }
 
         if let Some((num_id, level)) = effective.num_id.zip(effective.num_ilvl)
@@ -11010,6 +11012,55 @@ mod tests {
                 .expect("numbering level")
                 .has_marker_presentation
         );
+    }
+
+    #[test]
+    fn effective_paragraph_properties_use_the_final_numbering_identity() {
+        let mut doc = Document::new();
+        let inherited_num_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        let direct_num_id = doc.add_list_definition(&[ListLevel::decimal()]);
+        doc.numbering.as_mut().unwrap().abstract_nums[0].levels[0].ppr = Some(CT_PPr {
+            keep_next: Some(true),
+            ..Default::default()
+        });
+        doc.numbering.as_mut().unwrap().abstract_nums[1].levels[0].ppr = Some(CT_PPr {
+            keep_lines: Some(true),
+            ..Default::default()
+        });
+        doc.add_style(
+            StyleBuilder::paragraph("InheritedList", "Inherited List").paragraph_properties(
+                CT_PPr {
+                    num_id: Some(inherited_num_id),
+                    num_ilvl: Some(0),
+                    ..Default::default()
+                },
+            ),
+        );
+
+        doc.add_paragraph("direct").numbering(direct_num_id, 0);
+        doc.add_paragraph("override")
+            .style("InheritedList")
+            .numbering(direct_num_id, 0);
+        doc.add_paragraph("disabled")
+            .style("InheritedList")
+            .numbering(0, 0);
+
+        let direct =
+            doc.effective_paragraph_properties(&doc.paragraph(0).expect("direct paragraph"));
+        assert_eq!(direct.num_id, Some(direct_num_id));
+        assert_eq!(direct.keep_lines, Some(true));
+
+        let overridden =
+            doc.effective_paragraph_properties(&doc.paragraph(1).expect("overridden paragraph"));
+        assert_eq!(overridden.num_id, Some(direct_num_id));
+        assert_eq!(overridden.keep_next, None);
+        assert_eq!(overridden.keep_lines, Some(true));
+
+        let disabled =
+            doc.effective_paragraph_properties(&doc.paragraph(2).expect("disabled paragraph"));
+        assert_eq!(disabled.num_id, Some(0));
+        assert_eq!(disabled.keep_next, None);
+        assert_eq!(disabled.keep_lines, None);
     }
 
     #[test]

--- a/crates/rdocx/src/epub.rs
+++ b/crates/rdocx/src/epub.rs
@@ -1478,6 +1478,7 @@ fn render_numbering(numbering: Option<&CT_Numbering>) -> Result<Option<CT_Number
                     ilvl: level.ilvl,
                     start: level.start,
                     num_fmt: level.num_fmt.clone(),
+                    p_style: None,
                     suffix: level.suffix,
                     lvl_text: None,
                     lvl_jc: level.lvl_jc,
@@ -1489,7 +1490,9 @@ fn render_numbering(numbering: Option<&CT_Numbering>) -> Result<Option<CT_Number
                     rpr_raw: None,
                 })
                 .collect(),
+            nsid: None,
             multi_level_type: None,
+            tmpl: None,
             extra_xml: Vec::new(),
             extra_attributes: Vec::new(),
         })

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -45,7 +45,8 @@ pub use comparison::ComparisonDiagnostic;
 pub use content_control::ContentControlRef;
 pub use document::{
     AccessibilityIssue, BodyContentRef, BodyItemRef, Document, ImageInfo, IssueSeverity, LinkInfo,
-    ListLevel, ListNumberFormat, OutlineNode, RenderOptions, UnsupportedXmlRef,
+    ListLevel, ListLevelSuffix, ListNumberFormat, NumberingFormat, NumberingLevel, OutlineNode,
+    RenderOptions, UnsupportedXmlRef,
 };
 pub use epub::{EpubDiagnostic, EpubWriteResult};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

- model standard numbering identifiers, templates, and paragraph-style links
- preserve producer-defined numbering suffix and alignment values as unmodeled XML
- expose a read-only numbering-level projection with exact known, none, and producer-defined formats
- expose start, suffix, marker text, alignment, style, and presentation facts
- resolve concrete paragraph and body-run properties through their applicable inheritance layers

## Review follow-up

- rebased onto current `main`
- keep numbering-level run properties scoped to marker presentation
- stop merging marker formatting into ordinary paragraph body runs
- retain marker-presentation reporting through the numbering-level reader API
- ready for maintainer F-ID integration

## Validation

- `cargo test -p rdocx-oxml --lib`
- focused `rdocx` numbering and effective-formatting tests
- `cargo clippy -p rdocx-oxml -p rdocx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/hash_harness.py --check`
- CI Test and MSRV jobs pass

The local unfiltered `rdocx` run only reaches the existing environment-dependent `word_and_powerpoint_chart_pixels_are_identical` rasterizer oracle assertion. The failure does not exercise these reader changes.
