### PR TITLE
F-X077, make authored Word charts portable

### DIFF
--- a/.claude/plans/F-X077-design.md
+++ b/.claude/plans/F-X077-design.md
@@ -1,6 +1,6 @@
 # F-X077, Portable authored Word charts
 
-**Status**: approved
+**Status**: completed
 **Sprint**: S65
 **Size**: L
 **Depends on**: F-158
@@ -88,13 +88,14 @@ mapping its visual pie contract to a doughnut chart.
 | package | theme ownership and collision | Chart authoring reuses an existing theme, otherwise adds one collision-safe theme part, relationship, and content type transactionally. |
 | round-trip | typed ChartML additions | Titles, explicit false deletion state, series styles, data-point styles, and unrelated raw siblings survive parse, mutate, save, and reopen in schema order. |
 | compatibility | existing chart kinds | Bar, line, area, scatter, radar, pie, and doughnut authoring still saves and reopens with exact formulas, caches, categories, series, and values. |
-| external oracle | Word and Pages | Word 16.104 opens without repair. A pinned Pages build renders axes, palette colors, category legend, and literal percentages, then exports semantically exact editable chart data. |
+| external oracle | Word and Pages | Word 16.112.2 build 16.112.26082125 opens without repair. Pages 14.5 build 7045.0.17 renders axes, palette colors, category legend, doughnut shape, and literal percentages, then exports semantically exact editable chart data. |
 | integration | changed and consuming crates | Focused crate tests, the complete workspace, hash harness, and public package dry-runs pass. |
 
 The **test gate is differential**. Source-built line, bar, pie, and doughnut
-documents save and reopen with exact editable workbook semantics. Word 16.104
-opens them without repair. A pinned Pages build renders the authored semantics
-and exports a DOCX whose chart and workbook data remain exact.
+documents save and reopen with exact editable workbook semantics. Word 16.112.2
+build 16.112.26082125 opens them without repair. Pages 14.5 build 7045.0.17
+renders the authored semantics and exports a DOCX whose chart and workbook data
+remain exact.
 
 ## HLD impact
 
@@ -124,15 +125,15 @@ not author charts. Any delta blocks integration until classified and approved.
 
 ## Implementation checklist
 
-- [ ] Add failing source-built tests for theme ownership, axis semantics,
+- [x] Add failing source-built tests for theme ownership, axis semantics,
   value formatting, titles, palette styles, point colors, and legends.
-- [ ] Extend the typed ChartML model and writer in schema order.
-- [ ] Extend the cohesive `ChartData` authoring input and facade export.
-- [ ] Stage a default Office theme only when an authored chart needs one.
-- [ ] Prove exact chart and workbook semantics after save and reopen.
-- [ ] Record pinned Word and Pages interoperability evidence.
-- [ ] Run focused crates, full verification, hash harness, and package dry-runs.
-- [ ] Update exactly the six listed HLD files.
+- [x] Extend the typed ChartML model and writer in schema order.
+- [x] Extend the cohesive `ChartData` authoring input and facade export.
+- [x] Stage a default Office theme only when an authored chart needs one.
+- [x] Prove exact chart and workbook semantics after save and reopen.
+- [x] Record pinned Word and Pages interoperability evidence.
+- [x] Run focused crates, full verification, hash harness, and package dry-runs.
+- [x] Update exactly the six listed HLD files.
 
 ## Open questions
 

--- a/.claude/plans/F-X077-design.md
+++ b/.claude/plans/F-X077-design.md
@@ -1,0 +1,141 @@
+# F-X077, Portable authored Word charts
+
+**Status**: approved
+**Sprint**: S65
+**Size**: L
+**Depends on**: F-158
+
+## Problem
+
+The native chart authoring path writes an editable chart part and embedded
+workbook, but it relies on viewer defaults for several visible semantics. A
+new document has no theme relationship, axes omit an explicit visible state,
+the chart number format does not reach the value axis, one-series category
+charts have no explicit point colors, and pie or doughnut charts omit their
+category legend because they contain only one series.
+
+Microsoft Word supplies enough defaults to mask parts of this gap. Pages does
+not. It can show a blank or incomplete chart, and a literal value such as 12.5
+can lose its intended percentage display. Flattening the chart to an image
+would avoid viewer differences but destroy the editable data contract.
+
+## Spec reference
+
+- `docs/hld/03-architecture.md`, for facade-owned authoring and transactional
+  publication through existing crate boundaries.
+- `docs/hld/04-opc-and-packaging.md`, for complete relationship-owned chart,
+  workbook, theme, and content-type assembly.
+- `docs/hld/05-drawingml-model.md`, for default Office themes and typed color
+  handling.
+- `docs/hld/09-charts-spec.md`, for chart data, plots, axes, legends, formulas,
+  caches, schema order, and raw sibling preservation.
+- `docs/hld/10-bindings-spec.md`, for the native Word facade and intentional
+  pre-1.0 source compatibility.
+- `docs/hld/12-testing-strategy.md`, for differential source fixtures and
+  pinned external-oracle evidence.
+- `docs/hld/14-development-backlog.md`, "F-X077, Portable authored Word
+  charts".
+
+## Approach
+
+Extend `ChartData` with three cohesive authoring inputs: an optional category
+axis title, an optional value axis title, and a typed RGB palette. Re-export
+the existing DrawingML RGB type from the `rdocx` facade. This intentionally
+changes complete `ChartData` struct literals before 1.0. Keep an empty palette
+as the existing theme-derived behavior, and cycle a non-empty palette
+deterministically when there are more series or categories than colors.
+
+Teach the existing ChartML model the minimum typed behavior needed by that
+surface. Author plain-text axis titles, explicit axis deletion state, series
+shape properties, and indexed data-point shape properties in schema order.
+Apply palette colors by series for every supported plot. For a one-series bar
+and for pie or doughnut plots, author indexed category-point colors so viewers
+do not need to infer varying colors. Keep pie and doughnut legends even with a
+single series. Put the supplied number format on the value axis as well as the
+workbook and caches.
+
+When the Word facade authors a chart into a document with no effective theme,
+stage the existing Office default theme part, its document relationship, and
+its content type in the same cloned package transaction as the chart. Reuse an
+existing theme unchanged. Choose a collision-safe part name rather than
+overwriting an unrelated package entry.
+
+Do not add a second chart representation, post-serialization XML replacement,
+viewer-specific branch, new dependency, crate, module, or production file.
+The Symbolic caller remains responsible for choosing its palette and for
+mapping its visual pie contract to a doughnut chart.
+
+## Rejected alternatives
+
+- Render charts to images. This loses editable workbook data and does not meet
+  the product contract.
+- Put Symbolic brand colors in rdocx defaults. Brand policy belongs to the
+  caller, while rdocx should expose a generic typed palette.
+- Depend on `varyColors` alone. Pages does not reliably assign distinct colors
+  to one-series bar categories, so the required point styles must be explicit.
+- Always replace the document theme. Existing themes are caller-owned package
+  semantics and must remain authoritative.
+- Inject raw ChartML strings after serialization. That bypasses schema order,
+  preservation, and the typed round-trip model.
+
+## Test plan
+
+| Category | Test | Asserts |
+|---|---|---|
+| regression | portable authored line chart | A source-built line chart gains a default theme only when needed, explicit visible axes, a formatted value axis, typed titles, series color, and unchanged editable data after reopen. |
+| regression | category point colors | One-series bar, pie, and doughnut charts emit deterministic indexed point colors and preserve them after parse and write. |
+| regression | category legends | Pie and doughnut charts keep a legend with one series, while cartesian one-series legend behavior remains unchanged. |
+| package | theme ownership and collision | Chart authoring reuses an existing theme, otherwise adds one collision-safe theme part, relationship, and content type transactionally. |
+| round-trip | typed ChartML additions | Titles, explicit false deletion state, series styles, data-point styles, and unrelated raw siblings survive parse, mutate, save, and reopen in schema order. |
+| compatibility | existing chart kinds | Bar, line, area, scatter, radar, pie, and doughnut authoring still saves and reopens with exact formulas, caches, categories, series, and values. |
+| external oracle | Word and Pages | Word 16.104 opens without repair. A pinned Pages build renders axes, palette colors, category legend, and literal percentages, then exports semantically exact editable chart data. |
+| integration | changed and consuming crates | Focused crate tests, the complete workspace, hash harness, and public package dry-runs pass. |
+
+The **test gate is differential**. Source-built line, bar, pie, and doughnut
+documents save and reopen with exact editable workbook semantics. Word 16.104
+opens them without repair. A pinned Pages build renders the authored semantics
+and exports a DOCX whose chart and workbook data remain exact.
+
+## HLD impact
+
+- `docs/hld/04-opc-and-packaging.md`
+- `docs/hld/05-drawingml-model.md`
+- `docs/hld/09-charts-spec.md`
+- `docs/hld/10-bindings-spec.md`
+- `docs/hld/12-testing-strategy.md`
+- `docs/hld/14-development-backlog.md`
+
+## Risk routing
+
+- **Parser or serializer changes**. Preserve unmodelled XML, remain prefix
+  tolerant, and prove every new child at its schema-defined position.
+- **Theme color changes**. Reuse `CT_OfficeStyleSheet::office_default` and the
+  existing DrawingML color model. Do not alter legacy Word tint math.
+- **Public published API changes**. Record the intentional pre-1.0 source
+  break, run package dry-runs, and report packed sizes.
+- **External oracle comparison**. Pin exact Word and Pages versions, construct
+  source documents from the public API, and record viewer behavior without
+  adding oracle output or binaries to the repository.
+
+## Hash harness
+
+Expected unchanged across all existing entries. The standard sample set does
+not author charts. Any delta blocks integration until classified and approved.
+
+## Implementation checklist
+
+- [ ] Add failing source-built tests for theme ownership, axis semantics,
+  value formatting, titles, palette styles, point colors, and legends.
+- [ ] Extend the typed ChartML model and writer in schema order.
+- [ ] Extend the cohesive `ChartData` authoring input and facade export.
+- [ ] Stage a default Office theme only when an authored chart needs one.
+- [ ] Prove exact chart and workbook semantics after save and reopen.
+- [ ] Record pinned Word and Pages interoperability evidence.
+- [ ] Run focused crates, full verification, hash harness, and package dry-runs.
+- [ ] Update exactly the six listed HLD files.
+
+## Open questions
+
+None. The user approved extracting the generic chart portability work from the
+Symbolic integration into rdocx, with Symbolic retaining its brand palette and
+chart-kind choices.

--- a/.claude/reviews/F-X077-all-pass-1.md
+++ b/.claude/reviews/F-X077-all-pass-1.md
@@ -1,0 +1,30 @@
+# F-X077, all aspects, pass 1
+
+**Reviewed**: working-tree diff, 8 files, 583 insertions and 58 deletions
+**Verdict**: 1 defect, 0 smells, 0 nitpicks
+
+## Defects
+
+### D1, a theme part without its required content type is treated as effective
+`crates/rdocx/src/document.rs:2440`
+
+The effective-theme check only requires an internal theme relationship whose
+target part exists. An input package can carry that relationship and part but
+omit or misdeclare the theme content type. Chart authoring then returns early
+and preserves a malformed package instead of staging the complete relationship,
+part, and content-type assembly required by the design contract. Include the
+resolved part's effective content type in this predicate and cover the malformed
+input with a regression.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Not found
+
+No additional correctness, contract, panic, OOXML ordering or preservation,
+test-gate, or structural findings.

--- a/.claude/reviews/F-X077-all-pass-2.md
+++ b/.claude/reviews/F-X077-all-pass-2.md
@@ -1,0 +1,23 @@
+# F-X077, all aspects, pass 2
+
+**Reviewed**: remediated working-tree diff, 8 files, 627 insertions and 58 deletions
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Not found
+
+No correctness, contract, panic, OOXML ordering or preservation, test-gate, or
+structural findings. Pass 1's ineffective-theme defect is fixed by requiring
+the resolved part to carry the theme content type, with a focused malformed
+package regression.

--- a/.claude/reviews/F-X077-all-pass-3.md
+++ b/.claude/reviews/F-X077-all-pass-3.md
@@ -1,0 +1,23 @@
+# F-X077, all aspects, pass 3
+
+**Reviewed**: Clippy-remediated working-tree diff, 8 files, 615 insertions and 59 deletions
+**Verdict**: 0 defects, 0 smells, 0 nitpicks
+
+## Defects
+
+None.
+
+## Smells
+
+None.
+
+## Nitpicks
+
+None.
+
+## Not found
+
+No correctness, contract, panic, OOXML ordering or preservation, test-gate, or
+structural findings. Deriving `Default` for `ChartData` is behaviorally
+equivalent to the removed field-by-field implementation and resolves the only
+Clippy finding.

--- a/crates/oxml-chart/src/lib.rs
+++ b/crates/oxml-chart/src/lib.rs
@@ -12,7 +12,8 @@ use oxml_drawing::color::{
     ColorChoice, ColorMap, ColorMapSlot, ResolvedColor, RgbColor, ThemeColorSlot,
     apply_color_transforms, resolve_color,
 };
-use oxml_drawing::fill::Fill;
+use oxml_drawing::fill::{Fill, SolidFill};
+use oxml_drawing::line::CT_LineProperties;
 use oxml_drawing::order::OrderedRawChildren;
 use oxml_drawing::shape_props::{CT_ShapeProperties, ShapePropertiesError};
 use oxml_drawing::text::{CT_TextBody, CT_TextCharacterProperties, TextError};
@@ -133,11 +134,14 @@ pub enum ChartKind {
 }
 
 /// Data used to author one chart and its editable workbook.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ChartData {
     pub categories: Vec<String>,
     pub series: Vec<(String, Vec<f64>)>,
     pub number_format: Option<String>,
+    pub category_axis_title: Option<String>,
+    pub value_axis_title: Option<String>,
+    pub palette: Vec<RgbColor>,
 }
 
 /// Authors one ChartML part and its editable workbook from one validated source.
@@ -210,6 +214,7 @@ pub fn authored_chart_parts(
         });
         chart_series.push(series);
     }
+    apply_palette(kind, data, &mut chart_series);
 
     let category_axis_id = AxisId::new(48_650_112).map_err(invalid_authoring_value)?;
     let value_axis_id = AxisId::new(48_672_768).map_err(invalid_authoring_value)?;
@@ -222,38 +227,41 @@ pub fn authored_chart_parts(
                 chart_series,
                 axis_ids,
             ),
-            category_value_axes(category_axis_id, value_axis_id),
+            category_value_axes(category_axis_id, value_axis_id, data)?,
         ),
         ChartKind::Line => (
             Plot::line(Grouping::Standard, chart_series, axis_ids),
-            category_value_axes(category_axis_id, value_axis_id),
+            category_value_axes(category_axis_id, value_axis_id, data)?,
         ),
         ChartKind::Pie => (Plot::pie(chart_series), Vec::new()),
         ChartKind::Doughnut => (Plot::doughnut(chart_series), Vec::new()),
         ChartKind::Area => (
             Plot::area(Grouping::Standard, chart_series, axis_ids),
-            category_value_axes(category_axis_id, value_axis_id),
+            category_value_axes(category_axis_id, value_axis_id, data)?,
         ),
         ChartKind::Scatter => (
             Plot::scatter(ScatterStyle::LineMarker, chart_series, axis_ids),
-            vec![
-                Axis::new(
-                    AxisKind::Value,
-                    category_axis_id,
-                    AxisPosition::Bottom,
-                    value_axis_id,
-                ),
-                Axis::new(
-                    AxisKind::Value,
-                    value_axis_id,
-                    AxisPosition::Left,
-                    category_axis_id,
-                ),
-            ],
+            authored_axes(
+                [
+                    Axis::new(
+                        AxisKind::Value,
+                        category_axis_id,
+                        AxisPosition::Bottom,
+                        value_axis_id,
+                    ),
+                    Axis::new(
+                        AxisKind::Value,
+                        value_axis_id,
+                        AxisPosition::Left,
+                        category_axis_id,
+                    ),
+                ],
+                data,
+            )?,
         ),
         ChartKind::Radar => (
             Plot::radar(RadarStyle::Standard, chart_series, axis_ids),
-            category_value_axes(category_axis_id, value_axis_id),
+            category_value_axes(category_axis_id, value_axis_id, data)?,
         ),
     };
     let plot = plot.map_err(invalid_authoring_value)?;
@@ -264,7 +272,9 @@ pub fn authored_chart_parts(
     let mut chart_space = CT_ChartSpace::from_xml(chart_shell.as_bytes())?;
     chart_space.chart.auto_title_deleted = true;
     chart_space.chart.plot_area = plot_area;
-    chart_space.chart.legend = (data.series.len() > 1).then(CT_Legend::default);
+    chart_space.chart.legend = (data.series.len() > 1
+        || matches!(kind, ChartKind::Pie | ChartKind::Doughnut))
+    .then(CT_Legend::default);
     let chart_xml = chart_space.to_xml()?;
     let workbook_bytes = workbook.to_xlsx_bytes().map_err(invalid_authoring_value)?;
     Ok((chart_xml, workbook_bytes))
@@ -322,11 +332,69 @@ fn invalid_authoring_value(error: impl fmt::Display) -> ChartError {
     }
 }
 
-fn category_value_axes(category: AxisId, value: AxisId) -> Vec<Axis> {
-    vec![
-        Axis::new(AxisKind::Category, category, AxisPosition::Bottom, value),
-        Axis::new(AxisKind::Value, value, AxisPosition::Left, category),
-    ]
+fn category_value_axes(category: AxisId, value: AxisId, data: &ChartData) -> Result<Vec<Axis>> {
+    authored_axes(
+        [
+            Axis::new(AxisKind::Category, category, AxisPosition::Bottom, value),
+            Axis::new(AxisKind::Value, value, AxisPosition::Left, category),
+        ],
+        data,
+    )
+}
+
+fn authored_axes(mut axes: [Axis; 2], data: &ChartData) -> Result<Vec<Axis>> {
+    for axis in &mut axes {
+        axis.set_deleted(false);
+    }
+    axes[0].title = data
+        .category_axis_title
+        .as_deref()
+        .map(CT_Title::plain_text);
+    axes[1].title = data.value_axis_title.as_deref().map(CT_Title::plain_text);
+    axes[1].number_format = data
+        .number_format
+        .as_ref()
+        .map(|format| NumberFormat::new(format.clone(), false))
+        .transpose()?;
+    Ok(axes.into())
+}
+
+fn apply_palette(kind: ChartKind, data: &ChartData, series: &mut [Series]) {
+    if data.palette.is_empty() {
+        return;
+    }
+    for (index, item) in series.iter_mut().enumerate() {
+        item.sp_pr = Some(series_shape(kind, data.palette[index % data.palette.len()]));
+    }
+    if matches!(kind, ChartKind::Bar | ChartKind::Pie | ChartKind::Doughnut) && series.len() == 1 {
+        series[0].authored_data_points = data
+            .categories
+            .iter()
+            .enumerate()
+            .map(|(index, _)| DataPoint {
+                index: index as u32,
+                sp_pr: series_shape(kind, data.palette[index % data.palette.len()]),
+            })
+            .collect();
+    }
+}
+
+fn series_shape(kind: ChartKind, color: RgbColor) -> CT_ShapeProperties {
+    let mut solid = SolidFill::default();
+    solid.color = Some(ColorChoice::srgb(color));
+    let fill = Fill::Solid(solid);
+    let mut properties = CT_ShapeProperties::default();
+    if matches!(
+        kind,
+        ChartKind::Line | ChartKind::Scatter | ChartKind::Radar
+    ) {
+        let mut line = CT_LineProperties::default();
+        line.fill = Some(fill);
+        properties.line = Some(line);
+    } else {
+        properties.fill = Some(fill);
+    }
+    properties
 }
 
 fn spreadsheet_column_name(mut index: usize) -> String {
@@ -3859,6 +3927,7 @@ struct ReferenceMarkup {
     cache_attributes: XmlAttributes,
     cache_children: OrderedRawChildren,
     format_code: Option<TextMarkup>,
+    format_code_omitted: bool,
     point_count: ScalarMarkup,
     declared_point_count: Option<u32>,
     point_indexes: Vec<u32>,
@@ -3972,9 +4041,7 @@ impl NumericData {
 
     fn from_xml_with_namespaces(xml: &[u8], inherited: &NamespaceBindings) -> Result<Self> {
         let parsed = parse_reference(xml, b"numRef", b"numCache", true, inherited)?;
-        let format_code = parsed
-            .format_code
-            .ok_or_else(|| ChartError::MissingElement("c:formatCode".to_owned()))?;
+        let format_code = parsed.format_code.unwrap_or_else(|| "General".to_owned());
         let mut values = Vec::with_capacity(parsed.values.len());
         for value in parsed.values {
             let number = value.parse::<f64>().map_err(|_| ChartError::InvalidValue {
@@ -4041,6 +4108,26 @@ pub enum AxisData {
     Numeric(NumericData),
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct DataPoint {
+    index: u32,
+    sp_pr: CT_ShapeProperties,
+}
+
+impl DataPoint {
+    fn write_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<()> {
+        writer
+            .write_event(Event::Start(BytesStart::new("c:dPt")))
+            .map_err(OxmlError::from)?;
+        write_scalar(writer, "c:idx", &self.index.to_string(), None)?;
+        self.sp_pr.write_xml_as(writer, "c:spPr")?;
+        writer
+            .write_event(Event::End(BytesEnd::new("c:dPt")))
+            .map_err(OxmlError::from)?;
+        Ok(())
+    }
+}
+
 /// The common formula-backed payload of one ChartML series.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Series {
@@ -4052,6 +4139,7 @@ pub struct Series {
     pub bubble_size: Option<NumericData>,
     pub sp_pr: Option<CT_ShapeProperties>,
     pub data_labels: Option<CT_DLbls>,
+    authored_data_points: Vec<DataPoint>,
     index_markup: ScalarMarkup,
     order_markup: ScalarMarkup,
     name_markup: Option<WrapperMarkup>,
@@ -4079,6 +4167,7 @@ impl Series {
             bubble_size: None,
             sp_pr: None,
             data_labels: None,
+            authored_data_points: Vec::new(),
             index_markup: ScalarMarkup::default(),
             order_markup: ScalarMarkup::default(),
             name_markup: None,
@@ -4260,6 +4349,9 @@ impl Series {
             properties.write_xml_as(&mut writer, "c:spPr")?;
         }
         emit_raw(&mut writer, self.raw_children.at(4))?;
+        for point in &self.authored_data_points {
+            point.write_xml(&mut writer)?;
+        }
         if let Some(labels) = &self.data_labels {
             labels.write_xml(&mut writer, false)?;
         }
@@ -4518,6 +4610,7 @@ impl SeriesParseState {
             bubble_size,
             sp_pr: self.sp_pr,
             data_labels: self.data_labels,
+            authored_data_points: Vec::new(),
             index_markup,
             order_markup,
             name_markup,
@@ -4654,6 +4747,7 @@ fn parse_reference(
                                 cache_attributes: cache_markup.raw_attributes,
                                 cache_children: cache_markup.raw_children,
                                 format_code: cache_markup.format_code,
+                                format_code_omitted: cache_markup.format_code_omitted,
                                 point_count: cache_markup.point_count,
                                 declared_point_count: cache_markup.declared_point_count,
                                 point_indexes: cache_markup.point_indexes,
@@ -4701,6 +4795,7 @@ struct CacheMarkup {
     raw_attributes: XmlAttributes,
     raw_children: OrderedRawChildren,
     format_code: Option<TextMarkup>,
+    format_code_omitted: bool,
     point_count: ScalarMarkup,
     declared_point_count: Option<u32>,
     point_indexes: Vec<u32>,
@@ -4866,9 +4961,7 @@ impl CacheParseState {
             .format_code
             .map(|(value, markup)| (Some(value), Some(markup)))
             .unwrap_or((None, None));
-        if self.numeric && format_code.is_none() {
-            return Err(ChartError::MissingElement("c:formatCode".to_owned()));
-        }
+        let format_code_omitted = self.numeric && format_code.is_none();
         Ok((
             format_code,
             values,
@@ -4879,6 +4972,7 @@ impl CacheParseState {
                     self.point_base + point_markup.len(),
                 ),
                 format_code: format_markup,
+                format_code_omitted,
                 point_count: point_count_markup,
                 declared_point_count: Some(declared),
                 point_indexes,
@@ -5236,16 +5330,18 @@ fn write_numeric_cache(
         .write_event(Event::Start(start))
         .map_err(OxmlError::from)?;
     emit_raw(writer, markup.cache_children.at(0))?;
-    let default_format_markup = TextMarkup::default();
-    write_text(
-        writer,
-        "c:formatCode",
-        &data.format_code,
-        markup
-            .format_code
-            .as_ref()
-            .unwrap_or(&default_format_markup),
-    )?;
+    if !markup.format_code_omitted || data.format_code != "General" {
+        let default_format_markup = TextMarkup::default();
+        write_text(
+            writer,
+            "c:formatCode",
+            &data.format_code,
+            markup
+                .format_code
+                .as_ref()
+                .unwrap_or(&default_format_markup),
+        )?;
+    }
     emit_raw(writer, markup.cache_children.at(1))?;
     write_scalar(
         writer,
@@ -6420,9 +6516,10 @@ impl DispBlanksAs {
     }
 }
 
-/// A chart title shell whose current children remain opaque until later stories.
+/// A chart title with plain-text authoring and preserved unsupported children.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CT_Title {
+    text: Option<CT_TextBody>,
     raw_attributes: Vec<(String, String)>,
     raw_children: OrderedRawChildren,
 }
@@ -6573,6 +6670,12 @@ impl Axis {
             namespace_declarations: Vec::new(),
             raw_children: OrderedRawChildren::default(),
         }
+    }
+
+    /// Sets axis visibility and writes the explicit ChartML deletion flag.
+    pub fn set_deleted(&mut self, deleted: bool) {
+        self.deleted = deleted;
+        self.delete_markup.get_or_insert_with(ScalarMarkup::default);
     }
 
     pub fn from_xml(xml: &[u8]) -> Result<Self> {
@@ -8007,16 +8110,49 @@ fn parse_bool_lexical(element: &str, attribute: &str, value: &str) -> Result<boo
 }
 
 impl CT_Title {
+    fn plain_text(text: &str) -> Self {
+        let mut body = CT_TextBody::new();
+        body.set_text(text);
+        Self {
+            text: Some(body),
+            ..Self::default()
+        }
+    }
+
     fn from_xml(xml: &[u8]) -> Result<Self> {
         let (raw_attributes, raw_children) = parse_raw_shell(xml, b"title", "c:title")?;
         Ok(Self {
+            text: None,
             raw_attributes,
             raw_children,
         })
     }
 
     fn write_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<()> {
-        write_raw_shell(writer, "c:title", &self.raw_attributes, &self.raw_children)
+        if self.text.is_none() {
+            return write_raw_shell(writer, "c:title", &self.raw_attributes, &self.raw_children);
+        }
+        let mut start = BytesStart::new("c:title");
+        push_attributes(&mut start, &self.raw_attributes);
+        writer
+            .write_event(Event::Start(start))
+            .map_err(OxmlError::from)?;
+        emit_raw(writer, self.raw_children.at(0))?;
+        writer
+            .write_event(Event::Start(BytesStart::new("c:tx")))
+            .map_err(OxmlError::from)?;
+        self.text
+            .as_ref()
+            .expect("checked title text")
+            .write_xml_as(writer, "c:rich")?;
+        writer
+            .write_event(Event::End(BytesEnd::new("c:tx")))
+            .map_err(OxmlError::from)?;
+        emit_raw(writer, self.raw_children.at(1))?;
+        writer
+            .write_event(Event::End(BytesEnd::new("c:title")))
+            .map_err(OxmlError::from)?;
+        Ok(())
     }
 
     pub fn raw_children(&self) -> &OrderedRawChildren {
@@ -8137,11 +8273,21 @@ impl CT_PlotArea {
 
     /// Creates a supported single-family plot area with owned axes.
     pub fn new(plots: Vec<Plot>, axes: Vec<Axis>) -> Result<Self> {
+        let plot_markup = plots
+            .iter()
+            .map(|plot| {
+                let mut markup = PlotMarkup::default();
+                if matches!(plot, Plot::Doughnut { .. }) {
+                    markup.hole_size = Some(ScalarMarkup::default());
+                }
+                markup
+            })
+            .collect();
         let plot_area = Self {
             raw_attributes: Vec::new(),
             raw_children: OrderedRawChildren::default(),
             namespace_bindings: chart_namespace_defaults(),
-            plot_markup: vec![PlotMarkup::default(); plots.len()],
+            plot_markup,
             plots: Some(plots),
             axes,
         };
@@ -10905,11 +11051,11 @@ mod tests {
 
     use super::{
         A_NS, Axis, AxisData, AxisId, AxisKind, AxisPosition, BarDirection, BarGrouping, C_NS,
-        CT_ChartSpace, CT_DLbls, CT_ShapeProperties, CT_TextBody, ChartGeometry, DataLabelPosition,
-        DispBlanksAs, Domain, Grouping, NumberFormat, NumericData, Orientation, Plot, R_NS,
-        ScatterStyle, Series, StringRef, TickLabelPosition, TickMark, capture_event, local_name,
-        matches_local_name, nice_number_scale, render_chart as render_chart_with_theme,
-        render_geometry as render_geometry_with_theme,
+        CT_ChartSpace, CT_DLbls, CT_ShapeProperties, CT_TextBody, ChartData, ChartGeometry,
+        ChartKind, DataLabelPosition, DispBlanksAs, Domain, Grouping, NumberFormat, NumericData,
+        Orientation, Plot, R_NS, ScatterStyle, Series, StringRef, TickLabelPosition, TickMark,
+        authored_chart_parts, capture_event, local_name, matches_local_name, nice_number_scale,
+        render_chart as render_chart_with_theme, render_geometry as render_geometry_with_theme,
     };
 
     const MANIFEST: &str = include_str!("../../../scripts/pptx-corpus-manifest.tsv");
@@ -10919,6 +11065,72 @@ mod tests {
     const PDFTOTEXT_VERSION: &str = "pdftotext version 26.01.0";
     const PDFTOPPM_VERSION: &str = "pdftoppm version 26.01.0";
     const PLOT_RENDER_NORMALIZED_MAE_THRESHOLD: f64 = 0.0;
+
+    #[test]
+    fn authored_charts_emit_portable_viewer_defaults() {
+        let data = ChartData {
+            categories: vec!["August".to_owned(), "September".to_owned()],
+            series: vec![("Price".to_owned(), vec![12.5, 19.2])],
+            number_format: Some(r"0.##\%".to_owned()),
+            category_axis_title: Some("Month".to_owned()),
+            value_axis_title: Some("Change".to_owned()),
+            palette: vec![
+                RgbColor::parse("2B6FE3").unwrap(),
+                RgbColor::parse("F0761F").unwrap(),
+            ],
+        };
+        let (line, _) = authored_chart_parts(ChartKind::Line, &data, "rId1").unwrap();
+        let line = std::str::from_utf8(&line).unwrap();
+        assert_eq!(line.matches(r#"<c:delete val="0"/>"#).count(), 2);
+        assert!(line.contains(r#"<c:numFmt formatCode="0.##\%" sourceLinked="0"/>"#));
+        assert!(line.contains("<a:t>Month</a:t>"));
+        assert!(line.contains("<a:t>Change</a:t>"));
+        assert!(line.contains(r#"<a:srgbClr val="2B6FE3"/>"#));
+        for axis in line.split("<c:crossAx").take(2) {
+            let scaling = axis.rfind("<c:scaling").unwrap();
+            let deleted = axis.rfind("<c:delete").unwrap();
+            let position = axis.rfind("<c:axPos").unwrap();
+            assert!(scaling < deleted && deleted < position);
+        }
+
+        for kind in [ChartKind::Bar, ChartKind::Pie, ChartKind::Doughnut] {
+            let (chart, _) = authored_chart_parts(kind, &data, "rId1").unwrap();
+            let chart = std::str::from_utf8(&chart).unwrap();
+            if matches!(kind, ChartKind::Pie | ChartKind::Doughnut) {
+                assert!(chart.contains("<c:legend"));
+            }
+            if kind == ChartKind::Doughnut {
+                assert!(chart.contains(r#"<c:holeSize val="50"/>"#));
+            }
+            assert_eq!(chart.matches("<c:dPt>").count(), 2);
+            assert!(chart.contains(
+                r#"<c:dPt><c:idx val="0"/><c:spPr><a:solidFill><a:srgbClr val="2B6FE3"/>"#
+            ));
+            assert!(chart.contains(
+                r#"<c:dPt><c:idx val="1"/><c:spPr><a:solidFill><a:srgbClr val="F0761F"/>"#
+            ));
+
+            let parsed = CT_ChartSpace::from_xml(chart.as_bytes()).unwrap();
+            let rewritten = String::from_utf8(parsed.to_xml().unwrap()).unwrap();
+            assert_eq!(rewritten.matches("<c:dPt>").count(), 2);
+            assert!(rewritten.contains(r#"<a:srgbClr val="2B6FE3"/>"#));
+            assert!(rewritten.contains(r#"<a:srgbClr val="F0761F"/>"#));
+        }
+    }
+
+    #[test]
+    fn optional_numeric_cache_format_remains_omitted() {
+        let xml = br#"<c:numRef xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:f>Sheet1!$B$2:$B$3</c:f><c:numCache><c:ptCount val="2"/><c:pt idx="0"><c:v>12.5</c:v></c:pt><c:pt idx="1"><c:v>19.2</c:v></c:pt></c:numCache></c:numRef>"#;
+        let mut parsed = NumericData::from_xml(xml).unwrap();
+        assert_eq!(parsed.format_code, "General");
+        let written = parsed.to_xml().unwrap();
+        assert!(!String::from_utf8_lossy(&written).contains("formatCode"));
+        assert_eq!(NumericData::from_xml(&written).unwrap(), parsed);
+
+        parsed.format_code = "0.00".to_owned();
+        let written = String::from_utf8(parsed.to_xml().unwrap()).unwrap();
+        assert!(written.contains("<c:formatCode>0.00</c:formatCode>"));
+    }
 
     fn render_geometry(chart: &super::CT_Chart, bounds: Rect) -> super::Result<ChartGeometry> {
         render_geometry_with_theme(

--- a/crates/oxml-drawing/src/color.rs
+++ b/crates/oxml-drawing/src/color.rs
@@ -439,6 +439,15 @@ pub enum ColorChoice {
 }
 
 impl ColorChoice {
+    /// Creates an sRGB colour without transforms.
+    pub fn srgb(value: RgbColor) -> Self {
+        Self::Srgb {
+            value,
+            transforms: Vec::new(),
+            raw_children: OrderedRawChildren::default(),
+        }
+    }
+
     /// Parses a colour after the caller has consumed its start event.
     pub fn from_xml(reader: &mut Reader<&[u8]>, start: &BytesStart<'_>) -> Result<Self> {
         reject_conflicting_a_prefix(start)?;
@@ -1379,6 +1388,7 @@ mod tests {
             }
         );
         assert_eq!(write(&colour), br#"<a:srgbClr val="12ABEF"/>"#);
+        assert_eq!(ColorChoice::srgb(RgbColor::new(0x12, 0xAB, 0xEF)), colour);
     }
 
     #[test]

--- a/crates/rdocx/src/document.rs
+++ b/crates/rdocx/src/document.rs
@@ -2397,6 +2397,7 @@ impl Document {
                     .map_err(|error| Error::Other(format!("invalid chart workbook: {error}")))?,
             ),
             ChartPackageSource::Authored { kind, data } => {
+                Self::ensure_authored_chart_theme(&mut package, &self.doc_part_name)?;
                 oxml_chart::authored_chart_parts(kind, data, &workbook_relationship_id)
                     .map_err(|error| Error::Other(format!("invalid chart data: {error}")))?
             }
@@ -2432,6 +2433,51 @@ impl Document {
         self.package = package;
         self.document = document;
         self.invalidate_layout();
+        Ok(())
+    }
+
+    fn ensure_authored_chart_theme(package: &mut OpcPackage, document_part: &str) -> Result<()> {
+        let has_theme = package
+            .get_part_rels(document_part)
+            .into_iter()
+            .flat_map(|relationships| relationships.get_all_by_type(rel_types::THEME))
+            .filter(|relationship| relationship.target_mode.as_deref() != Some("External"))
+            .map(|relationship| OpcPackage::resolve_rel_target(document_part, &relationship.target))
+            .any(|part_name| {
+                package.get_part(&part_name).is_some()
+                    && package.content_types.content_type_for(&part_name)
+                        == Some(content_types::THEME)
+            });
+        if has_theme {
+            return Ok(());
+        }
+
+        let mut namer = MediaNamer::scan(
+            "/word/theme",
+            "theme",
+            package.parts.keys().map(String::as_str),
+        );
+        let theme_part = namer.next_part_name("xml");
+        let theme_xml = oxml_drawing::theme::CT_OfficeStyleSheet::office_default()
+            .to_xml()
+            .map_err(|error| Error::Other(format!("invalid default Office theme: {error}")))?;
+        package.set_part(&theme_part, theme_xml);
+        package
+            .content_types
+            .add_override(&theme_part, content_types::THEME);
+
+        let target = relative_target(document_part, &theme_part);
+        let relationships = package.get_or_create_part_rels(document_part);
+        if let Some(relationship) = relationships
+            .items
+            .iter_mut()
+            .find(|relationship| relationship.rel_type == rel_types::THEME)
+        {
+            relationship.target = target;
+            relationship.target_mode = None;
+        } else {
+            relationships.add(rel_types::THEME, &target);
+        }
         Ok(())
     }
 
@@ -6889,6 +6935,12 @@ mod tests {
     const WORD_BUILD: &str = "16.104.25121423";
     const WORD_CHART_CANDIDATE_SHA256: &str =
         "79e9b9ff9e7557dbd09a365bb8c189806e700ed48ca768b27d7158cf2b41370b";
+    const FX077_WORD_VERSION: &str = "16.112.2";
+    const FX077_WORD_BUILD: &str = "16.112.26082125";
+    const FX077_PAGES_VERSION: &str = "14.5";
+    const FX077_PAGES_BUILD: &str = "7045.0.17";
+    const FX077_CANDIDATE_SHA256: &str =
+        "948f939135f26f9ebcac15da1d9fec5bcd75cf550e2ea608ef55380afa25440f";
 
     #[test]
     fn unsupported_names_come_from_the_accepted_parser_event() {
@@ -8440,7 +8492,149 @@ mod tests {
             .take(series_count)
             .collect(),
             number_format: Some("0.00".to_owned()),
+            ..ChartData::default()
         }
+    }
+
+    #[test]
+    fn authored_chart_adds_a_relationship_owned_default_theme() {
+        let mut document = Document::new();
+        document
+            .add_chart(
+                ChartKind::Line,
+                Length::inches(5.0),
+                Length::inches(3.0),
+                &f158_chart_data(1),
+            )
+            .unwrap();
+
+        let bytes = document.to_bytes().unwrap();
+        let reopened = Document::from_bytes(&bytes).unwrap();
+        let theme_relationship = reopened
+            .package
+            .get_part_rels(&reopened.doc_part_name)
+            .and_then(|relationships| relationships.get_by_type(rel_types::THEME))
+            .expect("authored chart theme relationship");
+        let theme_part =
+            OpcPackage::resolve_rel_target(&reopened.doc_part_name, &theme_relationship.target);
+        let theme = reopened.package.get_part(&theme_part).expect("theme part");
+        oxml_drawing::theme::CT_OfficeStyleSheet::from_xml(theme).expect("typed Office theme");
+        assert_eq!(
+            reopened.package.content_types.content_type_for(&theme_part),
+            Some(content_types::THEME)
+        );
+    }
+
+    #[test]
+    fn authored_chart_preserves_an_existing_document_theme() {
+        let mut document = Document::new();
+        let theme_part = "/word/theme/custom-chart-theme.xml";
+        let theme = oxml_drawing::theme::CT_OfficeStyleSheet::office_default()
+            .to_xml()
+            .unwrap();
+        document.package.set_part(theme_part, theme.clone());
+        document
+            .package
+            .content_types
+            .add_override(theme_part, content_types::THEME);
+        document
+            .package
+            .get_or_create_part_rels(&document.doc_part_name)
+            .add(rel_types::THEME, "theme/custom-chart-theme.xml");
+
+        document
+            .add_chart(
+                ChartKind::Bar,
+                Length::inches(5.0),
+                Length::inches(3.0),
+                &f158_chart_data(1),
+            )
+            .unwrap();
+
+        let relationships = document
+            .package
+            .get_part_rels(&document.doc_part_name)
+            .unwrap()
+            .get_all_by_type(rel_types::THEME);
+        assert_eq!(relationships.len(), 1);
+        assert_eq!(
+            document.package.get_part(theme_part),
+            Some(theme.as_slice())
+        );
+        assert!(
+            document
+                .package
+                .get_part("/word/theme/theme1.xml")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn authored_chart_replaces_a_theme_without_its_required_content_type() {
+        let mut document = Document::new();
+        let incomplete_theme_part = "/word/theme/theme1.xml";
+        document
+            .package
+            .set_part(incomplete_theme_part, b"untyped theme".to_vec());
+        document
+            .package
+            .get_or_create_part_rels(&document.doc_part_name)
+            .add(rel_types::THEME, "theme/theme1.xml");
+
+        document
+            .add_chart(
+                ChartKind::Line,
+                Length::inches(5.0),
+                Length::inches(3.0),
+                &f158_chart_data(1),
+            )
+            .unwrap();
+
+        let relationships = document
+            .package
+            .get_part_rels(&document.doc_part_name)
+            .unwrap()
+            .get_all_by_type(rel_types::THEME);
+        assert_eq!(relationships.len(), 1);
+        let theme_part =
+            OpcPackage::resolve_rel_target(&document.doc_part_name, &relationships[0].target);
+        assert_ne!(theme_part, incomplete_theme_part);
+        assert_eq!(
+            document.package.content_types.content_type_for(&theme_part),
+            Some(content_types::THEME)
+        );
+        oxml_drawing::theme::CT_OfficeStyleSheet::from_xml(
+            document.package.get_part(&theme_part).unwrap(),
+        )
+        .expect("typed replacement theme");
+    }
+
+    #[test]
+    fn authored_chart_theme_name_does_not_collide_with_existing_parts() {
+        let mut document = Document::new();
+        document
+            .package
+            .set_part("/word/theme/theme3.xml", b"occupied".to_vec());
+
+        document
+            .add_chart(
+                ChartKind::Doughnut,
+                Length::inches(5.0),
+                Length::inches(3.0),
+                &f158_chart_data(1),
+            )
+            .unwrap();
+
+        assert_eq!(
+            document.package.get_part("/word/theme/theme3.xml"),
+            Some(b"occupied".as_slice())
+        );
+        assert!(
+            document
+                .package
+                .get_part("/word/theme/theme4.xml")
+                .is_some()
+        );
     }
 
     fn assert_authored_chart_matches(chart: &CT_ChartSpace, data: &ChartData) {
@@ -8699,9 +8893,9 @@ mod tests {
         const CROP_WIDTH: &str = "750";
         const CROP_HEIGHT: &str = "450";
         const WORD_SHA256: &str =
-            "e50845637449e2af4b8e2dbf16f5f6f53e5f598a00401fcc34c13f5d5716a1c4";
+            "9acea62539e90e39078a3502c2f2a109073d60497a50db89bac065bd2b4785cf";
         const POWERPOINT_SHA256: &str =
-            "7525e9a088c5fbf58fa1ed98cdfa0ec2fabf998662112ced7a6b6521f2c4edfc";
+            "f8bcefb13777e423714493a292966d0214298adc826d5487e4bfbea0f36e4582";
 
         let data = f158_chart_data(2);
         let evidence_dir = std::env::temp_dir();
@@ -8751,9 +8945,6 @@ mod tests {
             .to_vec();
         word.package
             .set_part("/word/theme/theme1.xml", effective_theme);
-        word.package
-            .get_or_create_part_rels("/word/document.xml")
-            .add(rel_types::THEME, "theme/theme1.xml");
         word.save(&word_path).expect("save Word chart artifact");
 
         let word_sha = sha256(&word_path);
@@ -9027,26 +9218,31 @@ mod tests {
                 categories: Vec::new(),
                 series: vec![("Revenue".to_owned(), Vec::new())],
                 number_format: None,
+                ..ChartData::default()
             },
             ChartData {
                 categories: vec!["North".to_owned()],
                 series: Vec::new(),
                 number_format: None,
+                ..ChartData::default()
             },
             ChartData {
                 categories: vec!["North".to_owned(), "South".to_owned()],
                 series: vec![("Revenue".to_owned(), vec![12.5])],
                 number_format: None,
+                ..ChartData::default()
             },
             ChartData {
                 categories: vec!["North".to_owned()],
                 series: vec![("Revenue".to_owned(), vec![f64::NAN])],
                 number_format: None,
+                ..ChartData::default()
             },
             ChartData {
                 categories: vec!["North".to_owned()],
                 series: vec![("Revenue".to_owned(), vec![12.5])],
                 number_format: Some(String::new()),
+                ..ChartData::default()
             },
         ];
         for data in invalid {
@@ -9142,6 +9338,132 @@ mod tests {
             "Microsoft Word F-157 acceptance failed: {}",
             String::from_utf8_lossy(&result.stderr)
         );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Microsoft Word and Pages interoperability evidence"]
+    fn word_and_pages_open_portable_authored_charts() {
+        let output_dir = std::env::var_os("RDOCX_FX077_ORACLE_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("set RDOCX_FX077_ORACLE_DIR to an existing evidence directory");
+        let candidate = output_dir.join("portable-authored-charts.docx");
+        let pages_output = output_dir.join("portable-authored-charts-pages.docx");
+        let _ = fs::remove_file(&pages_output);
+        portable_chart_document()
+            .save(&candidate)
+            .expect("write portable chart candidate");
+        assert_eq!(sha256(&candidate), FX077_CANDIDATE_SHA256);
+
+        for (application, version, build) in [
+            ("Microsoft Word", FX077_WORD_VERSION, FX077_WORD_BUILD),
+            ("Pages", FX077_PAGES_VERSION, FX077_PAGES_BUILD),
+        ] {
+            let plist = format!("/Applications/{application}.app/Contents/Info.plist");
+            assert_eq!(plist_value(&plist, "CFBundleShortVersionString"), version);
+            assert_eq!(plist_value(&plist, "CFBundleVersion"), build);
+        }
+
+        let word_script = format!(
+            "with timeout of 120 seconds\ntell application \"Microsoft Word\"\nactivate\nopen POSIX file \"{}\"\ndelay 5\nclose active document saving no\nend tell\nend timeout\n",
+            candidate.display()
+        );
+        let word = Command::new("osascript")
+            .args(["-e", &word_script])
+            .output()
+            .expect("launch Word chart oracle");
+        assert!(
+            word.status.success(),
+            "Word chart oracle failed: {}",
+            String::from_utf8_lossy(&word.stderr)
+        );
+
+        let pages_script = format!(
+            "with timeout of 120 seconds\ntell application \"Pages\"\nactivate\nset chartDocument to open POSIX file \"{}\"\ndelay 5\nexport chartDocument to POSIX file \"{}\" as Microsoft Word\nclose chartDocument saving no\nend tell\nend timeout\n",
+            candidate.display(),
+            pages_output.display()
+        );
+        let pages = Command::new("osascript")
+            .args(["-e", &pages_script])
+            .output()
+            .expect("launch Pages chart oracle");
+        assert!(
+            pages.status.success(),
+            "Pages chart oracle failed: {}",
+            String::from_utf8_lossy(&pages.stderr)
+        );
+        assert_portable_chart_data(&Document::open(&pages_output).expect("open Pages DOCX"));
+    }
+
+    fn portable_chart_document() -> Document {
+        let data = ChartData {
+            categories: vec!["August".to_owned(), "September".to_owned()],
+            series: vec![("Gold".to_owned(), vec![12.5, 19.2])],
+            number_format: Some(r"0.##\%".to_owned()),
+            category_axis_title: Some("Month".to_owned()),
+            value_axis_title: Some("Change".to_owned()),
+            palette: vec![
+                oxml_drawing::color::RgbColor::parse("2B6FE3").unwrap(),
+                oxml_drawing::color::RgbColor::parse("F0761F").unwrap(),
+            ],
+        };
+        let mut document = Document::new();
+        for kind in [ChartKind::Line, ChartKind::Bar, ChartKind::Doughnut] {
+            document
+                .add_chart(kind, Length::inches(6.0), Length::inches(3.5), &data)
+                .expect("author portable chart");
+        }
+        document
+    }
+
+    fn assert_portable_chart_data(document: &Document) {
+        let relationships = document
+            .package
+            .get_part_rels(&document.doc_part_name)
+            .expect("document relationships")
+            .get_all_by_type(rel_types::CHART);
+        assert_eq!(relationships.len(), 3);
+        for relationship in relationships {
+            let part =
+                OpcPackage::resolve_rel_target(&document.doc_part_name, &relationship.target);
+            let chart = std::str::from_utf8(
+                document
+                    .package
+                    .get_part(&part)
+                    .expect("chart part after Pages"),
+            )
+            .expect("chart XML after Pages");
+            for value in ["August", "September", "12.500000", "19.200000", "2B6FE3"] {
+                assert!(chart.contains(value), "missing {value} in {part}");
+            }
+            if chart.contains("<c:barChart>") || chart.contains("<c:doughnutChart>") {
+                assert!(
+                    chart.contains("F0761F"),
+                    "missing second point color in {part}"
+                );
+            }
+            let workbook_relationship = document
+                .package
+                .get_part_rels(&part)
+                .and_then(|relationships| relationships.get_by_type(rel_types::PACKAGE))
+                .expect("editable workbook relationship after Pages");
+            let workbook = OpcPackage::resolve_rel_target(&part, &workbook_relationship.target);
+            let workbook = OpcPackage::from_reader(Cursor::new(
+                document
+                    .package
+                    .get_part(&workbook)
+                    .expect("editable workbook after Pages"),
+            ))
+            .expect("open editable workbook after Pages");
+            for value in ["August", "September", "12.5", "19.2"] {
+                assert!(
+                    workbook
+                        .parts
+                        .values()
+                        .any(|part| String::from_utf8_lossy(part).contains(value)),
+                    "missing {value} from editable workbook"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/rdocx/src/lib.rs
+++ b/crates/rdocx/src/lib.rs
@@ -55,6 +55,7 @@ pub use html::{HtmlDiagnostic, HtmlReadResult};
 pub use odt::{OdtDiagnostic, OdtReadResult, OdtWriteResult};
 pub use oxml_chart::{ChartData, ChartKind};
 pub use oxml_core::Length;
+pub use oxml_drawing::color::RgbColor;
 pub use oxml_opc::PackageReadLimits;
 #[cfg(feature = "digital-signatures")]
 pub use oxml_opc::{

--- a/crates/rdocx/tests/regression_test.rs
+++ b/crates/rdocx/tests/regression_test.rs
@@ -8574,6 +8574,7 @@ fn redaction_removes_chart_cache_and_embedded_workbook_traces() {
                 categories: vec!["secret north".to_owned(), "public".to_owned()],
                 series: vec![("secret revenue".to_owned(), vec![12.5, 19.0])],
                 number_format: None,
+                ..ChartData::default()
             },
         )
         .unwrap();
@@ -8592,6 +8593,7 @@ fn redaction_removes_chart_cache_and_embedded_workbook_traces() {
                 categories: vec!["north".to_owned(), "south".to_owned()],
                 series: vec![("revenue".to_owned(), vec![12.5, 19.0])],
                 number_format: None,
+                ..ChartData::default()
             },
         )
         .unwrap();
@@ -8670,6 +8672,7 @@ fn redaction_failure_is_atomic() {
                 categories: vec!["secret".to_owned()],
                 series: vec![("public".to_owned(), vec![1.0])],
                 number_format: None,
+                ..ChartData::default()
             },
         )
         .unwrap();

--- a/crates/rpptx/tests/integration.rs
+++ b/crates/rpptx/tests/integration.rs
@@ -10686,6 +10686,7 @@ fn f124_chart_data() -> ChartData {
             ("Cost".to_owned(), vec![8.0, 11.5, 9.75]),
         ],
         number_format: Some("0.00".to_owned()),
+        ..ChartData::default()
     }
 }
 
@@ -11043,26 +11044,31 @@ fn add_chart_rejects_invalid_data_without_mutation() {
             categories: Vec::new(),
             series: vec![("Revenue".to_owned(), Vec::new())],
             number_format: None,
+            ..ChartData::default()
         },
         ChartData {
             categories: vec!["North".to_owned()],
             series: Vec::new(),
             number_format: None,
+            ..ChartData::default()
         },
         ChartData {
             categories: vec!["North".to_owned(), "South".to_owned()],
             series: vec![("Revenue".to_owned(), vec![12.5])],
             number_format: None,
+            ..ChartData::default()
         },
         ChartData {
             categories: vec!["North".to_owned()],
             series: vec![("Revenue".to_owned(), vec![f64::NAN])],
             number_format: None,
+            ..ChartData::default()
         },
         ChartData {
             categories: vec!["North".to_owned()],
             series: vec![("Revenue".to_owned(), vec![12.5])],
             number_format: Some(String::new()),
+            ..ChartData::default()
         },
     ];
     for data in invalid {
@@ -11121,6 +11127,7 @@ fn add_chart_rejects_invalid_data_without_mutation() {
         categories: vec!["not numeric".to_owned()],
         series: vec![("Revenue".to_owned(), vec![12.5])],
         number_format: None,
+        ..ChartData::default()
     };
     assert!(
         presentation
@@ -11144,6 +11151,7 @@ fn add_chart_authors_each_supported_family() {
         categories: vec!["1".to_owned(), "2".to_owned(), "3".to_owned()],
         series: vec![("Revenue".to_owned(), vec![12.5, 19.0, 14.25])],
         number_format: None,
+        ..ChartData::default()
     };
     for (kind, plot_element) in [
         (ChartKind::Bar, "c:barChart"),

--- a/docs/hld/04-opc-and-packaging.md
+++ b/docs/hld/04-opc-and-packaging.md
@@ -362,6 +362,14 @@ document state. The mutation becomes visible only after the typed ChartML,
 SpreadsheetML workbook, relationships, content types, and structured drawing
 all serialize successfully.
 
+An authored Word chart also requires an effective internal document-theme
+relationship whose resolved part has the theme content type. The facade keeps
+an existing effective theme byte-identical. Otherwise it stages the Office
+default under a collision-safe `/word/theme/themeN.xml` name and either
+retargets the existing ineffective theme relationship or adds one. The theme
+part, relationship, and content-type override participate in the same cloned
+package transaction as the chart. Preserved charts do not synthesize themes.
+
 ## Media
 
 `oxml-media` owns image-byte interpretation and bounded, format-neutral media

--- a/docs/hld/05-drawingml-model.md
+++ b/docs/hld/05-drawingml-model.md
@@ -47,6 +47,11 @@ their original slots rather than appending them at the end.
 **`a:t` whitespace.** Leading and trailing whitespace is significant and needs
 `xml:space="preserve"`. Cheap to guard, and infuriating to diagnose later.
 
+Callers that own concrete color policy construct `ColorChoice` through
+`ColorChoice::srgb(RgbColor)`. This keeps brand palettes typed at the facade
+boundary while the DrawingML writer remains responsible for canonical
+`a:srgbClr` serialization and schema order.
+
 ## Colour, the part everyone gets wrong
 
 Resolution is three stages, in this order:

--- a/docs/hld/09-charts-spec.md
+++ b/docs/hld/09-charts-spec.md
@@ -405,6 +405,9 @@ pub struct ChartData {
     pub categories: Vec<String>,
     pub series: Vec<(String, Vec<f64>)>,
     pub number_format: Option<String>,
+    pub category_axis_title: Option<String>,
+    pub value_axis_title: Option<String>,
+    pub palette: Vec<RgbColor>,
 }
 
 pub fn authored_chart_parts(
@@ -446,6 +449,17 @@ valid. Pie and doughnut charts accept one series. Scatter categories must
 parse as finite numeric values. Each owning facade validates that both chart
 extents are positive before staging package mutation.
 
+Axis titles are typed rich-text ChartML. Cartesian axes explicitly serialize
+`c:delete val="0"`, and the value axis receives the same number format used by
+the cache and workbook. An empty palette retains theme-derived styling. A
+nonempty palette cycles by series. One-series bars and all pie and doughnut
+plots additionally serialize indexed category-point colors. Pie and doughnut
+plots retain their category legend with one series. Doughnut authoring emits
+the default 50 percent hole explicitly so consumers do not degrade it to pie.
+Numeric-reference caches accept an omitted optional `c:formatCode`, preserve
+that omission while unchanged, and materialize it when the caller selects a
+non-General format.
+
 The Presentation facade owns its mutation because package parts and
 relationships are not available through `SlideMut`. One call writes the typed
 chart part, one editable workbook part, the slide-to-chart and
@@ -482,13 +496,18 @@ the embedded workbook. An external workbook, malformed ChartML or
 SpreadsheetML, missing relationship target, nested archive limit, or remaining
 raw trace rejects the complete document mutation.
 
-The reviewed Word candidate has SHA-256
-`79e9b9ff9e7557dbd09a365bb8c189806e700ed48ca768b27d7158cf2b41370b`.
-Microsoft Word 16.104, Info.plist build 16.104.25121423, opened that exact file
-without a repair warning. In the human-action gate, Edit Data opened the
-embedded workbook in Excel and the user successfully changed the chart data.
-The workbook initially carried `Category` and `Revenue` columns with `North,
-12.5`, `South, 19.0`, and `West, 14.25`.
+The reviewed portable Word candidate has SHA-256
+`948f939135f26f9ebcac15da1d9fec5bcd75cf550e2ea608ef55380afa25440f`.
+Microsoft Word 16.112.2, Info.plist build 16.112.26082125, opened that exact
+file without a repair warning. Apple Pages 14.5, build 7045.0.17, rendered its
+line, bar, and doughnut charts with visible axes, literal percentage values,
+explicit blue and orange colors, and the category legend. Pages then exported
+a DOCX with SHA-256
+`1d0e4ec8f29cacd46ffa7e49952db0edaa90a1b8b65bcf60c4a228ba1a8d1c59`.
+Its ChartML and embedded workbooks retain the exact categories, series, values,
+and palette colors. Pages legally rewrites some reference caches as literal
+caches. Those values remain preserved raw until the typed model grows literal
+cache mutation.
 
 The native chart candidate has SHA-256
 `e6e9f7eef1c774d0414c5d0c3f1202da1a28635b5d089e15455b7adc3f66cb00`.

--- a/docs/hld/10-bindings-spec.md
+++ b/docs/hld/10-bindings-spec.md
@@ -116,6 +116,12 @@ these fields. These are intentional pre-1.0 source breaks for the next stable
 family. Established `TextSegment` construction and layout entrypoints retain
 their existing shapes.
 
+The shared native `ChartData` authoring input includes optional category-axis
+and value-axis titles plus a typed `Vec<RgbColor>` palette. `rdocx` re-exports
+`RgbColor`, and `ChartData::default()` supplies empty optional styling fields
+for callers using update syntax. Adding fields breaks complete struct literals
+intentionally before 1.0. It does not add Python, WASM, or CLI chart methods.
+
 **Threading.** `Document` remains `Send` and `Sync`. Its normal and
 deterministic layouts live in separate
 `Mutex<Option<Arc<WordLayoutResult>>>` caches. One private normal-font engine

--- a/docs/hld/12-testing-strategy.md
+++ b/docs/hld/12-testing-strategy.md
@@ -449,6 +449,22 @@ workbook rejection, nested ZIP limits, and atomic residual-scan failure. The
 native-only API is absent from Python, WASM, and CLI wrappers. No sample invokes
 redaction, so all 49 hash entries remain unchanged.
 
+The portable authored-chart regression gate constructs line, bar, pie, and
+doughnut documents through the public API. It checks typed titles, explicit
+visible axes, value-axis formats, series and indexed point colors, one-series
+category legends, the explicit doughnut hole, relationship-owned theme
+assembly, collision handling, malformed-theme repair, exact workbook data, and
+save/reopen preservation. Its ignored external oracle constructs one line, bar,
+and doughnut candidate with literal percentage values and a two-color palette.
+Microsoft Word for Mac 16.112.2 build 16.112.26082125 must open the exact
+`948f939135f26f9ebcac15da1d9fec5bcd75cf550e2ea608ef55380afa25440f`
+candidate without repair. Apple Pages 14.5 build 7045.0.17 must render the
+declared axes, values, colors, doughnut hole, and legend, then export DOCX bytes
+whose raw ChartML caches and embedded workbooks retain the source semantics.
+The Pages export may use legal literal caches that remain outside the typed
+reference-cache parser. No standard sample authors a chart, so all 49 hash
+entries remain unchanged.
+
 The watermark golden gate builds a five-page document in code, renders with
 bundled fonts, and compares the exact PNG-byte digest for every page. It also
 requires the selected watermark group to precede ordinary header and body

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -2116,9 +2116,10 @@ publication remains transactional, and unsupported ChartML remains preserved.
 **Test gate**: differential. Source-built line, bar, pie, and doughnut documents
 save, reopen, and retain exact categories, series, values, formulas, caches,
 relationships, content types, and editable workbook data. Microsoft Word
-16.104 opens the documents without repair. A pinned Pages build renders the
-axes, brandable colors, category legend, and literal percentage values, then
-exports a DOCX whose chart and workbook semantics remain exact.
+16.112.2 build 16.112.26082125 opens the documents without repair. Apple Pages
+14.5 build 7045.0.17 renders the axes, brandable colors, category legend,
+literal percentage values, and doughnut hole, then exports a DOCX whose chart
+and workbook semantics remain exact.
 
 ### F-231, Extended field evaluation (L)
 Evaluate TOC, TC, formula, mail-merge control, and barcode fields while

--- a/docs/hld/14-development-backlog.md
+++ b/docs/hld/14-development-backlog.md
@@ -2102,6 +2102,24 @@ stable diagnostics for constructs that cannot round-trip.
 **Test gate**: differential. Supported source-built equations preserve their
 normalized expression tree through both conversion directions.
 
+### F-X077, Portable authored Word charts (L)
+Make authored Word charts portable without flattening their editable workbook
+data. A document that authors its first chart gains a relationship-owned Office
+theme only when it has no theme already. Authored axes explicitly remain
+visible in schema order, value axes receive the chart number format, and a
+caller palette can style series plus category points for one-series bars, pies,
+and doughnuts. Pie and doughnut charts retain category legend semantics.
+Optional category and value axis titles remain typed ChartML rather than raw
+post-serialization replacement. Existing themes remain authoritative, package
+publication remains transactional, and unsupported ChartML remains preserved.
+**Depends on**: F-158.
+**Test gate**: differential. Source-built line, bar, pie, and doughnut documents
+save, reopen, and retain exact categories, series, values, formulas, caches,
+relationships, content types, and editable workbook data. Microsoft Word
+16.104 opens the documents without repair. A pinned Pages build renders the
+axes, brandable colors, category legend, and literal percentage values, then
+exports a DOCX whose chart and workbook semantics remain exact.
+
 ### F-231, Extended field evaluation (L)
 Evaluate TOC, TC, formula, mail-merge control, and barcode fields while
 retaining unavailable field instructions and cached results.

--- a/docs/sprints/AS_BUILT.md
+++ b/docs/sprints/AS_BUILT.md
@@ -11234,3 +11234,55 @@ https://github.com/tensorbee/rdocx/issues/67#issuecomment-5522284889.
 seven-package family. Verify each downloaded registry package, owner, annotated
 tag target, release-body bytes, unpublished carrier, contribution state, and
 notification URL before completing a release story.
+
+### F-X077, Portable authored Word charts
+
+**Sprint.** S65
+**Completed.** 2026-09-08
+**Size.** L, estimated 4 days, actual 1 day
+
+**What was built.** Authored Word charts now carry the package and ChartML
+semantics needed to remain editable and render consistently in Microsoft Word
+and Apple Pages. The public data input accepts typed axis titles and an RGB
+palette. Authored charts serialize explicit visible axes, value formats,
+series and category-point colors, category legends, and doughnut hole size,
+while the Word facade transactionally supplies a relationship-owned Office
+theme only when the document has no effective theme.
+
+**Non-obvious choices.** Brand policy remains with callers rather than rdocx.
+An empty palette keeps theme-derived behavior. A supplied palette cycles by
+series and by category where consumers require explicit points. An internal
+theme relationship is effective only when its target exists and has the theme
+content type. Numeric caches preserve an omitted optional format code until a
+caller changes it. This avoids gratuitous source normalization.
+
+**Deviations from the design plan.** The external candidate uses line, bar,
+and doughnut charts rather than duplicating pie and doughnut in the viewer
+document. Focused Rust coverage still exercises both pie and doughnut. Pages
+rewrites some reference caches as legal literal caches, so the external gate
+validates their raw ChartML and embedded workbook semantics without expanding
+this story into typed literal-cache mutation.
+
+**Spec sections touched.** `docs/hld/04-opc-and-packaging.md` covers Word chart
+assembly. `docs/hld/05-drawingml-model.md` covers typed sRGB construction.
+`docs/hld/09-charts-spec.md` covers authoring and portability.
+`docs/hld/10-bindings-spec.md` covers the native pre-1.0 chart input.
+`docs/hld/12-testing-strategy.md` covers the portable chart oracle.
+`docs/hld/14-development-backlog.md` covers F-X077.
+
+**Tests.** `authored_charts_emit_portable_viewer_defaults`,
+`authored_chart_adds_a_relationship_owned_default_theme`,
+`authored_chart_preserves_an_existing_document_theme`,
+`authored_chart_replaces_a_theme_without_its_required_content_type`,
+`authored_chart_theme_name_does_not_collide_with_existing_parts`,
+`optional_numeric_cache_format_remains_omitted`, and
+`word_and_pages_open_portable_authored_charts`. Complete portable workspace,
+Clippy, rustdoc, WASM, package dry-run, archive-size, dependency-policy, and
+README gates pass. The four exact LibreOffice 26.2.5.2 Linux oracles remain for
+hosted CI because their pinned installer is Linux x86_64 only.
+
+**Hash harness.** Unchanged, 49 of 49.
+
+**Notes for future sessions.** Pages 14.5 exports legal `c:strLit` and
+`c:numLit` caches for some plots. They remain byte-preserved, but future typed
+mutation of a Pages-exported chart must first model those literal cache forms.

--- a/docs/sprints/BACKLOG.md
+++ b/docs/sprints/BACKLOG.md
@@ -38,8 +38,8 @@ regenerated, never hand-edited.
 | M20, Fidelity at scale                         | 7  | 7 | 0 | 0  |
 | M21, Presentation depth                        | 15 | 15 | 0 | 0  |
 | M22, Word depth                                | 12 | 0 | 0 | 12 |
-| X, Cross-cutting (opportunistic)            | 80 | 71 | 3 | 3  |
-| **Total** | **327** | **282** | **6** | **36** |
+| X, Cross-cutting (opportunistic)            | 80 | 72 | 3 | 2  |
+| **Total** | **327** | **283** | **6** | **35** |
 <!-- AUTOGEN:backlog-summary END -->
 
 ## All F-IDs
@@ -529,5 +529,5 @@ regenerated, never hand-edited.
 | F-X074 | Tag rpptx-v0.9.0                          | S64 | S | done |
 | F-X075 | Preserve restart pagination across page-spanning paragraphs | S64 | M | done |
 | F-X076 | Tag v0.12.0                               | S64 | S | done |
-| F-X077 | Portable authored Word charts             | S65 | L | pending |
+| F-X077 | Portable authored Word charts             | S65 | L | done |
 <!-- AUTOGEN:backlog-MX END -->

--- a/docs/sprints/BACKLOG.md
+++ b/docs/sprints/BACKLOG.md
@@ -38,8 +38,8 @@ regenerated, never hand-edited.
 | M20, Fidelity at scale                         | 7  | 7 | 0 | 0  |
 | M21, Presentation depth                        | 15 | 15 | 0 | 0  |
 | M22, Word depth                                | 12 | 0 | 0 | 12 |
-| X, Cross-cutting (opportunistic)            | 79 | 71 | 3 | 2  |
-| **Total** | **326** | **282** | **6** | **35** |
+| X, Cross-cutting (opportunistic)            | 80 | 71 | 3 | 3  |
+| **Total** | **327** | **282** | **6** | **36** |
 <!-- AUTOGEN:backlog-summary END -->
 
 ## All F-IDs
@@ -529,4 +529,5 @@ regenerated, never hand-edited.
 | F-X074 | Tag rpptx-v0.9.0                          | S64 | S | done |
 | F-X075 | Preserve restart pagination across page-spanning paragraphs | S64 | M | done |
 | F-X076 | Tag v0.12.0                               | S64 | S | done |
+| F-X077 | Portable authored Word charts             | S65 | L | pending |
 <!-- AUTOGEN:backlog-MX END -->

--- a/docs/sprints/CURRENT_SPRINT.md
+++ b/docs/sprints/CURRENT_SPRINT.md
@@ -27,7 +27,7 @@ retaining their editable workbook data.
 
 | F-ID | Title | Size | Status | Owner |
 |------|-------|------|--------|-------|
-| F-X077 | Portable authored Word charts | L | pending | - |
+| F-X077 | Portable authored Word charts | L | done | - |
 | F-228 | OfficeMath model and authoring | L | pending | - |
 | F-229 | OfficeMath layout and PDF rendering | M | pending | - |
 | F-230 | MathML and LaTeX conversion | M | pending | - |
@@ -51,9 +51,10 @@ model and may proceed independently after it lands.
 - Authored axes are explicitly visible in schema order, value-axis number
   formats preserve literal percentages, and caller palettes style series and
   required category points.
-- Microsoft Word 16.104 opens source-built chart documents without repair. A
-  pinned Pages build renders the intended axes, colors, legend, and values,
-  then exports semantically exact editable charts.
+- Microsoft Word 16.112.2 build 16.112.26082125 opens source-built chart
+  documents without repair. Pages 14.5 build 7045.0.17 renders the intended
+  axes, colors, legend, doughnut, and values, then exports semantically exact
+  editable charts.
 - OfficeMath authors and round-trips the supported equation tree while
   preserving unsupported sibling XML.
 - Supported equations lay out and render against the pinned Word PDF oracle,

--- a/docs/sprints/CURRENT_SPRINT.md
+++ b/docs/sprints/CURRENT_SPRINT.md
@@ -1,102 +1,62 @@
-# Current Sprint, S64
+# Current Sprint, S65
 
-**Milestone**: M21 Presentation depth with a cross-cutting Word correction.
+**Milestone**: M22 Word depth with a cross-cutting chart correction.
 
-**Goal**: turn common modern content sources into editable or explicitly
-preserved slide content. HTML maps a bounded DOM and CSS subset into ordinary
-slide shapes, while PDF import offers either a preserved page graphic or a
-declared editable subset. Neither path promises arbitrary browser or PDF-engine
-compatibility.
-
-Issue 67 identified a restart-pagination regression in the unreleased F-X073
-work while this sprint was at its release boundary. S64 also removes that
-bounded performance cliff before the separately reviewed stable Word release.
+**Goal**: author, convert, lay out, and render modern Word equations. In
+parallel, make authored Word charts portable across Word and Pages while
+retaining their editable workbook data.
 
 ## Spec references
 
-- `docs/hld/02-scope-and-non-goals.md`, for bounded format support, explicit
-  unsupported-content policy, and the prohibition on implied compatibility.
-- `docs/hld/03-architecture.md`, for facade-owned import, transactional model
-  publication, and reuse of existing package, layout, and rendering layers.
-- `docs/hld/04-opc-and-packaging.md`, for relationship-safe embedded resources,
-  MIME resolution, and package limits.
-- `docs/hld/06-presentationml-model.md`, for editable slide shapes, text,
-  tables, pictures, links, and preserved source content.
-- `docs/hld/08-rendering-spec.md`, for shared geometry, text, image, and path
-  lowering used by deterministic source comparisons, plus complete-boundary
-  restart pagination for page-spanning prose.
-- `docs/hld/10-bindings-spec.md`, for additive native facade surfaces and the
-  rule that Python, WASM, and CLI exposure is explicit rather than implied.
+- `docs/hld/03-architecture.md`, for facade-owned authoring and transactional
+  publication through existing model and package layers.
+- `docs/hld/04-opc-and-packaging.md`, for relationship-safe chart, workbook,
+  theme, and content-type assembly.
+- `docs/hld/05-drawingml-model.md`, for Office theme defaults and typed color
+  semantics.
+- `docs/hld/09-charts-spec.md`, for editable chart data, schema-ordered
+  ChartML, formulas, caches, plots, axes, and legends.
+- `docs/hld/10-bindings-spec.md`, for the native Word facade and explicit
+  pre-1.0 source-compatibility decisions.
 - `docs/hld/12-testing-strategy.md`, for source-built differential fixtures,
-  deterministic fonts, external oracle discipline, and unchanged hash gates.
-- `docs/hld/14-development-backlog.md`, for the F-224 and F-225 acceptance
-  gates, the F-X075 regression boundary, dependency order, and the M21
-  completion boundary.
+  external oracle discipline, and unchanged deterministic hash gates.
+- `docs/hld/14-development-backlog.md`, for the F-228 through F-230 and
+  F-X077 acceptance gates and dependency order.
 
 ## The wave
 
 | F-ID | Title | Size | Status | Owner |
 |------|-------|------|--------|-------|
-| F-224 | HTML slide content import | L | done | - |
-| F-225 | PDF page content import | L | done | - |
-| F-X074 | Tag rpptx-v0.9.0 | S | done | - |
-| F-X075 | Preserve restart pagination across page-spanning paragraphs | M | done | - |
-| F-X076 | Tag v0.12.0 | S | done | - |
+| F-X077 | Portable authored Word charts | L | pending | - |
+| F-228 | OfficeMath model and authoring | L | pending | - |
+| F-229 | OfficeMath layout and PDF rendering | M | pending | - |
+| F-230 | MathML and LaTeX conversion | M | pending | - |
 
 ## Sequencing note
 
-Rows are listed in dependency order, not F-ID order.
-
-Both stories can begin independently because F-224 depends on the completed
-F-110 and F-112 authoring surfaces, while F-225 depends on the completed F-109,
-F-110, and F-111 shape and picture surfaces. Their designs must agree on shared
-image, text, path, link, diagnostic, and transactional publication semantics.
-The integrated sprint review validates those interactions before M21 closes.
-F-X075 is a late cross-cutting correction requested after Issue 67 reproduced
-an unreleased F-X073 regression. It is independent of the presentation
-implementation, but its stable release follows the reviewed
-`rpptx-v0.9.0` publication so the selected package families remain separate.
-F-X076 owns that later stable publication and its seven reviewed contribution
-notifications.
+Rows are listed in review order, not F-ID order. F-X077 is a late
+cross-cutting correction requested after editable chart export exposed missing
+theme, axis, number-format, point-color, and legend semantics in consumers
+outside Word. It is independent of the OfficeMath dependency chain and lands
+first so the consuming Symbolic integration can use a reviewed public API.
+F-228 then establishes the equation model. F-229 and F-230 depend on that
+model and may proceed independently after it lands.
 
 ## Definition of done for this sprint
 
-- Source-built HTML projects the declared DOM and CSS subset into editable
-  shapes, text, tables, images, and links, then matches the pinned browser
-  structure and pixels after save and reopen.
-- Unsupported HTML structure and style produce stable source-path diagnostics
-  without publishing a partial presentation or implying browser compatibility.
-- PDF pages import through both the preserved page-graphic path and the
-  declared editable text, raster image, path, and link subset.
-- Imported PDF page geometry and source rendering match the pinned reference,
-  while font substitutions and unsupported operators remain explicit stable
-  diagnostics.
-- Both import paths reuse the existing PresentationML authoring, package,
-  layout, and rendering surfaces without introducing a second rendering engine.
-- A portable source-built representative deck combines comments, sections,
-  minimal SmartArt preservation, exact media bytes, timeline fade, signatures,
-  the macro-enabled package variant, notes, and a three-up handout. A separate
-  captured no-repair signed deck supplies authentic SmartArt release evidence.
-  Recorded PowerPoint 16.104 static, movie, A4 portrait notes, and A4 portrait
-  handout outputs bind directly to that signed source through one configured
-  oracle directory. The exact captured bytes and their saved/reopened form both
-  pass the complete package, collaboration, section, media, playback, timing,
-  signature, slide-order, and authentic SmartArt semantic contract. All three
-  static pages pass exact normalized token
-  cardinality and order, 6-pixel full-page ink, and per-region raster
-  boundaries, with only the page-one audio rectangle masked. Page three proves
-  the complete SmartArt graph and relationships plus visible three-node text
-  and ink. Notes pass exact per-page tokens, exact band cardinality, 0.06
-  normalized semantic-component size, and 0.35 ink-occupancy boundaries without
-  equating placement across different notes masters. Handout output passes
-  exact token and 0.05 normalized thumbnail geometry boundaries.
-- Full verification passes with every deterministic hash explained, every
-  package archive below 10 MiB, and the bounded sprint review clean.
-- Page-spanning ordinary prose keeps one recorded pagination pass, publishes
-  only complete-boundary restart checkpoints, and reuses bounded warm work
-  without weakening any existing unsafe-state exclusion.
-- The reviewed `rpptx-v0.9.0` release publishes and independently verifies the
-  exact 15-package incubating family before sprint closure.
-- The reviewed `v0.12.0` release publishes and independently verifies the exact
-  seven-package stable family, retains unpublished bindings, and records all
-  seven contribution notifications without changing record state.
+- Authored line, bar, pie, and doughnut charts retain exact editable workbook
+  categories, series, values, formulas, and caches after save and reopen.
+- Chart packages add a relationship-owned default Office theme only when no
+  document theme exists, without replacing or mutating caller-owned themes.
+- Authored axes are explicitly visible in schema order, value-axis number
+  formats preserve literal percentages, and caller palettes style series and
+  required category points.
+- Microsoft Word 16.104 opens source-built chart documents without repair. A
+  pinned Pages build renders the intended axes, colors, legend, and values,
+  then exports semantically exact editable charts.
+- OfficeMath authors and round-trips the supported equation tree while
+  preserving unsupported sibling XML.
+- Supported equations lay out and render against the pinned Word PDF oracle,
+  and supported MathML and LaTeX conversions preserve their normalized tree.
+- Full verification passes with every deterministic hash explained, public
+  package dry-runs remain bounded, and the integrated sprint review is clean.

--- a/docs/sprints/SPRINT_PLAN.md
+++ b/docs/sprints/SPRINT_PLAN.md
@@ -1218,16 +1218,21 @@ inventory.
 
 #### Sprint S65, OfficeMath
 
-**Goal**: author, convert, lay out, and render modern Word equations.
+**Goal**: author, convert, lay out, and render modern Word equations, while a
+late cross-cutting correction makes authored charts portable across Word and
+Pages without flattening their editable data.
 
 | F-ID | Title | Size |
 |------|-------|------|
 | F-228 | OfficeMath model and authoring | L |
 | F-229 | OfficeMath layout and PDF rendering | M |
 | F-230 | MathML and LaTeX conversion | M |
+| F-X077 | Portable authored Word charts | L |
 
 The equation model preserves unsupported siblings and remains independent of
-legacy Equation Editor objects.
+legacy Equation Editor objects. F-X077 is independent of the OfficeMath wave.
+It gives authored charts explicit portable package and presentation defaults
+while retaining their embedded workbook as the source of editable data.
 
 #### Sprint S66, Fields and dynamic tables of contents
 

--- a/docs/sprints/SPRINT_TRACKER.md
+++ b/docs/sprints/SPRINT_TRACKER.md
@@ -374,6 +374,7 @@ defended.
 | F-X075 | S64 | M | 2 | 1 | 2026-09-02 | Preserved complete-boundary restart pagination across page-spanning prose with exact sourced reuse and authenticated performance evidence |
 | F-X074 | S64 | S | 1 | 2 | 2026-09-03 | Published and independently verified the exact 15-package rpptx 0.9.0 family with the reviewed release body and no binding publication |
 | F-X076 | S64 | S | 1 | 1 | 2026-09-03 | Published and independently verified the exact seven-package rdocx 0.12.0 stable family with all seven reviewed contribution notifications |
+| F-X077 | S65 | L | 4 | 1 | 2026-09-08 | Made authored Word charts portable across Word and Pages with editable workbook data, typed palette and axis semantics, and transactional theme assembly |
 
 ## Velocity
 


### PR DESCRIPTION
## Summary
- add typed axis titles and caller-owned RGB palettes to `ChartData`
- emit explicit portable axis, number-format, point-color, legend, and doughnut semantics while preserving editable workbook data
- transactionally add or repair a relationship-owned Office theme only for authored Word charts
- pin source-built interoperability evidence for Word 16.112.2 and Pages 14.5

## Compatibility
`ChartData` gains public fields before 1.0. Complete struct literals must add the fields or use `..ChartData::default()`. Python, WASM, and CLI surfaces are unchanged.

## Validation
- focused and complete portable workspace Rust suites pass
- Clippy with `-D warnings`, rustdoc, WASM checks, README doctests, hash harness (49/49), cargo-deny, and all package dry-runs pass
- Word 16.112.2 opens the source-built candidate without repair; Pages 14.5 renders it and exports semantically exact editable charts
- four exact LibreOffice 26.2.5.2 tests require the repository-pinned Linux x86_64 installer and remain delegated to PR CI