### PR TITLE
Expose tracked insertion and field safety facts

### DIFF
--- a/crates/rdocx-oxml/src/revision.rs
+++ b/crates/rdocx-oxml/src/revision.rs
@@ -110,13 +110,9 @@ impl CT_Revision {
         };
         let (kind, id, author, timestamp) = kind;
         let (content, content_paragraph, nested_revisions) = if kind == RevisionKind::Insertion {
+            let (content, nested_revisions) = parse_content(&mut reader, kind, &prefixes)?;
             let paragraph = parse_insertion_content(&raw_xml, &prefixes)?;
-            let content = if paragraph.runs.is_empty() {
-                RevisionContent::Marker
-            } else {
-                RevisionContent::Runs(paragraph.runs.clone())
-            };
-            (content, Some(Box::new(paragraph)), Vec::new())
+            (content, Some(Box::new(paragraph)), nested_revisions)
         } else {
             let (content, nested_revisions) = parse_content(&mut reader, kind, &prefixes)?;
             (content, None, nested_revisions)
@@ -790,6 +786,43 @@ mod tests {
         assert_eq!(paragraph.text(), "beforelinked");
         assert_eq!(paragraph.hyperlinks.len(), 1);
         assert_eq!(paragraph.hyperlinks[0].rel_id.as_deref(), Some("rId9"));
+    }
+
+    #[test]
+    fn insertion_content_retains_nested_revision_projection() {
+        let raw = format!(
+            r#"<w:ins xmlns:w="{W_NS}" w:id="7" w:author="Ada"><w:r><w:t>before</w:t></w:r><w:del w:id="8" w:author="Ben"><w:r><w:delText>removed</w:delText></w:r></w:del><w:ins w:id="9" w:author="Cy"><w:r><w:t>nested</w:t></w:r></w:ins><w:r><w:t>after</w:t></w:r></w:ins>"#
+        )
+        .into_bytes();
+        let revision = CT_Revision::from_raw(raw, &["w".to_owned()]).expect("insertion parses");
+
+        let RevisionContent::Runs(runs) = revision.content() else {
+            panic!("insertion exposes direct runs");
+        };
+        assert_eq!(
+            runs.iter().map(CT_R::text).collect::<String>(),
+            "beforeafter"
+        );
+        assert_eq!(
+            revision
+                .nested_revisions()
+                .iter()
+                .map(|(boundary, nested)| (*boundary, nested.kind()))
+                .collect::<Vec<_>>(),
+            vec![(1, RevisionKind::Deletion), (1, RevisionKind::Insertion),]
+        );
+        let paragraph = revision
+            .content_paragraph()
+            .expect("insertion exposes paragraph content");
+        assert_eq!(paragraph.text(), "beforeafter");
+        assert_eq!(
+            paragraph
+                .revisions
+                .iter()
+                .map(|(_, _, nested)| nested.kind())
+                .collect::<Vec<_>>(),
+            vec![RevisionKind::Deletion, RevisionKind::Insertion]
+        );
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/revision.rs
+++ b/crates/rdocx-oxml/src/revision.rs
@@ -11,7 +11,7 @@ use crate::raw_xml::capture_empty_element;
 use crate::table::{CT_Row, CT_Tbl, CT_TblPr, CT_Tc, CellContent};
 use crate::text::{CT_P, CT_R, hyperlink_revision_index};
 
-const MAX_REVISION_NESTING_DEPTH: usize = 64;
+const MAX_REVISION_NESTING_DEPTH: usize = 32;
 
 /// The modeled tracked-change element kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rdocx-oxml/src/revision.rs
+++ b/crates/rdocx-oxml/src/revision.rs
@@ -45,6 +45,7 @@ pub struct CT_Revision {
     timestamp: Option<String>,
     raw_xml: Vec<u8>,
     content: RevisionContent,
+    content_paragraph: Option<Box<CT_P>>,
     nested_revisions: Vec<(usize, CT_Revision)>,
 }
 
@@ -94,6 +95,7 @@ impl CT_Revision {
                         timestamp,
                         raw_xml,
                         content: RevisionContent::Marker,
+                        content_paragraph: None,
                         nested_revisions: Vec::new(),
                     });
                 }
@@ -107,7 +109,18 @@ impl CT_Revision {
             buffer.clear();
         };
         let (kind, id, author, timestamp) = kind;
-        let (content, nested_revisions) = parse_content(&mut reader, kind, &prefixes)?;
+        let (content, content_paragraph, nested_revisions) = if kind == RevisionKind::Insertion {
+            let paragraph = parse_insertion_content(&raw_xml, &prefixes)?;
+            let content = if paragraph.runs.is_empty() {
+                RevisionContent::Marker
+            } else {
+                RevisionContent::Runs(paragraph.runs.clone())
+            };
+            (content, Some(Box::new(paragraph)), Vec::new())
+        } else {
+            let (content, nested_revisions) = parse_content(&mut reader, kind, &prefixes)?;
+            (content, None, nested_revisions)
+        };
         Ok(Self {
             kind,
             id,
@@ -115,6 +128,7 @@ impl CT_Revision {
             timestamp,
             raw_xml,
             content,
+            content_paragraph,
             nested_revisions,
         })
     }
@@ -137,6 +151,12 @@ impl CT_Revision {
 
     pub fn content(&self) -> &RevisionContent {
         &self.content
+    }
+
+    /// Return the paragraph projection for an insertion, when it has inline wrappers.
+    #[doc(hidden)]
+    pub fn content_paragraph(&self) -> Option<&CT_P> {
+        self.content_paragraph.as_deref()
     }
 
     /// Return nested revision wrappers at their direct-run boundaries.
@@ -370,6 +390,10 @@ fn collect_control<'a>(control: &'a CT_Sdt, revisions: &mut Vec<&'a CT_Revision>
 
 fn collect_revision<'a>(revision: &'a CT_Revision, revisions: &mut Vec<&'a CT_Revision>) {
     revisions.push(revision);
+    if let Some(paragraph) = revision.content_paragraph() {
+        collect_paragraph(paragraph, revisions);
+        return;
+    }
     if let RevisionContent::Runs(runs) = revision.content() {
         for boundary in 0..=runs.len() {
             for (_, nested) in revision
@@ -387,6 +411,41 @@ fn collect_revision<'a>(revision: &'a CT_Revision, revisions: &mut Vec<&'a CT_Re
         for (_, nested) in &revision.nested_revisions {
             collect_revision(nested, revisions);
         }
+    }
+}
+
+fn parse_insertion_content(raw_xml: &[u8], word_prefixes: &[String]) -> crate::Result<CT_P> {
+    let mut reader = Reader::from_reader(raw_xml);
+    reader.config_mut().trim_text(false);
+    let mut buffer = Vec::new();
+    let content_start = loop {
+        match reader.read_event_into(&mut buffer)? {
+            Event::Start(_) => break reader.buffer_position() as usize,
+            Event::Eof => {
+                return Err(crate::OxmlError::MissingElement(
+                    "insertion element".to_owned(),
+                ));
+            }
+            _ => {}
+        }
+        buffer.clear();
+    };
+    let content_end = raw_xml
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, byte)| (*byte == b'<').then_some(index))
+        .ok_or_else(|| crate::OxmlError::MissingElement("insertion close tag".to_owned()))?;
+    let mut paragraph_xml = Vec::from(b"<w:p>".as_slice());
+    paragraph_xml.extend_from_slice(&raw_xml[content_start..content_end]);
+    paragraph_xml.extend_from_slice(b"</w:p>");
+    let mut paragraph_reader = Reader::from_reader(paragraph_xml.as_slice());
+    let mut paragraph_buffer = Vec::new();
+    match paragraph_reader.read_event_into(&mut paragraph_buffer)? {
+        Event::Start(_) => CT_P::from_xml_with_prefixes(&mut paragraph_reader, word_prefixes),
+        _ => Err(crate::OxmlError::MissingElement(
+            "insertion content".to_owned(),
+        )),
     }
 }
 
@@ -715,6 +774,22 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![30]
         );
+    }
+
+    #[test]
+    fn insertion_content_retains_inline_paragraph_structure() {
+        let raw = format!(
+            r#"<w:ins xmlns:w="{W_NS}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" w:id="7" w:author="Ada"><w:r><w:t>before</w:t></w:r><w:hyperlink r:id="rId9"><w:r><w:t>linked</w:t></w:r></w:hyperlink></w:ins>"#
+        )
+        .into_bytes();
+        let revision = CT_Revision::from_raw(raw, &["w".to_owned()]).expect("insertion parses");
+        let paragraph = revision
+            .content_paragraph()
+            .expect("insertion exposes paragraph content");
+
+        assert_eq!(paragraph.text(), "beforelinked");
+        assert_eq!(paragraph.hyperlinks.len(), 1);
+        assert_eq!(paragraph.hyperlinks[0].rel_id.as_deref(), Some("rId9"));
     }
 
     #[test]

--- a/crates/rdocx-oxml/src/revision.rs
+++ b/crates/rdocx-oxml/src/revision.rs
@@ -11,6 +11,8 @@ use crate::raw_xml::capture_empty_element;
 use crate::table::{CT_Row, CT_Tbl, CT_TblPr, CT_Tc, CellContent};
 use crate::text::{CT_P, CT_R, hyperlink_revision_index};
 
+const MAX_REVISION_NESTING_DEPTH: usize = 64;
+
 /// The modeled tracked-change element kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RevisionKind {
@@ -59,6 +61,7 @@ impl CT_Revision {
     }
 
     fn try_from_raw(raw_xml: Vec<u8>, word_prefixes: &[String]) -> crate::Result<Self> {
+        validate_revision_nesting_depth(&raw_xml, word_prefixes)?;
         let mut reader = Reader::from_reader(raw_xml.as_slice());
         reader.config_mut().trim_text(false);
         let mut buffer = Vec::new();
@@ -176,6 +179,55 @@ impl CT_Revision {
     ) -> crate::Result<()> {
         crate::text::write_raw_with_word_override(writer, &self.raw_xml, foreign_word_namespace)
     }
+}
+
+fn validate_revision_nesting_depth(raw_xml: &[u8], word_prefixes: &[String]) -> crate::Result<()> {
+    let mut reader = Reader::from_reader(raw_xml);
+    reader.config_mut().trim_text(false);
+    let mut buffer = Vec::new();
+    let mut scopes = vec![(word_prefixes.to_vec(), false)];
+    let mut revision_depth = 0usize;
+
+    loop {
+        match reader.read_event_into(&mut buffer)? {
+            Event::Start(start) => {
+                let inherited = &scopes.last().expect("root namespace scope").0;
+                let prefixes = word_prefixes_at(&start, inherited)?;
+                let is_revision = revision_kind(start.name().as_ref(), &prefixes).is_some();
+                if is_revision {
+                    revision_depth += 1;
+                    if revision_depth > MAX_REVISION_NESTING_DEPTH {
+                        return Err(crate::OxmlError::InvalidValue(
+                            "revision nesting depth exceeds reader limit".to_owned(),
+                        ));
+                    }
+                }
+                scopes.push((prefixes, is_revision));
+            }
+            Event::Empty(start) => {
+                let inherited = &scopes.last().expect("root namespace scope").0;
+                let prefixes = word_prefixes_at(&start, inherited)?;
+                if revision_kind(start.name().as_ref(), &prefixes).is_some()
+                    && revision_depth + 1 > MAX_REVISION_NESTING_DEPTH
+                {
+                    return Err(crate::OxmlError::InvalidValue(
+                        "revision nesting depth exceeds reader limit".to_owned(),
+                    ));
+                }
+            }
+            Event::End(_) => {
+                let (_, was_revision) = scopes.pop().expect("balanced namespace scope");
+                if was_revision {
+                    revision_depth -= 1;
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+        buffer.clear();
+    }
+
+    Ok(())
 }
 
 impl CT_Document {
@@ -666,6 +718,33 @@ mod tests {
     use super::*;
     use crate::namespace::W_NS;
     use crate::text::RunContent;
+
+    fn nested_insertions(depth: usize) -> Vec<u8> {
+        let mut xml = format!(r#"<w:ins xmlns:w="{W_NS}" w:id="0" w:author="Ada">"#);
+        for id in 1..depth {
+            xml.push_str(&format!(r#"<w:ins w:id="{id}" w:author="Ada">"#));
+        }
+        xml.push_str("<w:r><w:t>visible</w:t></w:r>");
+        for _ in 0..depth {
+            xml.push_str("</w:ins>");
+        }
+        xml.into_bytes()
+    }
+
+    #[test]
+    fn revision_nesting_depth_is_bounded_before_recursive_projection() {
+        let prefixes = ["w".to_owned()];
+        assert!(
+            validate_revision_nesting_depth(
+                &nested_insertions(MAX_REVISION_NESTING_DEPTH),
+                &prefixes,
+            )
+            .is_ok()
+        );
+        let too_deep = nested_insertions(MAX_REVISION_NESTING_DEPTH + 1);
+        assert!(validate_revision_nesting_depth(&too_deep, &prefixes).is_err());
+        assert!(CT_Revision::from_raw(too_deep, &prefixes).is_none());
+    }
 
     #[test]
     fn revision_attributes_are_prefix_tolerant_and_namespace_checked() {

--- a/crates/rdocx-oxml/src/text.rs
+++ b/crates/rdocx-oxml/src/text.rs
@@ -199,6 +199,12 @@ impl Field {
         )
     }
 
+    /// Whether this field was parsed from a complex `w:fldChar` sequence.
+    #[doc(hidden)]
+    pub fn is_complex(&self) -> bool {
+        self.is_parsed_complex()
+    }
+
     /// Return the text this field contributes to [`CT_R::text`].
     #[doc(hidden)]
     pub fn projected_text(&self) -> Option<&str> {

--- a/crates/rdocx-oxml/src/text.rs
+++ b/crates/rdocx-oxml/src/text.rs
@@ -11,7 +11,7 @@ use crate::drawing::CT_Drawing;
 use crate::error::{OxmlError, Result};
 use crate::namespace::{R_NS, matches_local_name};
 use crate::numbering::{namespace_bindings, parse_scoped_ppr, word_prefixes_at};
-use crate::properties::{CT_PPr, CT_RPr, is_word_element};
+use crate::properties::{CT_PPr, CT_RPr, is_word_attribute, is_word_element};
 use crate::raw_xml::{capture_element, capture_empty_element};
 use crate::revision::CT_Revision;
 
@@ -204,6 +204,23 @@ impl Field {
     pub fn projected_text(&self) -> Option<&str> {
         self.is_parsed_complex()
             .then_some(self.cached_result.as_str())
+    }
+
+    /// Whether the retained field source carries semantic attributes outside
+    /// the modeled instruction, type, and dirty-state projection.
+    pub fn has_unmodeled_semantic_attributes(&self) -> bool {
+        let FieldSource::Parsed {
+            form,
+            raw_xml,
+            word_prefixes,
+            ..
+        } = &self.source
+        else {
+            return false;
+        };
+
+        field_source_has_unmodeled_semantic_attributes(raw_xml, *form, word_prefixes)
+            .unwrap_or(true)
     }
 
     /// Return the stored display split by its original result-run formatting.
@@ -2792,6 +2809,62 @@ fn scan_complex_source(raw: &[u8], word_prefixes: &[String]) -> Result<ComplexSo
                 }
             }
             Event::Eof => return Ok(ComplexSourceScan { runs, nested }),
+            _ => {}
+        }
+        buffer.clear();
+    }
+}
+
+fn field_source_has_unmodeled_semantic_attributes(
+    raw: &[u8],
+    form: FieldForm,
+    word_prefixes: &[String],
+) -> Result<bool> {
+    let mut reader = Reader::from_reader(raw);
+    reader.config_mut().trim_text(false);
+    let mut buffer = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buffer)? {
+            Event::Start(element) | Event::Empty(element) => {
+                let prefixes = word_prefixes_at(&element, word_prefixes)?;
+                let allowed = match form {
+                    FieldForm::Simple
+                        if is_word_element(element.name().as_ref(), b"fldSimple", &prefixes) =>
+                    {
+                        &[b"instr".as_slice(), b"dirty".as_slice()][..]
+                    }
+                    FieldForm::Complex
+                        if is_word_element(element.name().as_ref(), b"fldChar", &prefixes) =>
+                    {
+                        &[b"fldCharType".as_slice(), b"dirty".as_slice()][..]
+                    }
+                    _ => {
+                        buffer.clear();
+                        continue;
+                    }
+                };
+
+                for attribute in element.attributes() {
+                    let attribute = attribute?;
+                    let key = attribute.key.as_ref();
+                    if key == b"xmlns" || key.starts_with(b"xmlns:") {
+                        continue;
+                    }
+                    if allowed
+                        .iter()
+                        .any(|local| is_word_attribute(key, local, &prefixes))
+                    {
+                        continue;
+                    }
+                    return Ok(true);
+                }
+
+                if matches!(form, FieldForm::Simple) {
+                    return Ok(false);
+                }
+            }
+            Event::Eof => return Ok(false),
             _ => {}
         }
         buffer.clear();

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -82,6 +82,12 @@ pub struct UnsupportedXmlRef<'a> {
 }
 
 impl<'a> UnsupportedXmlRef<'a> {
+    /// Inspect preserved reader-item bytes using the same unsupported XML
+    /// projection as body compatibility items.
+    pub fn from_bytes(raw: &'a [u8]) -> Self {
+        Self::raw(raw, &[])
+    }
+
     fn raw(raw: &'a [u8], inherited_namespaces: &'a [(String, String)]) -> Self {
         let names = raw_element_names(raw);
         let namespace_uri = names.as_ref().and_then(|(name, _)| {
@@ -11510,7 +11516,7 @@ mod watermark_tests {
 }
 
 #[cfg(test)]
-mod reader_revision_tests {
+mod reader_fact_tests {
     use super::*;
 
     #[test]
@@ -11538,6 +11544,21 @@ mod reader_revision_tests {
             panic!("expected hyperlink");
         };
         assert_eq!(link.relationship_id(), Some("rId9"));
+    }
+
+    #[test]
+    fn unsupported_xml_reader_inspects_preserved_item_bytes() {
+        let raw = br#"<w:proofErr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:type="spellStart"/>"#;
+        let fact = UnsupportedXmlRef::from_bytes(raw);
+
+        assert_eq!(fact.raw_xml(), Some(raw.as_slice()));
+        assert_eq!(fact.qualified_name(), Some("w:proofErr"));
+        assert_eq!(fact.local_name(), "proofErr");
+        assert_eq!(
+            fact.namespace_uri(),
+            Some("http://schemas.openxmlformats.org/wordprocessingml/2006/main")
+        );
+        assert!(!fact.has_child_content());
     }
 }
 

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -11510,6 +11510,38 @@ mod watermark_tests {
 }
 
 #[cfg(test)]
+mod reader_revision_tests {
+    use super::*;
+
+    #[test]
+    fn revision_reader_exposes_tracked_insertion_paragraph_items() {
+        let xml = br#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:body><w:p><w:ins w:id="7" w:author="Ada"><w:r><w:t>before</w:t></w:r><w:hyperlink r:id="rId9"><w:r><w:t>linked</w:t></w:r></w:hyperlink></w:ins></w:p></w:body></w:document>"#;
+        let mut document = Document::new();
+        document.document = CT_Document::from_xml(xml).expect("document parses");
+        let crate::BodyItemRef::Paragraph(paragraph) =
+            document.body_items().next().expect("paragraph body item")
+        else {
+            panic!("expected paragraph");
+        };
+        let crate::ParagraphItemRef::Revision(revision) =
+            paragraph.items().next().expect("revision paragraph item")
+        else {
+            panic!("expected revision");
+        };
+        let insertion = revision
+            .insertion_paragraph()
+            .expect("insertion paragraph projection");
+        let items = insertion.items().collect::<Vec<_>>();
+
+        assert!(matches!(items[0], crate::ParagraphItemRef::Run(_)));
+        let crate::ParagraphItemRef::Hyperlink(link) = &items[1] else {
+            panic!("expected hyperlink");
+        };
+        assert_eq!(link.relationship_id(), Some("rId9"));
+    }
+}
+
+#[cfg(test)]
 mod odttf_tests {
     use super::*;
 

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -72,8 +72,8 @@ pub use redaction::RedactionReport;
 pub use revision::{RevisionKind, RevisionRef};
 pub use rtf::{RtfDiagnostic, RtfReadResult, RtfWriteResult};
 pub use run::{
-    BreakKind, DrawingRef, FieldRef, LegacyHorizontalRuleRef, Run, RunItemRef, RunRef,
-    UnderlineStyle,
+    BreakKind, DrawingRef, FieldDisplaySegmentRef, FieldKind, FieldRef, LegacyHorizontalRuleRef,
+    Run, RunItemRef, RunProperties, RunRef, UnderlineStyle,
 };
 pub use style::{Style, StyleBuilder};
 pub use svg::{SvgDiagnostic, SvgRenderResult};

--- a/crates/rdocx/src/revision.rs
+++ b/crates/rdocx/src/revision.rs
@@ -7,7 +7,7 @@ use quick_xml::{Reader, XmlVersion};
 pub use rdocx_oxml::RevisionKind;
 use rdocx_oxml::{CT_Document, CT_Revision};
 
-use crate::{Document, Error, Result};
+use crate::{Document, Error, ParagraphRef, Result};
 
 const WORD_NS: &str = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
@@ -35,6 +35,16 @@ impl RevisionRef<'_> {
 
     pub fn kind(&self) -> RevisionKind {
         self.inner.kind()
+    }
+
+    /// Return the insertion content as a paragraph reader projection.
+    ///
+    /// This retains runs, hyperlinks, fields, and preserved XML in their
+    /// original inline order. Non-insertion revisions return `None`.
+    pub fn insertion_paragraph(&self) -> Option<ParagraphRef<'_>> {
+        self.inner
+            .content_paragraph()
+            .map(|inner| ParagraphRef { inner })
     }
 }
 

--- a/crates/rdocx/src/run.rs
+++ b/crates/rdocx/src/run.rs
@@ -147,6 +147,12 @@ impl FieldRef<'_> {
     pub fn dirty(&self) -> Option<bool> {
         self.inner.dirty
     }
+
+    /// Whether the retained field source carries semantic attributes outside
+    /// the modeled reader projection.
+    pub fn has_unmodeled_semantic_attributes(&self) -> bool {
+        self.inner.has_unmodeled_semantic_attributes()
+    }
 }
 
 /// One direct child of a run, in source order.
@@ -837,6 +843,17 @@ mod tests {
         paragraph.runs.remove(0)
     }
 
+    fn run_from_paragraph_inner_xml(inner_xml: &str) -> CT_R {
+        let xml = format!(
+            r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p>{inner_xml}</w:p></w:body></w:document>"#
+        );
+        let mut document = CT_Document::from_xml(xml.as_bytes()).unwrap();
+        let BodyContent::Paragraph(mut paragraph) = document.body.content.remove(0) else {
+            panic!("expected paragraph");
+        };
+        paragraph.runs.remove(0)
+    }
+
     #[test]
     fn legacy_horizontal_rule_classification_is_namespace_aware() {
         let cases = [
@@ -925,6 +942,33 @@ mod tests {
         let items = run.items().collect::<Vec<_>>();
         assert!(matches!(items[0], RunItemRef::Text("typed")));
         assert!(matches!(items[1], RunItemRef::UnsupportedXml(b"<x:raw/>")));
+    }
+
+    #[test]
+    fn field_reader_reports_unmodeled_semantic_attributes() {
+        let supported = run_from_paragraph_inner_xml(
+            r#"<w:fldSimple w:instr="PAGE" w:dirty="false"><w:r><w:t>1</w:t></w:r></w:fldSimple>"#,
+        );
+        let unsupported = run_from_paragraph_inner_xml(
+            r#"<w:fldSimple w:instr="PAGE" w:fldLock="true"><w:r><w:t>1</w:t></w:r></w:fldSimple>"#,
+        );
+
+        let supported_run = RunRef { inner: &supported };
+        let RunItemRef::Field(supported) = supported_run.items().next().expect("supported field")
+        else {
+            panic!("expected field");
+        };
+        let unsupported_run = RunRef {
+            inner: &unsupported,
+        };
+        let RunItemRef::Field(unsupported) =
+            unsupported_run.items().next().expect("unsupported field")
+        else {
+            panic!("expected field");
+        };
+
+        assert!(!supported.has_unmodeled_semantic_attributes());
+        assert!(unsupported.has_unmodeled_semantic_attributes());
     }
 
     #[test]

--- a/crates/rdocx/src/run.rs
+++ b/crates/rdocx/src/run.rs
@@ -19,6 +19,18 @@ pub enum BreakKind {
     Column,
 }
 
+/// The source representation of a Word field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+    /// A `w:fldSimple` element.
+    Simple,
+    /// A `w:fldChar` begin/separate/end sequence.
+    Complex,
+}
+
+/// Resolved or direct run properties returned by the reader API.
+pub type RunProperties = CT_RPr;
+
 /// An immutable drawing embedded in a run.
 #[derive(Debug, Clone, Copy)]
 pub struct DrawingRef<'a> {
@@ -114,6 +126,25 @@ pub struct FieldRef<'a> {
     inner: &'a Field,
 }
 
+/// One cached display segment retained from a complex field result.
+#[derive(Debug, Clone, Copy)]
+pub struct FieldDisplaySegmentRef<'a> {
+    text: &'a str,
+    properties: Option<&'a RunProperties>,
+}
+
+impl FieldDisplaySegmentRef<'_> {
+    /// The visible text retained from the result run.
+    pub fn text(&self) -> &str {
+        self.text
+    }
+
+    /// Direct run properties retained from the result run.
+    pub fn properties(&self) -> Option<&RunProperties> {
+        self.properties
+    }
+}
+
 /// An immutable legacy VML horizontal rule retained by a run.
 #[derive(Debug, Clone, Copy)]
 pub struct LegacyHorizontalRuleRef<'a> {
@@ -128,6 +159,15 @@ impl LegacyHorizontalRuleRef<'_> {
 }
 
 impl FieldRef<'_> {
+    /// Whether the field was represented as a simple element or complex run sequence.
+    pub fn kind(&self) -> FieldKind {
+        if self.inner.is_complex() {
+            FieldKind::Complex
+        } else {
+            FieldKind::Simple
+        }
+    }
+
     /// The retained field instruction text.
     pub fn instruction(&self) -> &str {
         &self.inner.instruction.raw
@@ -152,6 +192,15 @@ impl FieldRef<'_> {
     /// the modeled reader projection.
     pub fn has_unmodeled_semantic_attributes(&self) -> bool {
         self.inner.has_unmodeled_semantic_attributes()
+    }
+
+    /// Cached display segments retained from the result runs of a complex field.
+    pub fn cached_display_segments(&self) -> Vec<FieldDisplaySegmentRef<'_>> {
+        self.inner
+            .cached_display_segments()
+            .into_iter()
+            .map(|(text, properties)| FieldDisplaySegmentRef { text, properties })
+            .collect()
     }
 }
 
@@ -969,6 +1018,34 @@ mod tests {
 
         assert!(!supported.has_unmodeled_semantic_attributes());
         assert!(unsupported.has_unmodeled_semantic_attributes());
+    }
+
+    #[test]
+    fn field_reader_exposes_complex_cached_display_segments() {
+        let simple = run_from_paragraph_inner_xml(
+            r#"<w:fldSimple w:instr="PAGE"><w:r><w:t>1</w:t></w:r></w:fldSimple>"#,
+        );
+        let complex = run_from_paragraph_inner_xml(
+            r#"<w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText>PAGE</w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:rPr><w:b/></w:rPr><w:t>1</w:t></w:r><w:r><w:rPr><w:i/></w:rPr><w:t>2</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r>"#,
+        );
+
+        let simple_run = RunRef { inner: &simple };
+        let RunItemRef::Field(simple) = simple_run.items().next().unwrap() else {
+            panic!("expected simple field");
+        };
+        let complex_run = RunRef { inner: &complex };
+        let RunItemRef::Field(complex) = complex_run.items().next().unwrap() else {
+            panic!("expected complex field");
+        };
+
+        assert_eq!(simple.kind(), FieldKind::Simple);
+        assert_eq!(complex.kind(), FieldKind::Complex);
+        let segments = complex.cached_display_segments();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text(), "1");
+        assert_eq!(segments[0].properties().unwrap().bold, Some(true));
+        assert_eq!(segments[1].text(), "2");
+        assert_eq!(segments[1].properties().unwrap().italic, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve tracked insertion content as an ordered paragraph reader projection
- expose the insertion projection through `RevisionRef` without restoring a compatibility facade
- report unsupported semantic attributes retained by simple and complex field sources

## Review follow-up

- rebased onto current `main`
- preserve the existing direct-run and nested-revision projections while adding the paragraph view
- add regression coverage for nested insertion and deletion wrappers at direct-run boundaries
- ready for maintainer F-ID integration

## Validation

- `cargo test -p rdocx-oxml --lib`
- focused `rdocx` insertion and field reader tests
- `cargo clippy -p rdocx-oxml -p rdocx-layout -p rdocx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/hash_harness.py --check`

The local unfiltered `rdocx` run only reaches the existing environment-dependent `word_and_powerpoint_chart_pixels_are_identical` rasterizer oracle assertion. The failure does not exercise these reader changes.
